### PR TITLE
feat(vscode): fix local install loop and enrich Silk highlighting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,18 @@
       "request": "launch",
       "cwd": "${workspaceFolder}",
       "command": "out=$(mktemp -t silk-run) && node \"${workspaceFolder}/packages/compiler-cli/dist/bin.js\" build-exe \"${file}\" --source-root \"${fileDirname}\" --output \"$out\" && \"$out\"; echo \"exit: $?\"; rm -f \"$out\""
+    },
+    {
+      "name": "Silk: Extension Development Host",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"],
+      "preLaunchTask": "Silk: Build extension host deps",
+      "outFiles": [
+        "${workspaceFolder}/packages/vscode/dist/**/*.js",
+        "${workspaceFolder}/packages/lsp/dist/**/*.js"
+      ]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,6 +16,86 @@
         "clear": true
       },
       "problemMatcher": []
+    },
+    {
+      "label": "Silk: Build language server",
+      "type": "shell",
+      "command": "pnpm --filter @silk-effect/lsp run build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": ["$tsc"],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "Silk: Build extension",
+      "type": "shell",
+      "command": "pnpm --filter silk-language run build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": ["$tsc"],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "Silk: Build extension host deps",
+      "dependsOn": ["Silk: Build language server", "Silk: Build extension"],
+      "dependsOrder": "sequence",
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "Silk: Watch language server",
+      "type": "shell",
+      "command": "pnpm --filter @silk-effect/lsp run dev",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "pattern": "$tsc-watch",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "Watching for file changes"
+        }
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      }
+    },
+    {
+      "label": "Silk: Watch extension",
+      "type": "shell",
+      "command": "pnpm --filter silk-language run dev",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "pattern": "$tsc-watch",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "Watching for file changes"
+        }
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated"
+      }
     }
   ]
 }

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/design.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/design.md
@@ -1,0 +1,104 @@
+## Context
+
+See proposal.md for motivation. Constraints that shape the approach:
+
+- `packages/vscode` is a private package (`silk-language`) whose README documents a hand symlink into `~/.cursor/extensions`. That absolute path breaks across worktrees; a dangling symlink to a deleted agent worktree was observed in the wild.
+- Extension `main` is `./dist/extension.js`; `@silk-effect/lsp` is a workspace dependency resolved via `require.resolve('@silk-effect/lsp/bin')`. Both need a built checkout.
+- Grammar SoT remains `packages/language/src/TextMate.ts`, synced into the extension by `pnpm --filter @silk-effect/language sync:vscode` and drift-checked in tests. Docs Shiki consumes the same grammar.
+- `.vscode/launch.json` today only runs Silk programs; there is no `extensionHost` configuration.
+- The extension already exposes `silk.restartLanguageServer` for server-only iteration.
+- Existing specs: `cursor-extension`, `language-textmate`. This change adds `extension-dev-host`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One command retargets the local editor install to *this* checkout and builds what it needs.
+- F5 / Extension Development Host loads the workspace extension without touching the global extensions dir.
+- Clear split: restart LS vs reload window.
+- Richer TextMate scopes that themes actually map, without abandoning the shared SoT or keyword-parity tests.
+
+**Non-Goals:**
+
+- Marketplace / `.vsix` publication, OpenVSX, iconography.
+- LSP semantic tokens (deferred; TextMate enrichment only).
+- Hot-reloading TextMate grammars without a window reload (editor limitation).
+- Changing LSP protocol features or analysis behavior.
+
+## Decisions
+
+### 1. Two supported workflows, one package
+
+```
+  Daily Silk editing          Extension / LSP development
+  ─────────────────          ───────────────────────────
+  install:cursor             Extension Development Host
+       │                              │
+       ▼                              ▼
+  ~/.cursor/extensions           --extensionDevelopmentPath
+  symlink → this checkout        = ${workspaceFolder}/packages/vscode
+       │                              │
+       └──────── reload / restart LS ─┘
+```
+
+- **Why both:** EDH alone does not highlight `.silk` in the main Cursor window where people write Silk. Symlink alone is what broke on worktrees. Keep both; document which to use when.
+- **Alternative considered:** Only EDH — rejected; daily language work happens in the main window.
+- **Alternative considered:** Only fix the symlink — rejected; EDH is the right loop for extension/LSP changes and avoids global-install cache confusion.
+
+### 2. Install script retargets a stable extension id folder
+
+- Script (Node, package script on `silk-language`, e.g. `install:cursor`) resolves the absolute path of `packages/vscode`, ensures `pnpm` builds `@silk-effect/lsp` and `silk-language` (or relies on turbo filter build), then `ln -sfn` into `~/.cursor/extensions/silk-effect.silk-language-0.0.0` (and optionally `~/.vscode/extensions/...` via a flag or sibling script).
+- Use `ln -sfn` so dangling or wrong-worktree links are replaced atomically.
+- Keep version `0.0.0` and folder naming stable so the entry is uniquely identifiable; do not introduce marketplace versioning.
+- Print the resolved target path and a one-line "Reload Window" reminder; mention `Silk: Restart Language Server` for server-only rebuilds.
+- **Alternative considered:** Bump a local build timestamp in `package.json` on each install to bust caches — deferred unless Reload Window proves insufficient after retargeting; prefer not to dirty the tree.
+- **Alternative considered:** Pack a `.vsix` each time — heavier, was a non-goal in the original language-package design; revisit only if symlink+reload stays flaky on Cursor.
+
+### 3. Extension Development Host launch + tasks
+
+- Add a launch config: `type: extensionHost`, `request: launch`, `args: ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"]`, with `preLaunchTask` that builds extension + lsp (and syncs grammar if needed).
+- Prefer composing existing package `build` / `dev` scripts via `tasks.json` (`dependsOn` for lsp + vscode; optional compound watch).
+- Document: contribution/grammar → reload host; server `dist` → `Silk: Restart Language Server`.
+- **Cursor note:** Cursor is VS Code-compatible for `extensionHost` launches when debugging from the repo; if a given Cursor build refuses EDH, the same `launch.json` still serves VS Code, and `install:cursor` remains the main-window path.
+- **Alternative considered:** CLI-only `cursor --extensionDevelopmentPath=...` wrapper — optional later; launch.json is the standard discoverable entry.
+
+### 4. TextMate enrichment stays regex SoT, not lexer-in-extension
+
+Improve `TextMate.ts` patterns:
+
+| Concern | Approach |
+| --- | --- |
+| Keyword families | Split keyword list into control (`if`/`else`/`return`/`while`/…) vs storage/declaration (`pub`/`fn`/`struct`/`let`/…) with scopes like `keyword.control.silk` and `storage.type.silk` / `keyword.declaration.silk` |
+| Function names | Match `fn` + identifier capture → `entity.name.function.silk` |
+| Types | Broaden PascalCase type matching beyond builtins and `Name{` patterns (signature/type positions), keeping builtins if useful for consistency |
+| Parity tests | Keep compiler keyword-set equality; add Shiki/scope fixture assertions for the new families |
+
+- Still generate JSON via `sync:vscode`; extension remains a consumer.
+- **Why not LSP semantic tokens yet:** more protocol + theme surface; proposal defers them. TextMate upgrades help Cursor and Shiki immediately from one SoT.
+- **Why not drive VS Code highlighting from the compiler lexer:** VS Code expects TextMate or semantic tokens; embedding the lexer in the extension would fork the CodeMirror approach and fight the editor model.
+- **Alternative considered:** Only remap existing `keyword.other` without new patterns — helps themes less than adding function/type entity scopes.
+
+### 5. Docs updates, not new packages
+
+- Update `packages/vscode/README.md` as the source of truth for install + EDH + reload/restart.
+- No new workspace package; scripts live under `packages/vscode` (install) and reuse `packages/language` sync.
+
+## Risks / Trade-offs
+
+- **[Risk] Cursor EDH quirks** → Mitigation: keep `install:cursor` as the reliable main-window path; verify EDH on Cursor once during apply; fall back to VS Code for extension debugging if needed.
+- **[Risk] Broader PascalCase type rules false-positive on constants** → Mitigation: scope conservatively (prefer known type positions / existing pattern heuristics); add fixture tests for false friends; prefer under-coloring over wrong coloring.
+- **[Risk] Symlink still requires Reload Window** → Mitigation: document explicitly; do not promise hot grammar reload.
+- **[Risk] Workspace `node_modules` resolution for `@silk-effect/lsp` from a symlinked extension** → Mitigation: install script builds from repo root; document that the checkout must remain `pnpm install &&` built; EDH loads from workspace so resolution matches the open monorepo.
+- **[Trade-off] No `.vsix`** → Simpler alpha workflow; harder to share installs outside the repo. Acceptable at this stage.
+
+## Migration Plan
+
+1. Land install script + README; contributors with a dangling symlink run `install:cursor` once and reload.
+2. Land EDH launch/tasks; no migration for people who only use the symlink.
+3. Land TextMate scope changes + `sync:vscode`; reload editor / EDH to see new highlighting; docs site picks up grammar on next docs build.
+4. Rollback: revert change; re-run old manual symlink if needed. No data migration.
+
+## Open Questions
+
+- Whether to also write `~/.vscode/extensions` by default or only behind `--vscode` / `install:code` (default Cursor-only is fine unless dual-editor use is common).
+- Exact TextMate scope strings (e.g. `storage.type` vs `keyword.declaration`) — pick during apply to match common theme mappings; specs require differentiated families, not a particular string.

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/proposal.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Local Silk editor support in Cursor is fragile and slow to iterate: the documented symlink install points at an absolute package path, so worktrees (and deleted agent checkouts) leave a dangling extension; there is no Extension Development Host launch config; and the TextMate grammar only paints a coarse keyword blob. Developers rebuild and reload without confidence that Cursor is loading *this* checkout, and highlighting is merely adequate when it could read more like a real language.
+
+## What Changes
+
+- Add a **worktree-safe Cursor install** path that retargets the local symlink to the current checkout, builds the extension (and its LSP dependency), and documents reload vs. language-server restart.
+- Add an **Extension Development Host** launch configuration (plus build/watch tasks) so F5 loads `packages/vscode` from the open workspace without touching `~/.cursor/extensions`.
+- Enrich the **TextMate grammar** with finer scopes (control vs storage keywords, function names, broader types/identifiers) so themes color Silk more usefully — still generated from `@silk-effect/language`, still drift-checked.
+- Update extension README / contributor docs for the two workflows: daily use in main Cursor vs. developing the extension/LSP in a guest host window.
+- **Non-goals:** marketplace/OpenVSX packaging, LSP semantic tokens, tree-sitter, theme contributions, Changesets publication of the private extension.
+
+## Capabilities
+
+### New Capabilities
+
+- `extension-dev-host`: Workspace launch and task definitions that open a VS Code / Cursor Extension Development Host against `packages/vscode`, with builds that keep the host and language server on current `dist` output.
+
+### Modified Capabilities
+
+- `cursor-extension`: Replace hand-maintained absolute symlink instructions with a retargetable local install that always points at the current checkout; clarify reload vs. `Silk: Restart Language Server`.
+- `language-textmate`: Require richer, theme-friendly scopes beyond a single `keyword.other` alternation while preserving keyword parity with the compiler and existing match/generics coverage.
+
+## Impact
+
+- `packages/vscode` — install script, README, possibly package scripts; no marketplace packaging.
+- `.vscode/launch.json` and `.vscode/tasks.json` — Extension Development Host + preLaunch / watch tasks.
+- `packages/language` — `TextMate.ts` patterns/scopes, sync script output, TextMate tests / Shiki fixtures.
+- Generated `packages/vscode/syntaxes/silk.tmLanguage.json` and `language-configuration.json` via existing `sync:vscode`.
+- Docs site Shiki highlighting inherits the richer grammar automatically.
+- Does not change `@silk-effect/lsp` protocol surface; LSP restart remains the thin extension command already present.

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/cursor-extension/spec.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/cursor-extension/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Retargetable local install for the current checkout
+
+The extension package SHALL provide a documented install command that creates or replaces the local Cursor (and optionally VS Code) extensions-directory symlink so it points at this repository checkout's `packages/vscode` path, after ensuring the extension and language-server packages are built.
+
+#### Scenario: Install from a worktree
+
+- **WHEN** a contributor runs the install command from a git worktree whose absolute path differs from any previous install
+- **THEN** the extensions-directory entry for Silk resolves to that worktree's `packages/vscode` folder and the extension entrypoint exists on disk
+
+#### Scenario: Replacing a dangling symlink
+
+- **WHEN** an existing Silk extensions-directory symlink points at a missing path
+- **THEN** running the install command replaces it with a symlink to the current checkout and leaves a loadable extension
+
+#### Scenario: Reload after install
+
+- **WHEN** the install command completes successfully
+- **THEN** documentation instructs the contributor to reload the editor window so contributions are picked up from the retargeted path
+
+### Requirement: Reload versus language-server restart is documented
+
+The extension README SHALL distinguish window reload (needed for contribution and grammar changes, and after retargeting the install) from `Silk: Restart Language Server` (sufficient after rebuilding the language-server binary when the extension path is already correct).
+
+#### Scenario: Contributor updates only the language server
+
+- **WHEN** a contributor rebuilds `@silk-effect/lsp` while the extension is already loaded from the correct checkout
+- **THEN** documentation tells them to run `Silk: Restart Language Server` rather than reinstalling the symlink
+
+## MODIFIED Requirements
+
+### Requirement: Local-only install, excluded from release machinery
+
+The extension SHALL be a private workspace package installable by running the package's local install command (which symlinks the extension folder into the editor's extensions directory for the current checkout), and SHALL be excluded from Changesets and release-candidate validation. Marketplace packaging remains out of scope.
+
+#### Scenario: Symlink install
+
+- **WHEN** the user runs the documented local install command and reloads Cursor
+- **THEN** the extension loads from the current checkout without any packaging or marketplace step
+
+#### Scenario: Release tooling ignores the extension
+
+- **WHEN** release-candidate validation runs
+- **THEN** the private extension package is not packed or validated for publication

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/extension-dev-host/spec.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/extension-dev-host/spec.md
@@ -1,0 +1,42 @@
+## Purpose
+
+Workspace launch and task definitions that open a VS Code-compatible Extension Development Host against the Silk extension package so contributors iterate without installing into the global extensions directory.
+
+## ADDED Requirements
+
+### Requirement: Extension Development Host launches the Silk extension from the workspace
+
+The repository SHALL provide a debug launch configuration that starts an Extension Development Host with the Silk extension loaded from the workspace `packages/vscode` path (not from `~/.cursor/extensions` or `~/.vscode/extensions`).
+
+#### Scenario: Launch from the open checkout
+
+- **WHEN** a contributor runs the Silk Extension Development Host launch configuration from the repository workspace
+- **THEN** the host window loads the Silk language contribution from that workspace's `packages/vscode` folder
+
+#### Scenario: Guest host is independent of global install
+
+- **WHEN** the global Cursor/VS Code extensions directory has no Silk extension, or points at a different checkout
+- **THEN** the Extension Development Host still highlights `.silk` files using the workspace extension
+
+### Requirement: Pre-launch build keeps host binaries current
+
+Launching the Extension Development Host SHALL ensure the extension and its language-server dependency are built so the host activates against current `dist` output rather than a missing or stale binary.
+
+#### Scenario: Fresh checkout launch
+
+- **WHEN** a contributor launches the Extension Development Host after a clean checkout that has been installed but not yet built for the extension packages
+- **THEN** the pre-launch build produces the extension entrypoint and the language-server binary the extension resolves before the host window opens
+
+### Requirement: Watch tasks support iterative extension and server rebuilds
+
+The repository SHALL provide watch tasks that rebuild the extension and language-server packages on change so a contributor can rebuild without leaving the editor, then restart the language server or reload the host window as appropriate.
+
+#### Scenario: Server code change without window reload
+
+- **WHEN** a contributor changes language-server sources while watch rebuild is running, the rebuild finishes, and they run `Silk: Restart Language Server` in the Extension Development Host
+- **THEN** the restarted server loads the rebuilt binary without requiring a full host window reload
+
+#### Scenario: Contribution or grammar change needs reload
+
+- **WHEN** a contributor changes extension activation code or the contributed TextMate grammar files
+- **THEN** documentation and tasks make clear that a host window reload is required for those changes to take effect

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/language-textmate/spec.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/specs/language-textmate/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Keywords use theme-friendly differentiated scopes
+
+The TextMate grammar SHALL assign distinct scope families for control-flow keywords, declaration/storage keywords, and boolean literals, rather than placing every non-boolean keyword under a single undifferentiated keyword scope.
+
+#### Scenario: Control versus declaration coloring
+
+- **WHEN** a TextMate consumer tokenizes `pub fn main() { if true { return 1 } else { return 0 } }`
+- **THEN** `if`, `else`, and `return` receive control-oriented keyword scopes while `pub` and `fn` receive declaration/storage-oriented scopes distinct from the control scopes, and `true` retains a boolean literal scope
+
+### Requirement: Function names after fn receive entity scopes
+
+The TextMate grammar SHALL scope the identifier immediately following `fn` as a function name so themes can color declarations differently from ordinary identifiers.
+
+#### Scenario: Function declaration name
+
+- **WHEN** a TextMate consumer tokenizes `fn greet()`
+- **THEN** `greet` receives a function-name entity scope and `fn` retains its declaration/storage keyword scope
+
+### Requirement: Type-like identifiers receive type scopes beyond builtins and patterns
+
+The TextMate grammar SHALL assign type-oriented scopes to PascalCase type identifiers used in ordinary type positions (not only builtin names and nominal patterns before `{`), so user-defined types are highlighted consistently with builtins where themes map type scopes.
+
+#### Scenario: User type in a signature
+
+- **WHEN** a TextMate consumer tokenizes `fn id(x: Point) -> Point`
+- **THEN** both `Point` occurrences receive a type scope
+
+## MODIFIED Requirements
+
+### Requirement: TextMate grammar covers the Silk lexical grammar
+
+The package SHALL export a TextMate grammar for Silk (scope `source.silk`) that assigns scopes to keywords (with differentiated control vs declaration families), line comments, doc comments, decimal integer literals, function declaration names, type-like identifiers, operators, and punctuation as defined by the compiler's token kinds and the added scope requirements in this capability.
+
+#### Scenario: Keyword scoping
+
+- **WHEN** the grammar tokenizes `pub fn main() -> I32 { return 42 }`
+- **THEN** `pub` and `fn` receive declaration/storage keyword scopes, `return` receives a control keyword scope, `main` receives a function-name scope, `I32` receives a type scope, and `42` receives a numeric scope
+
+#### Scenario: Doc comment scoping
+
+- **WHEN** the grammar tokenizes a line starting with `///`
+- **THEN** the line receives a documentation comment scope distinct from a `//` line comment scope

--- a/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/tasks.md
+++ b/openspec/changes/archive/2026-08-08-improve-cursor-extension-devloop/tasks.md
@@ -1,0 +1,27 @@
+## 1. Retargetable local install
+
+- [x] 1.1 Add a Node install script under `packages/vscode` that builds `@silk-effect/lsp` and `silk-language`, then `ln -sfn` the package folder to `~/.cursor/extensions/silk-effect.silk-language-0.0.0`
+- [x] 1.2 Wire `install:cursor` (and optional `install:code` / `--vscode` for `~/.vscode/extensions`) in `packages/vscode/package.json`
+- [x] 1.3 Make the script print the resolved symlink target and remind the user to reload the window; exit non-zero if build or link fails
+- [x] 1.4 Rewrite `packages/vscode/README.md` install section to use the script instead of a hand `ln -s`, and document reload vs `Silk: Restart Language Server`
+
+## 2. Extension Development Host
+
+- [x] 2.1 Add `.vscode/tasks.json` entries to build (and optionally watch) `@silk-effect/lsp` and `silk-language`, including a compound pre-launch build task
+- [x] 2.2 Add an `extensionHost` launch configuration in `.vscode/launch.json` with `--extensionDevelopmentPath=${workspaceFolder}/packages/vscode` and the pre-launch build task
+- [x] 2.3 Document the EDH workflow in `packages/vscode/README.md` (when to use EDH vs `install:cursor`; restart LS vs reload host for grammar/activation changes)
+
+## 3. Richer TextMate scopes
+
+- [x] 3.1 Split keyword spellings in `packages/language/src/TextMate.ts` into control vs declaration/storage families with distinct scopes; keep boolean literals separate
+- [x] 3.2 Add a `fn` + identifier pattern that scopes function declaration names as `entity.name.function`
+- [x] 3.3 Broaden type-like PascalCase scoping for ordinary type positions beyond builtins and nominal `Name{` patterns, with conservative heuristics to limit false positives
+- [x] 3.4 Extend TextMate/Shiki tests for the new scope families and preserve compiler keyword-parity checks
+- [x] 3.5 Run `sync:vscode` and confirm generated `packages/vscode/syntaxes/silk.tmLanguage.json` matches the language package export
+
+## 4. Verification
+
+- [x] 4.1 Run `pnpm typecheck`, package tests for `@silk-effect/language`, and `pnpm exec biome check` on touched paths
+- [x] 4.2 Manually verify `install:cursor` replaces a wrong/dangling symlink and that Reload Window loads `.silk` highlighting from this checkout
+- [x] 4.3 Manually verify Extension Development Host launches with Silk active even when the global symlink is absent or wrong
+- [x] 4.4 Spot-check highlighting on a sample `.silk` file (keywords, `fn` name, user types, match/generics still sane) in Cursor or the EDH window

--- a/openspec/specs/cursor-extension/spec.md
+++ b/openspec/specs/cursor-extension/spec.md
@@ -26,16 +26,56 @@ Silk TextMate grammar and language configuration, so an editor loading the exten
 
 ### Requirement: Local-only install, excluded from release machinery
 
-The extension SHALL be a private workspace package installable by symlinking its folder into the
-editor's extensions directory, and SHALL be excluded from Changesets and release-candidate
-validation.
+The extension SHALL be a private workspace package installable by running the package's local
+install command (which symlinks the extension folder into the editor's extensions directory for
+the current checkout), and SHALL be excluded from Changesets and release-candidate validation.
+Marketplace packaging remains out of scope.
 
 #### Scenario: Symlink install
 
-- **WHEN** the user symlinks the extension folder into `~/.cursor/extensions/` and reloads Cursor
-- **THEN** the extension loads without any packaging or marketplace step
+- **WHEN** the user runs the documented local install command and reloads Cursor
+- **THEN** the extension loads from the current checkout without any packaging or marketplace step
 
 #### Scenario: Release tooling ignores the extension
 
 - **WHEN** release-candidate validation runs
 - **THEN** the private extension package is not packed or validated for publication
+
+### Requirement: Retargetable local install for the current checkout
+
+The extension package SHALL provide a documented install command that creates or replaces the local
+Cursor (and optionally VS Code) extensions-directory symlink so it points at this repository
+checkout's `packages/vscode` path, after ensuring the extension and language-server packages are
+built.
+
+#### Scenario: Install from a worktree
+
+- **WHEN** a contributor runs the install command from a git worktree whose absolute path differs
+  from any previous install
+- **THEN** the extensions-directory entry for Silk resolves to that worktree's `packages/vscode`
+  folder and the extension entrypoint exists on disk
+
+#### Scenario: Replacing a dangling symlink
+
+- **WHEN** an existing Silk extensions-directory symlink points at a missing path
+- **THEN** running the install command replaces it with a symlink to the current checkout and
+  leaves a loadable extension
+
+#### Scenario: Reload after install
+
+- **WHEN** the install command completes successfully
+- **THEN** documentation instructs the contributor to reload the editor window so contributions
+  are picked up from the retargeted path
+
+### Requirement: Reload versus language-server restart is documented
+
+The extension README SHALL distinguish window reload (needed for contribution and grammar changes,
+and after retargeting the install) from `Silk: Restart Language Server` (sufficient after
+rebuilding the language-server binary when the extension path is already correct).
+
+#### Scenario: Contributor updates only the language server
+
+- **WHEN** a contributor rebuilds `@silk-effect/lsp` while the extension is already loaded from
+  the correct checkout
+- **THEN** documentation tells them to run `Silk: Restart Language Server` rather than
+  reinstalling the symlink

--- a/openspec/specs/extension-dev-host/spec.md
+++ b/openspec/specs/extension-dev-host/spec.md
@@ -1,0 +1,62 @@
+# extension-dev-host Specification
+
+## Purpose
+
+Workspace launch and task definitions that open a VS Code-compatible Extension Development Host
+against the Silk extension package so contributors iterate without installing into the global
+extensions directory.
+
+## Requirements
+
+### Requirement: Extension Development Host launches the Silk extension from the workspace
+
+The repository SHALL provide a debug launch configuration that starts an Extension Development Host
+with the Silk extension loaded from the workspace `packages/vscode` path (not from
+`~/.cursor/extensions` or `~/.vscode/extensions`).
+
+#### Scenario: Launch from the open checkout
+
+- **WHEN** a contributor runs the Silk Extension Development Host launch configuration from the
+  repository workspace
+- **THEN** the host window loads the Silk language contribution from that workspace's
+  `packages/vscode` folder
+
+#### Scenario: Guest host is independent of global install
+
+- **WHEN** the global Cursor/VS Code extensions directory has no Silk extension, or points at a
+  different checkout
+- **THEN** the Extension Development Host still highlights `.silk` files using the workspace
+  extension
+
+### Requirement: Pre-launch build keeps host binaries current
+
+Launching the Extension Development Host SHALL ensure the extension and its language-server
+dependency are built so the host activates against current `dist` output rather than a missing or
+stale binary.
+
+#### Scenario: Fresh checkout launch
+
+- **WHEN** a contributor launches the Extension Development Host after a clean checkout that has
+  been installed but not yet built for the extension packages
+- **THEN** the pre-launch build produces the extension entrypoint and the language-server binary
+  the extension resolves before the host window opens
+
+### Requirement: Watch tasks support iterative extension and server rebuilds
+
+The repository SHALL provide watch tasks that rebuild the extension and language-server packages on
+change so a contributor can rebuild without leaving the editor, then restart the language server or
+reload the host window as appropriate.
+
+#### Scenario: Server code change without window reload
+
+- **WHEN** a contributor changes language-server sources while watch rebuild is running, the
+  rebuild finishes, and they run `Silk: Restart Language Server` in the Extension Development Host
+- **THEN** the restarted server loads the rebuilt binary without requiring a full host window
+  reload
+
+#### Scenario: Contribution or grammar change needs reload
+
+- **WHEN** a contributor changes extension activation code or the contributed TextMate grammar
+  files
+- **THEN** documentation and tasks make clear that a host window reload is required for those
+  changes to take effect

--- a/openspec/specs/language-textmate/spec.md
+++ b/openspec/specs/language-textmate/spec.md
@@ -10,13 +10,17 @@ TextMate-based consumer (Shiki, VS Code, Cursor) highlights Silk consistently.
 ### Requirement: TextMate grammar covers the Silk lexical grammar
 
 The package SHALL export a TextMate grammar for Silk (scope `source.silk`) that assigns scopes to
-keywords, line comments, doc comments, decimal integer literals, operators, and punctuation as
-defined by the compiler's token kinds.
+keywords (with differentiated control vs declaration families), line comments, doc comments,
+decimal integer literals, function declaration names, type-like identifiers, operators, and
+punctuation as defined by the compiler's token kinds and the added scope requirements in this
+capability.
 
 #### Scenario: Keyword scoping
 
 - **WHEN** the grammar tokenizes `pub fn main() -> I32 { return 42 }`
-- **THEN** `pub`, `fn`, and `return` receive keyword scopes and `42` receives a numeric scope
+- **THEN** `pub` and `fn` receive declaration/storage keyword scopes, `return` receives a control
+  keyword scope, `main` receives a function-name scope, `I32` receives a type scope, and `42`
+  receives a numeric scope
 
 #### Scenario: Doc comment scoping
 
@@ -68,3 +72,38 @@ applications without reclassifying comparison operators or reserved template sta
 #### Scenario: Tokenize mixed angle contexts
 - **WHEN** a document contains a generic declaration, an explicit specialization, a comparison, and a reserved template start
 - **THEN** generated grammar fixtures assign stable context-appropriate scopes to all four forms
+
+### Requirement: Keywords use theme-friendly differentiated scopes
+
+The TextMate grammar SHALL assign distinct scope families for control-flow keywords,
+declaration/storage keywords, and boolean literals, rather than placing every non-boolean keyword
+under a single undifferentiated keyword scope.
+
+#### Scenario: Control versus declaration coloring
+
+- **WHEN** a TextMate consumer tokenizes `pub fn main() { if true { return 1 } else { return 0 } }`
+- **THEN** `if`, `else`, and `return` receive control-oriented keyword scopes while `pub` and `fn`
+  receive declaration/storage-oriented scopes distinct from the control scopes, and `true` retains
+  a boolean literal scope
+
+### Requirement: Function names after fn receive entity scopes
+
+The TextMate grammar SHALL scope the identifier immediately following `fn` as a function name so
+themes can color declarations differently from ordinary identifiers.
+
+#### Scenario: Function declaration name
+
+- **WHEN** a TextMate consumer tokenizes `fn greet()`
+- **THEN** `greet` receives a function-name entity scope and `fn` retains its declaration/storage
+  keyword scope
+
+### Requirement: Type-like identifiers receive type scopes beyond builtins and patterns
+
+The TextMate grammar SHALL assign type-oriented scopes to PascalCase type identifiers used in
+ordinary type positions (not only builtin names and nominal patterns before `{`), so user-defined
+types are highlighted consistently with builtins where themes map type scopes.
+
+#### Scenario: User type in a signature
+
+- **WHEN** a TextMate consumer tokenizes `fn id(x: Point) -> Point`
+- **THEN** both `Point` occurrences receive a type scope

--- a/packages/language/src/TextMate.ts
+++ b/packages/language/src/TextMate.ts
@@ -35,15 +35,33 @@ export const keywords: Record<KeywordKind, string> = {
   FalseKeyword: 'false',
 }
 
+/** Control-flow keyword kinds (theme: `keyword.control`). */
+const controlKeywordKinds = [
+  'IfKeyword',
+  'ElseKeyword',
+  'WhileKeyword',
+  'BreakKeyword',
+  'ContinueKeyword',
+  'ReturnKeyword',
+  'MatchKeyword',
+] as const satisfies ReadonlyArray<KeywordKind>
+
 const booleanSpellings = [keywords.TrueKeyword, keywords.FalseKeyword]
-const plainSpellings = Object.values(keywords).filter(
-  (spelling) => !booleanSpellings.includes(spelling),
+const controlSpellings: ReadonlyArray<string> = controlKeywordKinds.map((kind) => keywords[kind])
+const controlSpellingSet = new Set(controlSpellings)
+// `fn` is matched by the function-declaration capture rule, not the storage alternation.
+const declarationSpellings = Object.values(keywords).filter(
+  (spelling) =>
+    !booleanSpellings.includes(spelling) &&
+    !controlSpellingSet.has(spelling) &&
+    spelling !== keywords.FnKeyword,
 )
 
-/** One TextMate match rule. */
+/** One TextMate match rule (optional top-level name when using captures). */
 export interface GrammarPattern {
-  readonly name: string
+  readonly name?: string
   readonly match: string
+  readonly captures?: { readonly [group: string]: { readonly name: string } }
 }
 
 /** The subset of the TextMate grammar shape Silk needs. */
@@ -65,10 +83,26 @@ export const grammar: Grammar = {
   patterns: [
     { name: 'comment.line.documentation.silk', match: '///[^\\n]*' },
     { name: 'comment.line.double-slash.silk', match: '//[^\\n]*' },
-    { name: 'keyword.other.silk', match: `\\b(?:${plainSpellings.join('|')})\\b` },
+    {
+      // Color `fn` and the declaration name together so themes can style entity.name.function.
+      match: '\\b(fn)\\s+([A-Za-z_][A-Za-z0-9_]*)',
+      captures: {
+        '1': { name: 'storage.type.silk' },
+        '2': { name: 'entity.name.function.silk' },
+      },
+    },
+    {
+      name: 'keyword.control.silk',
+      match: `\\b(?:${controlSpellings.join('|')})\\b`,
+    },
+    {
+      name: 'storage.type.silk',
+      match: `\\b(?:${declarationSpellings.join('|')})\\b`,
+    },
     { name: 'constant.language.boolean.silk', match: `\\b(?:${booleanSpellings.join('|')})\\b` },
     { name: 'support.type.builtin.silk', match: '\\b(?:I32|Bool|Never)\\b' },
-    { name: 'entity.name.type.pattern.silk', match: '\\b[A-Z][A-Za-z0-9_]*(?=\\s*\\{)' },
+    // PascalCase identifiers are types by Silk convention (patterns, signatures, generics).
+    { name: 'entity.name.type.silk', match: '\\b[A-Z][A-Za-z0-9_]*\\b' },
     { name: 'variable.language.wildcard.silk', match: '\\b_\\b' },
     { name: 'constant.numeric.integer.silk', match: '\\b[0-9]+\\b' },
     {

--- a/packages/language/test/TextMate.test.ts
+++ b/packages/language/test/TextMate.test.ts
@@ -5,6 +5,12 @@ import * as SourceFile from '@silk-effect/compiler/SourceFile'
 import { assert, it } from 'vitest'
 import * as TextMate from '../src/TextMate.js'
 
+const keywordScopeNames = new Set([
+  'keyword.control.silk',
+  'storage.type.silk',
+  'constant.language.boolean.silk',
+])
+
 const lexKinds = (text: string): ReadonlyArray<string> =>
   Lexer.lex(SourceFile.make('test', new TextEncoder().encode(text)))
     .tokens.filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
@@ -13,11 +19,17 @@ const lexKinds = (text: string): ReadonlyArray<string> =>
 /** The keyword spellings the grammar actually matches, parsed back out of its regexes. */
 const grammarKeywordSpellings = (): ReadonlyArray<string> =>
   TextMate.grammar.patterns
-    .filter(
-      (pattern) =>
-        pattern.name === 'keyword.other.silk' || pattern.name === 'constant.language.boolean.silk',
-    )
+    .filter((pattern) => {
+      if (pattern.name !== undefined && keywordScopeNames.has(pattern.name)) {
+        return true
+      }
+      // `fn` is matched via captures on the function-declaration rule.
+      return pattern.captures?.['1']?.name === 'storage.type.silk'
+    })
     .flatMap((pattern) => {
+      if (pattern.captures?.['1']?.name === 'storage.type.silk') {
+        return ['fn']
+      }
       const alternation = pattern.match.match(/\(\?:([^)]*)\)/)
       assert.isNotNull(alternation, `keyword pattern has no alternation: ${pattern.match}`)
       return (alternation?.[1] ?? '').split('|')
@@ -72,27 +84,39 @@ it('assigns keyword, numeric, and comment scopes via a TextMate tokenizer', asyn
   }
 
   const program = 'pub fn main() -> I32 { return 42 }'
-  assert.include(scopesAt(program, 'pub'), 'keyword.other.silk')
-  assert.include(scopesAt(program, 'return'), 'keyword.other.silk')
-  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'impl'), 'keyword.other.silk')
-  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'for'), 'keyword.other.silk')
-  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'unsafe'), 'keyword.other.silk')
+  assert.include(scopesAt(program, 'pub'), 'storage.type.silk')
+  assert.include(scopesAt(program, 'fn'), 'storage.type.silk')
+  assert.include(scopesAt(program, 'main'), 'entity.name.function.silk')
+  assert.include(scopesAt(program, 'return'), 'keyword.control.silk')
+  assert.include(scopesAt(program, 'I32'), 'support.type.builtin.silk')
+  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'impl'), 'storage.type.silk')
+  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'for'), 'storage.type.silk')
+  assert.include(scopesAt('impl Allocator for Mine { unsafe {} }', 'unsafe'), 'storage.type.silk')
+  assert.include(
+    scopesAt('impl Allocator for Mine { unsafe {} }', 'Allocator'),
+    'entity.name.type.silk',
+  )
   assert.include(scopesAt(program, '42'), 'constant.numeric.integer.silk')
   assert.include(scopesAt('let ok = true', 'true'), 'constant.language.boolean.silk')
   assert.include(scopesAt('fn stop() -> Never', 'Never'), 'support.type.builtin.silk')
+  assert.include(scopesAt('fn id(x: Point) -> Point', 'Point'), 'entity.name.type.silk')
   assert.include(scopesAt('/// doc', '/// doc'), 'comment.line.documentation.silk')
   assert.include(scopesAt('// plain', '// plain'), 'comment.line.double-slash.silk')
   assert.notInclude(scopesAt('// plain', '// plain'), 'comment.line.documentation.silk')
+  const control = 'pub fn main() -> I32 { if true { return 1 } else { return 0 } }'
+  assert.include(scopesAt(control, 'if'), 'keyword.control.silk')
+  assert.include(scopesAt(control, 'else'), 'keyword.control.silk')
   const match = 'match &mut event { Token { kind, .. } if true => kind _ => 0 }'
-  assert.include(scopesAt(match, 'match'), 'keyword.other.silk')
+  assert.include(scopesAt(match, 'match'), 'keyword.control.silk')
   assert.include(scopesAt(match, '&'), 'keyword.operator.silk')
   assert.include(scopesAt(match, '=>'), 'keyword.operator.silk')
   assert.include(scopesAt(match, '..'), 'punctuation.definition.pattern.rest.silk')
-  assert.include(scopesAt(match, 'Token'), 'entity.name.type.pattern.silk')
+  assert.include(scopesAt(match, 'Token'), 'entity.name.type.silk')
   assert.include(scopesAt(match, '_'), 'variable.language.wildcard.silk')
   const generic = 'fn keep<T>(value: Box<T>) -> Box<T> { return keep<I32>(value) }'
   assert.include(scopesAt(generic, '<'), 'punctuation.definition.type-arguments.begin.silk')
   assert.include(scopesAt(generic, '>'), 'punctuation.definition.type-arguments.end.silk')
+  assert.include(scopesAt(generic, 'Box'), 'entity.name.type.silk')
   const nested = 'fn keep<value>(input: Box<Box<I32>>) -> Box<Box<I32>> { return input }'
   assert.include(scopesAt(nested, '<'), 'punctuation.definition.type-arguments.begin.silk')
   assert.include(scopesAt(nested, '>'), 'punctuation.definition.type-arguments.end.silk')

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -15,14 +15,50 @@ Two parts:
   supports standard dynamic watched-file registration, so no duplicate extension-owned watcher is
   installed.
 
-## Install (local, symlink)
+## Which workflow?
+
+| Goal | Use |
+| --- | --- |
+| Edit `.silk` in your normal Cursor window | [Install (local)](#install-local) |
+| Develop the extension or language server | [Extension Development Host](#extension-development-host) |
+
+## Install (local)
+
+From the repo root (or this package), retarget the editor symlink to **this** checkout and build
+the extension plus language server:
 
 ```sh
-pnpm build
-ln -s "$(pwd)/packages/vscode" ~/.cursor/extensions/silk-effect.silk-language-0.0.0
+pnpm --filter silk-language install:cursor
 ```
 
-Reload Cursor (`Developer: Reload Window`) and open a `.silk` file. For VS Code, use
-`~/.vscode/extensions` instead. The symlinked extension resolves `@silk-effect/lsp` through the
-workspace's `node_modules`, so it needs a built checkout (`pnpm install && pnpm build`) — after
-changing server code, rebuild and reload the window.
+For VS Code instead of Cursor:
+
+```sh
+pnpm --filter silk-language install:code
+```
+
+Both: `pnpm --filter silk-language exec node scripts/install-local.mjs --vscode`.
+
+Then reload the editor (`Developer: Reload Window`) and open a `.silk` file. The symlink lives at
+`~/.cursor/extensions/silk-effect.silk-language-0.0.0` (or `~/.vscode/extensions/...`) and always
+points at the checkout where you ran the command — re-run it after switching git worktrees.
+
+The extension resolves `@silk-effect/lsp` through the workspace `node_modules`, so the checkout
+must stay installed and built.
+
+## Extension Development Host
+
+To iterate on the extension or LSP without touching the global extensions directory, launch
+**Silk: Extension Development Host** from the Run and Debug view (F5). That opens a guest window
+with `--extensionDevelopmentPath` set to this package; a pre-launch task builds `@silk-effect/lsp`
+and `silk-language` first.
+
+Optional watch tasks (**Silk: Watch language server**, **Silk: Watch extension**) rebuild on save
+while the host is open.
+
+## Reload vs restart
+
+| Change | Action |
+| --- | --- |
+| Retargeted install, grammar (`sync:vscode`), or `extension.ts` / `package.json` contributions | **Developer: Reload Window** (main Cursor or the EDH guest) |
+| Rebuilt `@silk-effect/lsp` only, same extension path | **Silk: Restart Language Server** — picks up the new `dist` without a window reload |

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -47,6 +47,8 @@
     "build": "pnpm clean && tsc -p tsconfig.json",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "install:cursor": "node scripts/install-local.mjs",
+    "install:code": "node scripts/install-local.mjs --vscode-only",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/vscode/scripts/install-local.mjs
+++ b/packages/vscode/scripts/install-local.mjs
@@ -1,0 +1,83 @@
+/**
+ * Builds the Silk extension and language server, then retargets the local editor
+ * extensions symlink to this checkout's packages/vscode. Replaces dangling or
+ * wrong-worktree links via ln -sfn.
+ *
+ * Usage:
+ *   node scripts/install-local.mjs              # Cursor (~/.cursor/extensions)
+ *   node scripts/install-local.mjs --vscode     # also VS Code (~/.vscode/extensions)
+ *   node scripts/install-local.mjs --vscode-only
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const EXTENSION_DIR_NAME = 'silk-effect.silk-language-0.0.0'
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = resolve(packageRoot, '../..')
+
+const args = new Set(process.argv.slice(2))
+const installCursor = !args.has('--vscode-only')
+const installVscode = args.has('--vscode') || args.has('--vscode-only')
+
+if (args.has('--help') || args.has('-h')) {
+  console.log(`Usage: node scripts/install-local.mjs [--vscode] [--vscode-only]
+
+  (default)     Symlink into ~/.cursor/extensions
+  --vscode      Also symlink into ~/.vscode/extensions
+  --vscode-only Only symlink into ~/.vscode/extensions
+`)
+  process.exit(0)
+}
+
+const fail = (message) => {
+  console.error(`install-local: ${message}`)
+  process.exit(1)
+}
+
+const run = (command, commandArgs, cwd) => {
+  try {
+    execFileSync(command, commandArgs, { cwd, stdio: 'inherit' })
+  } catch {
+    fail(`${command} ${commandArgs.join(' ')} failed`)
+  }
+}
+
+console.log('Building @silk-effect/lsp and silk-language…')
+run('pnpm', ['--filter', '@silk-effect/lsp', '--filter', 'silk-language', 'run', 'build'], repoRoot)
+
+const entrypoint = join(packageRoot, 'dist/extension.js')
+if (!existsSync(entrypoint)) {
+  fail(`expected extension entrypoint at ${entrypoint}`)
+}
+
+const linkExtension = (extensionsRoot, editorLabel) => {
+  mkdirSync(extensionsRoot, { recursive: true })
+  const linkPath = join(extensionsRoot, EXTENSION_DIR_NAME)
+
+  try {
+    // Removes a prior symlink (including dangling / wrong-worktree targets) without
+    // following it into the old checkout.
+    rmSync(linkPath, { recursive: true, force: true })
+    symlinkSync(packageRoot, linkPath)
+  } catch (cause) {
+    fail(`could not link ${linkPath} -> ${packageRoot}: ${cause}`)
+  }
+
+  console.log(`${editorLabel}: ${linkPath} -> ${packageRoot}`)
+}
+
+if (installCursor) {
+  linkExtension(join(homedir(), '.cursor/extensions'), 'Cursor')
+}
+if (installVscode) {
+  linkExtension(join(homedir(), '.vscode/extensions'), 'VS Code')
+}
+
+console.log(`
+Installed. Reload the editor window (Developer: Reload Window) so contributions load from this checkout.
+
+After rebuilding only the language server, run "Silk: Restart Language Server" instead of reinstalling.
+`)

--- a/packages/vscode/syntaxes/silk.tmLanguage.json
+++ b/packages/vscode/syntaxes/silk.tmLanguage.json
@@ -1,9 +1,7 @@
 {
   "name": "silk",
   "scopeName": "source.silk",
-  "fileTypes": [
-    "silk"
-  ],
+  "fileTypes": ["silk"],
   "patterns": [
     {
       "name": "comment.line.documentation.silk",
@@ -14,8 +12,23 @@
       "match": "//[^\\n]*"
     },
     {
-      "name": "keyword.other.silk",
-      "match": "\\b(?:pub|struct|fn|effect|run|fail|drop|unsafe|impl|for|return|import|as|let|mut|once|move|match|if|else|while|break|continue)\\b"
+      "match": "\\b(fn)\\s+([A-Za-z_][A-Za-z0-9_]*)",
+      "captures": {
+        "1": {
+          "name": "storage.type.silk"
+        },
+        "2": {
+          "name": "entity.name.function.silk"
+        }
+      }
+    },
+    {
+      "name": "keyword.control.silk",
+      "match": "\\b(?:if|else|while|break|continue|return|match)\\b"
+    },
+    {
+      "name": "storage.type.silk",
+      "match": "\\b(?:pub|struct|effect|run|fail|drop|unsafe|impl|for|import|as|let|mut|once|move)\\b"
     },
     {
       "name": "constant.language.boolean.silk",
@@ -26,8 +39,8 @@
       "match": "\\b(?:I32|Bool|Never)\\b"
     },
     {
-      "name": "entity.name.type.pattern.silk",
-      "match": "\\b[A-Z][A-Za-z0-9_]*(?=\\s*\\{)"
+      "name": "entity.name.type.silk",
+      "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
     },
     {
       "name": "variable.language.wildcard.silk",


### PR DESCRIPTION
## Summary
- Add `install:cursor` / `install:code` to retarget the local extension symlink at the current checkout (fixes dangling worktree installs) and document reload vs language-server restart.
- Add Extension Development Host launch config plus build/watch tasks for iterating on the extension and LSP without touching global extensions.
- Enrich the shared TextMate grammar with control vs storage keyword scopes, `fn` name highlighting, and broader PascalCase type scopes; sync specs and archive the OpenSpec change.

## Test plan
- [ ] Run `pnpm --filter silk-language install:cursor` from this worktree and confirm `~/.cursor/extensions/silk-effect.silk-language-0.0.0` points here
- [ ] `Developer: Reload Window`, open a `.silk` file, and check control/fn/type coloring
- [ ] F5 **Silk: Extension Development Host** and confirm Silk works in the guest window
- [ ] Rebuild `@silk-effect/lsp` and confirm **Silk: Restart Language Server** picks it up without a full reload
- [ ] `pnpm --filter @silk-effect/language test` and typecheck for language + vscode packages