### PR TITLE
fix(compiler): add the missing artifact cache API

### DIFF
--- a/packages/compiler/src/NativeToolchain.ts
+++ b/packages/compiler/src/NativeToolchain.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   copyFileSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   renameSync,
@@ -28,6 +30,7 @@ export interface Toolchain {
   readonly _tag: 'Toolchain'
   readonly clang: string
   readonly shimCache?: ShimCache
+  readonly artifactCache?: ArtifactCache
 }
 
 /** Process-local compiled shim bytes shared explicitly across independent build scopes. */
@@ -67,6 +70,105 @@ export const makeShimCache = (): ShimCache => {
 
 /** Reads immutable counters from a shared shim cache. */
 export const shimCacheStats = (self: ShimCache): ShimCacheStats => self.stats()
+
+/**
+ * Content-addressed storage of finished artifact bytes, keyed by everything that can change the
+ * output. A hit skips the external toolchain entirely.
+ */
+export interface ArtifactCache {
+  readonly _tag: 'ArtifactCache'
+  readonly get: (key: string) => Uint8Array | undefined
+  readonly set: (key: string, bytes: Uint8Array) => void
+}
+
+/** Makes a durable artifact cache under `directory`, shared across processes. */
+export const makeDiskArtifactCache = (directory: string): ArtifactCache => {
+  const root = resolve(directory)
+  return Object.freeze({
+    _tag: 'ArtifactCache',
+    get: (key: string) => {
+      const path = join(root, key)
+      if (!existsSync(path)) return undefined
+      try {
+        return readFileSync(path)
+      } catch {
+        // ponytail: an unreadable entry is a miss, not a build failure.
+        return undefined
+      }
+    },
+    set: (key: string, bytes: Uint8Array) => {
+      try {
+        mkdirSync(root, { recursive: true })
+        // Stage then rename, so a concurrent reader never observes a partial entry.
+        const path = join(root, key)
+        const temporary = `${path}.silk-tmp-${process.pid}`
+        writeFileSync(temporary, bytes)
+        renameSync(temporary, path)
+      } catch {
+        // ponytail: caching is an optimization; a write failure must not fail the build.
+      }
+    },
+  })
+}
+
+const processArtifactCache = new Map<string, Uint8Array>()
+
+/** The process-local artifact cache used when a toolchain pins none of its own. */
+export const defaultArtifactCache = (): ArtifactCache =>
+  Object.freeze({
+    _tag: 'ArtifactCache',
+    get: (key: string) => processArtifactCache.get(key),
+    set: (key: string, bytes: Uint8Array) => {
+      processArtifactCache.set(key, Uint8Array.from(bytes))
+    },
+  })
+
+/**
+ * Derives the cache identity of a finished artifact. Every input that can change the emitted
+ * bytes participates, so a hit is only ever served for a byte-identical build.
+ */
+export const artifactCacheKey = (
+  toolchain: Toolchain,
+  kind: FinalArtifact['kind'],
+  target: Target.Target,
+  profile: ToolchainPlan.OptimizationProfile,
+  bitcode: Uint8Array | string,
+  shimSource: string,
+): string => {
+  const digest = createHash('sha256')
+  digest.update(kind)
+  digest.update('\0')
+  digest.update(target.triple)
+  digest.update('\0')
+  digest.update(profile)
+  digest.update('\0')
+  digest.update(toolchain.clang)
+  digest.update('\0')
+  digest.update(shimSource)
+  digest.update('\0')
+  digest.update(bitcode)
+  return `${digest.digest('hex')}.${kind === 'NativeExecutable' ? 'bin' : 'wasm'}`
+}
+
+/** Commits cached artifact bytes straight to their destination, bypassing the toolchain. */
+export const commitCachedArtifact = (
+  bytes: Uint8Array,
+  kind: FinalArtifact['kind'],
+  target: Target.Target,
+  destination: string,
+): FinalArtifact | StorageFailure => {
+  const path = resolve(destination)
+  const temporary = `${path}.silk-tmp-${process.pid}`
+  try {
+    // A cached native executable must be restored runnable; bytes alone do not carry the mode.
+    writeFileSync(temporary, bytes, kind === 'NativeExecutable' ? { mode: 0o755 } : undefined)
+    renameSync(temporary, path)
+    return Object.freeze({ _tag: 'FinalArtifact', kind, path, target })
+  } catch (cause) {
+    rmSync(temporary, { force: true })
+    return storageFailure(path, cause)
+  }
+}
 
 /** One owned, path-backed artifact tied to a build scope. */
 export interface PathArtifact {


### PR DESCRIPTION
## Problem

`main` does not build a single native or Wasm artifact. 50 of 1005 compiler tests fail, all with the same error:

```
TypeError: defaultArtifactCache is not a function
  ❯ Module.<anonymous> src/Driver.ts:214:61
```

Commit 0b565d7 ("webcontainer editor") added 62 lines to `Driver.ts` that call four `NativeToolchain` symbols, and a `Driver.test.ts` case that calls a fifth:

- `NativeToolchain.defaultArtifactCache`
- `NativeToolchain.artifactCacheKey`
- `NativeToolchain.commitCachedArtifact`
- `Toolchain.artifactCache`
- `NativeToolchain.makeDiskArtifactCache`

None of them has ever existed — `git log -S "export const defaultArtifactCache" --all` returns nothing. The callers were committed without the API.

## Fix

Implements the artifact cache in `NativeToolchain.ts`, mirroring the ownership idiom of the existing `ShimCache`:

- **`ArtifactCache`** — a `get`/`set` pair over finished artifact bytes.
- **`makeDiskArtifactCache(directory)`** — durable, shared across processes. Writes stage to a temp path and rename, so a concurrent reader never sees a partial entry. Read and write failures degrade to a miss rather than failing the build.
- **`defaultArtifactCache()`** — process-local, used when a toolchain pins none of its own.
- **`artifactCacheKey(...)`** — SHA-256 over every input that can change the emitted bytes: artifact kind, target triple, optimization profile, pinned clang path, shim source, and the bitcode. A hit is only ever served for a byte-identical build.
- **`commitCachedArtifact(...)`** — writes cached bytes straight to the destination, bypassing the toolchain.

Native executables are restored with mode `0755`; raw bytes do not carry the executable permission, and without it the cached binary cannot be run.

## Tests

Baseline on `main`: **50 failures / 1005 tests**. After this change: **0 failures / 1005 tests**, no new tests added — `Driver.test.ts`'s existing "serves identical bitcode from the artifact cache without invoking the toolchain" case now passes, asserting the second build reports an `artifact-cache` phase, skips the `object` phase, and produces a binary that runs and exits 42.

This also clears the 4 failures (StringBackend, StringAcceptance ×2, OsFileSystem) previously assumed to be permanent macOS/clang breakage. They were the same root cause.

## Notes

Two unrelated pre-existing breaks are left untouched, both confirmed to fail identically without this change:

- `apps/docs` fails to typecheck — `project-backend.tsx:627` compares a `_tag` against `'String'`, a variant absent from the union.
- `pnpm typecheck` fails on a stale generated stdlib table (`run pnpm stdlib:generate`). The compiler's own `test` script runs `stdlib:check` and passes.

Separately, `packages/llvm/dist` was stale — `Metadata.stringType` existed in `src` but not in the built output the compiler resolves. A rebuild fixed it; no source change was needed.