### PR TITLE
lexer: Add hex, binary, and octal integer literals

### DIFF
--- a/openspec/specs/bootstrap-lexer/spec.md
+++ b/openspec/specs/bootstrap-lexer/spec.md
@@ -11,9 +11,10 @@ The lexer SHALL recognize ASCII whitespace, `//` line comments, `///` documentat
 distinct token kind, the keywords `pub`, `fn`, `return`, `let`, `move`, and the provisional
 `import`, ASCII identifiers, decimal integer literals, `(`, `)`, `{`, `}`, `:`, `,`, `=`, `.`,
 `-`, `->`, and end-of-file. An identifier SHALL begin with an ASCII letter or underscore and
-continue with ASCII letters, digits, or underscores. A decimal integer literal SHALL contain one
-or more ASCII digits. A `-` immediately followed by `>` SHALL remain one arrow token; any other
-`-` SHALL be one minus token.
+continue with ASCII letters, digits, or underscores. An integer literal written without a base
+prefix SHALL contain one or more ASCII digits and SHALL be read in base ten; the base prefixes are
+specified by "Integer literals select a base from their prefix". A `-` immediately followed by `>`
+SHALL remain one arrow token; any other `-` SHALL be one minus token.
 
 #### Scenario: Lex the first parser fixture
 
@@ -262,3 +263,39 @@ multiline literal.
 
 - **WHEN** a multiline literal body contains `\"\"\"` followed later by an unescaped `"""`
 - **THEN** the escaped quotes remain literal content and the later unescaped triple quote closes the token
+
+### Requirement: Integer literals select a base from their prefix
+
+An integer literal SHALL accept the base prefixes `0x` and `0X` for base sixteen, `0b` and `0B` for
+base two, and `0o` and `0O` for base eight, each followed by one or more digits of its selected
+base. A prefixed literal SHALL be one integer literal token of the same kind as an unprefixed
+literal, SHALL retain its exact magnitude, and SHALL NOT accept a fraction part or an exponent
+part. A leading `0` that no base letter follows SHALL keep the decimal reading, so `0` alone and
+`0.5` retain their existing token kinds. A base prefix that no digit of its base follows SHALL be
+one invalid token producing exactly one lexical diagnostic. Every conversion of an integer literal
+to a value SHALL read the base from the token's own source slice rather than assume base ten.
+
+#### Scenario: Lex every base prefix
+
+- **WHEN** the source bytes spell `0xff 0b1010 0o777`
+- **THEN** the stream contains exactly three integer literal tokens whose slices are `0xff`, `0b1010`, and `0o777`
+
+#### Scenario: Preserve the unprefixed readings
+
+- **WHEN** the source bytes spell `0 0.5`
+- **THEN** the stream contains one integer literal token `0` and one floating-point literal token `0.5`
+
+#### Scenario: Reject a prefix without digits
+
+- **WHEN** the source bytes spell `0x` with no following hexadecimal digit
+- **THEN** the lexer emits one invalid token covering the prefix and exactly one lexical diagnostic
+
+#### Scenario: Keep a prefixed literal free of float parts
+
+- **WHEN** the source bytes spell `0xff.5`
+- **THEN** the integer literal token ends after `0xff` and the remaining bytes are tokenized independently
+
+#### Scenario: Convert a prefixed literal in its own base
+
+- **WHEN** a compiled program returns `0xff` where another returns `255`
+- **THEN** both programs produce the same value, and a prefixed literal outside its selected type's range produces the existing out-of-range diagnostic

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -1,6 +1,7 @@
 import * as Option from 'effect/Option'
 import * as Diagnostic from './Diagnostic.js'
 import * as Intrinsic from './Intrinsic.js'
+import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import type * as ModuleClosure from './ModuleClosure.js'
 import * as SourceFile from './SourceFile.js'
 import type * as SourceSpan from './SourceSpan.js'
@@ -614,9 +615,10 @@ const constantLiteral = (
     if (token === undefined) return Object.freeze({ _tag: 'Unavailable', syntax: initializer })
     const digits = spelling(source, token)
     const negative = SyntaxTree.directToken(initializer, 'Minus') !== undefined
+    const magnitude = IntegerLiteral.magnitude(digits)
     return Object.freeze({
       _tag: 'IntegerLiteral',
-      value: BigInt(`${negative ? '-' : ''}${digits}`),
+      value: negative ? -magnitude : magnitude,
       spelling: `${negative ? '-' : ''}${digits}`,
       token,
     })
@@ -920,7 +922,7 @@ export const analyzeDeclaredType = (
       })
     } else {
       const lengthSpelling = spelling(source, lengthToken)
-      const value = Number(lengthSpelling)
+      const value = Number(IntegerLiteral.magnitude(lengthSpelling))
       if (!Number.isSafeInteger(value) || value > 2147483647) {
         const diagnostic = Diagnostic.integerOutOfRange(lengthSpelling, lengthToken.span)
         diagnostics.push(diagnostic)

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -22,6 +22,9 @@ export const unknownLiteralModifierCode = 'LEX0002' as const
 /** Stable code for a literal whose matching closing delimiter is absent. */
 export const unterminatedStaticLiteralCode = 'LEX0003' as const
 
+/** Stable code for an integer-literal base prefix that no digit follows. */
+export const missingBaseDigitsCode = 'LEX0004' as const
+
 /** Stable code for one required token that is absent at its insertion position. */
 export const missingTokenCode = 'PAR0001' as const
 
@@ -199,6 +202,7 @@ export type Code =
   | typeof unsupportedBytesCode
   | typeof unknownLiteralModifierCode
   | typeof unterminatedStaticLiteralCode
+  | typeof missingBaseDigitsCode
   | typeof missingTokenCode
   | typeof unexpectedTokensCode
   | typeof reservedTemplateSyntaxCode
@@ -339,6 +343,7 @@ export type Reason =
       readonly modifier: string
       readonly delimiterWidth: 1 | 3
     }
+  | { readonly _tag: 'MissingBaseDigits'; readonly radix: 2 | 8 | 16 }
   | { readonly _tag: 'MissingToken'; readonly expected: Token.TokenKind }
   | {
       readonly _tag: 'UnexpectedTokens'
@@ -790,6 +795,18 @@ export const unterminatedStaticLiteral = (
     severity: 'error',
     message: `Unterminated ${delimiterWidth === 3 ? 'multiline ' : ''}static literal`,
     reason: Object.freeze({ _tag: 'UnterminatedStaticLiteral', modifier, delimiterWidth }),
+    span,
+  })
+
+/** Creates the lexical diagnostic for one base prefix that no digit of its base follows. */
+export const missingBaseDigits = (radix: 2 | 8 | 16, span: SourceSpan.SourceSpan): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'lexical',
+    code: missingBaseDigitsCode,
+    severity: 'error',
+    message: `Base-${radix} integer literal without digits`,
+    reason: Object.freeze({ _tag: 'MissingBaseDigits', radix }),
     span,
   })
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -5,6 +5,7 @@ import * as Diagnostic from './Diagnostic.js'
 import * as FloatingPoint from './FloatingPoint.js'
 import * as Hir from './Hir.js'
 import * as Intrinsic from './Intrinsic.js'
+import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import * as LiteralForm from './LiteralForm.js'
 import * as Match from './Match.js'
 import * as NameResolution from './NameResolution.js'
@@ -1095,12 +1096,6 @@ const spelling = (source: SourceFile.SourceFile, token: Token.Token): string =>
     () => new RangeError(`Semantic token span does not belong to source ${source.id}`),
   )
 
-const unsignedMagnitude = (bytes: Uint8Array): bigint => {
-  let value = 0n
-  for (const byte of bytes) value = value * 10n + BigInt(byte - 0x30)
-  return value
-}
-
 interface IntegerResult {
   readonly fact: IntegerExpressionFact
   readonly diagnostics: ReadonlyArray<Diagnostic.Diagnostic>
@@ -1178,7 +1173,7 @@ const analyzeInteger = (
       : Scalar.defaultInteger
   if (selected === undefined || selected.category !== 'Integer')
     throw new RangeError('The scalar catalog lost its default integer')
-  const magnitude = unsignedMagnitude(bytes)
+  const magnitude = IntegerLiteral.magnitude(bytes)
   const value = negative ? -magnitude : magnitude
   // Target-width integers are retained against the widest admitted target here. The concrete
   // target validates its selected 32- or 64-bit range before MIR is committed.

--- a/packages/compiler/src/Lexer.ts
+++ b/packages/compiler/src/Lexer.ts
@@ -1,5 +1,6 @@
 import * as Option from 'effect/Option'
 import * as Diagnostic from './Diagnostic.js'
+import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import * as LiteralForm from './LiteralForm.js'
 import type * as SourceFile from './SourceFile.js'
 import * as SourceSpan from './SourceSpan.js'
@@ -320,6 +321,16 @@ export const lex = (source: SourceFile.SourceFile): LexicalResult => {
     }
 
     if (isDecimalDigit(byte)) {
+      const base = IntegerLiteral.recognize(bytes, index)
+      if (base.radix !== 10) {
+        index += base.width
+        const digits = index
+        while (index < bytes.length && IntegerLiteral.isDigit(base, bytes[index])) index += 1
+        const empty = index === digits
+        const span = pushToken(empty ? 'Invalid' : 'DecimalInteger', start, index)
+        if (empty) diagnostics.push(Diagnostic.missingBaseDigits(base.radix, span))
+        continue
+      }
       index += 1
       while (index < bytes.length && isDecimalDigit(bytes[index])) index += 1
       let floating = false

--- a/packages/compiler/src/internal/IntegerLiteral.ts
+++ b/packages/compiler/src/internal/IntegerLiteral.ts
@@ -1,0 +1,91 @@
+/** The numeric base an integer literal's digits are read in. */
+export type Radix = 2 | 8 | 10 | 16
+
+/** Byte storage accepted from source files, tests, and generated tooling. */
+export type ByteSequence = ReadonlyArray<number> | Uint8Array
+
+/** Source storage accepted for one complete integer-literal slice. */
+export type Digits = ByteSequence | string
+
+/** The base selected by an integer literal's optional prefix, with its exact prefix width. */
+export interface Base {
+  readonly radix: Radix
+  readonly width: 0 | 2
+}
+
+const codeAt = (digits: Digits, index: number): number =>
+  typeof digits === 'string' ? digits.charCodeAt(index) : (digits[index] ?? Number.NaN)
+
+const digitValue = (byte: number): number =>
+  byte <= 0x39 ? byte - 0x30 : byte <= 0x46 ? byte - 0x41 + 10 : byte - 0x61 + 10
+
+const make = (radix: Radix, width: 0 | 2): Base => Object.freeze({ radix, width })
+
+/** The implicit base of a literal written without a prefix. */
+export const decimal: Base = make(10, 0)
+
+/** The base introduced by `0b` or `0B`. */
+export const binary: Base = make(2, 2)
+
+/** The base introduced by `0o` or `0O`. */
+export const octal: Base = make(8, 2)
+
+/** The base introduced by `0x` or `0X`. */
+export const hexadecimal: Base = make(16, 2)
+
+/**
+ * Recognizes the base prefix introducing an integer literal at `index`.
+ *
+ * A literal without a recognized prefix keeps the decimal base, so `0` alone and `0.5` retain
+ * their existing readings.
+ */
+export const recognize = (digits: Digits, index = 0): Base => {
+  if (codeAt(digits, index) !== 0x30) return decimal
+  switch (codeAt(digits, index + 1)) {
+    case 0x62:
+    case 0x42:
+      return binary
+    case 0x6f:
+    case 0x4f:
+      return octal
+    case 0x78:
+    case 0x58:
+      return hexadecimal
+    default:
+      return decimal
+  }
+}
+
+/** Reports whether one byte is a digit of the given base. */
+export const isDigit = (self: Base, byte: number | undefined): boolean => {
+  if (byte === undefined) return false
+  switch (self.radix) {
+    case 2:
+      return byte === 0x30 || byte === 0x31
+    case 8:
+      return byte >= 0x30 && byte <= 0x37
+    case 10:
+      return byte >= 0x30 && byte <= 0x39
+    case 16:
+      return (
+        (byte >= 0x30 && byte <= 0x39) ||
+        (byte >= 0x41 && byte <= 0x46) ||
+        (byte >= 0x61 && byte <= 0x66)
+      )
+  }
+}
+
+/**
+ * Reads the exact unsigned magnitude of one complete integer-literal slice.
+ *
+ * The slice carries its own base, so a conversion never assumes decimal for a prefixed literal.
+ */
+export const magnitude = (digits: Digits): bigint => {
+  const base = recognize(digits, 0)
+  const radix = BigInt(base.radix)
+  let value = 0n
+  for (let index = base.width; index < digits.length; index += 1) {
+    value = value * radix + BigInt(digitValue(codeAt(digits, index)))
+  }
+  return value
+}

--- a/packages/compiler/test/IntegerBaseAcceptance.test.ts
+++ b/packages/compiler/test/IntegerBaseAcceptance.test.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-integer-base-acceptance-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const parity = `const upperMask: i32 = 0xff00
+const lowBits: i32 = 0b1010
+const permission: i32 = 0o644
+
+fn identity(value: i32) -> i32 { return value }
+
+pub fn main() -> i32 {
+  let hexadecimal = 0xff
+  let upperHexadecimal = 0XFF
+  let binary = 0b1010
+  let octal = 0o777
+  if hexadecimal == 255 {} else { return 1 }
+  if upperHexadecimal == hexadecimal {} else { return 2 }
+  if binary == 10 {} else { return 3 }
+  if octal == 511 {} else { return 4 }
+  if upperMask == 65280 {} else { return 5 }
+  if lowBits == 10 {} else { return 6 }
+  if permission == 420 {} else { return 7 }
+  return identity(hexadecimal) - 213
+}`
+
+it.effect(
+  'reads hexadecimal, binary, and octal literals in their own base on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'integer-base/parity',
+        ascii(parity),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(
+        evaluated._tag,
+        'Completed',
+        JSON.stringify(evaluated, (_, value) =>
+          typeof value === 'bigint' ? value.toString() : value,
+        ),
+      )
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
+
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make('integer-base/parity', ascii(parity)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'parity'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 42, run.stderr)
+    }),
+  60_000,
+)
+
+it.effect('keeps a prefixed literal equal to its decimal spelling in the same program', () =>
+  Effect.gen(function* () {
+    const source = `pub fn main() -> i32 { return 0xff - 255 }`
+    const snapshot = yield* Analysis.ofSourceRealized('integer-base/equality', ascii(source))
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 0)
+  }),
+)
+
+it.effect('reports the existing out-of-range diagnostic for a prefixed literal', () =>
+  Effect.gen(function* () {
+    const source = `fn accept(value: u8) -> u8 { return value }
+pub fn main() -> i32 { let value = accept(0x1ff) return 42 }`
+    const snapshot = yield* Analysis.ofSourceRealized('integer-base/out-of-range', ascii(source))
+    const outOfRange = Analysis.expressionsOf(snapshot, 'integer-base/out-of-range').filter(
+      (expression) => expression._tag === 'Integer' && expression.integer._tag === 'OutOfRange',
+    )
+    assert.strictEqual(outOfRange.length, 1)
+    const reported = Analysis.diagnostics(snapshot).filter(
+      (diagnostic) => diagnostic.reason._tag === 'IntegerOutOfRange',
+    )
+    assert.strictEqual(reported.length, 1)
+    assert.deepEqual(
+      reported.map((diagnostic) =>
+        diagnostic.reason._tag === 'IntegerOutOfRange' ? diagnostic.reason.spelling : undefined,
+      ),
+      ['0x1ff'],
+    )
+  }),
+)
+
+it.effect('rejects a base prefix without digits before parsing', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'integer-base/missing-digits',
+      ascii('pub fn main() -> i32 { return 0x }'),
+    )
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'LEX0004',
+    )
+  }),
+)

--- a/packages/compiler/test/IntegerLiteral.test.ts
+++ b/packages/compiler/test/IntegerLiteral.test.ts
@@ -1,0 +1,48 @@
+import { assert, it } from '@effect/vitest'
+import * as IntegerLiteral from '../src/internal/IntegerLiteral.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+it('selects a base only from a committed prefix', () => {
+  assert.deepEqual(
+    ['0xff', '0XFF', '0b1', '0B1', '0o7', '0O7', '0', '00', '0.5', '42', '0e2'].map(
+      (spelling) => IntegerLiteral.recognize(spelling).radix,
+    ),
+    [16, 16, 2, 2, 8, 8, 10, 10, 10, 10, 10],
+  )
+  assert.strictEqual(IntegerLiteral.recognize(ascii('0xff')).width, 2)
+  assert.strictEqual(IntegerLiteral.recognize(ascii('42')).width, 0)
+})
+
+it('accepts only the digits belonging to each base', () => {
+  const digits = (base: IntegerLiteral.Base, candidates: string): string =>
+    Array.from(candidates)
+      .filter((character) => IntegerLiteral.isDigit(base, character.charCodeAt(0)))
+      .join('')
+
+  assert.strictEqual(digits(IntegerLiteral.binary, '0123456789abcdefABCDEF'), '01')
+  assert.strictEqual(digits(IntegerLiteral.octal, '0123456789abcdefABCDEF'), '01234567')
+  assert.strictEqual(digits(IntegerLiteral.decimal, '0123456789abcdefABCDEF'), '0123456789')
+  assert.strictEqual(
+    digits(IntegerLiteral.hexadecimal, '0123456789abcdefgABCDEFG'),
+    '0123456789abcdefABCDEF',
+  )
+  assert.isFalse(IntegerLiteral.isDigit(IntegerLiteral.decimal, undefined))
+})
+
+it('reads the exact magnitude of every base without losing precision', () => {
+  assert.strictEqual(IntegerLiteral.magnitude('0xff'), 255n)
+  assert.strictEqual(IntegerLiteral.magnitude('0XFF'), 255n)
+  assert.strictEqual(IntegerLiteral.magnitude(ascii('0b1010')), 10n)
+  assert.strictEqual(IntegerLiteral.magnitude('0o777'), 511n)
+  assert.strictEqual(IntegerLiteral.magnitude('0o644'), 420n)
+  assert.strictEqual(IntegerLiteral.magnitude('255'), 255n)
+  assert.strictEqual(IntegerLiteral.magnitude('0'), 0n)
+  assert.strictEqual(IntegerLiteral.magnitude('0x0'), 0n)
+  assert.strictEqual(IntegerLiteral.magnitude('0xffffffffffffffff'), 18446744073709551615n)
+  assert.strictEqual(
+    IntegerLiteral.magnitude('340282366920938463463374607431768211455'),
+    340282366920938463463374607431768211455n,
+  )
+})

--- a/packages/compiler/test/Lexer.test.ts
+++ b/packages/compiler/test/Lexer.test.ts
@@ -190,6 +190,92 @@ it('retains decimal fractions and exponent spellings as exact float tokens', () 
   )
 })
 
+it('lexes every base prefix as one integer token with its exact slice', () => {
+  const source = SourceFile.make(
+    'memory://base-prefixes.silk',
+    ascii('0xff 0XFF 0b1010 0B1 0o777 0O7'),
+  )
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'DecimalInteger', start: 0, end: 4, slice: '0xff' },
+      { kind: 'DecimalInteger', start: 5, end: 9, slice: '0XFF' },
+      { kind: 'DecimalInteger', start: 10, end: 16, slice: '0b1010' },
+      { kind: 'DecimalInteger', start: 17, end: 20, slice: '0B1' },
+      { kind: 'DecimalInteger', start: 21, end: 26, slice: '0o777' },
+      { kind: 'DecimalInteger', start: 27, end: 30, slice: '0O7' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('keeps unprefixed zero and decimal fractions at their existing kinds', () => {
+  const source = SourceFile.make('memory://unprefixed-zero.silk', ascii('0 0.5 00 0e2'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'DecimalInteger', start: 0, end: 1, slice: '0' },
+      { kind: 'DecimalFloat', start: 2, end: 5, slice: '0.5' },
+      { kind: 'DecimalInteger', start: 6, end: 8, slice: '00' },
+      { kind: 'DecimalFloat', start: 9, end: 12, slice: '0e2' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('stops a prefixed literal before any fraction, exponent, or foreign digit', () => {
+  const source = SourceFile.make('memory://prefixed-boundaries.silk', ascii('0xff.5 0b1e5 0o18'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'DecimalInteger', start: 0, end: 4, slice: '0xff' },
+      { kind: 'Dot', start: 4, end: 5, slice: '.' },
+      { kind: 'DecimalInteger', start: 5, end: 6, slice: '5' },
+      { kind: 'DecimalInteger', start: 7, end: 10, slice: '0b1' },
+      { kind: 'Identifier', start: 10, end: 12, slice: 'e5' },
+      { kind: 'DecimalInteger', start: 13, end: 16, slice: '0o1' },
+      { kind: 'DecimalInteger', start: 16, end: 17, slice: '8' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('diagnoses a base prefix without digits exactly once and resumes lexing', () => {
+  const source = SourceFile.make('memory://empty-base-prefix.silk', ascii('0x tail'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens.map((token) => tokenView(source, token)),
+    [
+      { kind: 'Invalid', start: 0, end: 2, slice: '0x' },
+      { kind: 'Whitespace', start: 2, end: 3, slice: ' ' },
+      { kind: 'Identifier', start: 3, end: 7, slice: 'tail' },
+      { kind: 'EndOfFile', start: 7, end: 7, slice: '' },
+    ],
+  )
+  assert.deepEqual(
+    result.diagnostics.map(({ code, reason }) => ({ code, reason })),
+    [{ code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 16 } }],
+  )
+
+  const others = Lexer.lex(SourceFile.make('memory://empty-base-prefixes.silk', ascii('0b 0O')))
+  assert.deepEqual(
+    others.diagnostics.map(({ code, reason }) => ({ code, reason })),
+    [
+      { code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 2 } },
+      { code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 8 } },
+    ],
+  )
+})
+
 it('recognizes struct only as a complete keyword', () => {
   const result = Lexer.lex(
     SourceFile.make('memory://struct-keyword.silk', ascii('struct structure structs')),


### PR DESCRIPTION
Closes #9

The number branch now looks at the byte after a leading `0` before it consumes a digit
run. `0x`/`0X`, `0b`/`0B`, and `0o`/`0O` each commit to their base and scan only that
base's digits, so `0xff` is one token rather than `0` followed by the identifier `xff`.
The token kind stays `DecimalInteger` and the scan stays a longest-token scan: a leading
`0` that no base letter follows falls back to the decimal rule, and a prefixed literal
never absorbs a fraction or exponent part.

Because the kind is shared, every conversion from a literal token to a value now reads
the base from the token's own slice through a new internal `IntegerLiteral` actor
(`packages/compiler/src/internal/IntegerLiteral.ts`), used by the lexer's digit scan,
`Elaboration.analyzeInteger`, and both `DeclarationIndex` conversions. The previous
`unsignedMagnitude` helper assumed base ten and `BigInt(\`-${digits}\`)` threw on a
negative prefixed constant.

A base prefix with no digit after it becomes one `Invalid` token carrying the new
`LEX0004` lexical diagnostic, which keeps the existing lossless-coverage and
invalid-byte recovery guarantees.

### Acceptance criteria

- [x] The lexer produces one integer token for `0xff`, `0b1010`, and `0o777`.
- [x] A lexer test shows that `0` and `0.5` keep their current token kinds.
- [x] A lexer test shows that `0x` alone produces one lexical diagnostic.
- [x] The value of `0xff` equals the value of `255` in a compiled program.
- [x] A literal outside the range of its selected type produces the existing diagnostic.
- [x] `openspec/specs/bootstrap-lexer/spec.md:14-15` gets an amendment for the three new base prefixes.

The spec amendment restates the decimal sentence at those lines as the unprefixed rule
and adds a `Requirement: Integer literals select a base from their prefix` section with
five scenarios.

Tests: baseline 3 failures, after 3 failures, +11 new tests

`packages/compiler/test/IntegerBaseAcceptance.test.ts` checks three-engine agreement
(MIR evaluation, direct Wasm, native clang) for hexadecimal, binary, and octal literals
in both `const` declarations and expressions. `test/OsFileSystem.test.ts > lowers the OS
directory-list provider runner` timed out once in the full parallel run on a machine
under heavy concurrent load and passes in isolation; it is not counted as a failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_