### PR TITLE
lexer: Accept _ as a digit separator in number literals

### DIFF
--- a/openspec/specs/bootstrap-lexer/spec.md
+++ b/openspec/specs/bootstrap-lexer/spec.md
@@ -13,8 +13,9 @@ distinct token kind, the keywords `pub`, `fn`, `return`, `let`, `move`, and the 
 `-`, `->`, and end-of-file. An identifier SHALL begin with an ASCII letter or underscore and
 continue with ASCII letters, digits, or underscores. An integer literal written without a base
 prefix SHALL contain one or more ASCII digits and SHALL be read in base ten; the base prefixes are
-specified by "Integer literals select a base from their prefix". A `-` immediately followed by `>`
-SHALL remain one arrow token; any other `-` SHALL be one minus token.
+specified by "Integer literals select a base from their prefix", and the `_` digit separator is
+specified by "Number literals accept a digit separator between digits". A `-` immediately followed
+by `>` SHALL remain one arrow token; any other `-` SHALL be one minus token.
 
 #### Scenario: Lex the first parser fixture
 
@@ -299,3 +300,43 @@ to a value SHALL read the base from the token's own source slice rather than ass
 
 - **WHEN** a compiled program returns `0xff` where another returns `255`
 - **THEN** both programs produce the same value, and a prefixed literal outside its selected type's range produces the existing out-of-range diagnostic
+
+### Requirement: Number literals accept a digit separator between digits
+
+An integer or floating-point literal SHALL accept the byte `_` as a digit separator, and the
+separator SHALL be well placed only with a digit of the same digit run immediately on each side.
+A separator therefore SHALL NOT open or close a literal, SHALL NOT follow another separator, SHALL
+NOT sit immediately after a base prefix, and SHALL NOT sit immediately before or after the decimal
+point or the exponent letter. The lexer SHALL consume the separators of a literal itself, keeping
+one token rather than a literal followed by an identifier, and SHALL NOT require any group size.
+A literal whose separators are not all well placed SHALL be one invalid token covering the literal
+and SHALL produce exactly one lexical diagnostic over that same span, without introducing a new
+token kind. Every conversion of a literal to a value SHALL read it without its separators, so a
+separated literal SHALL retain the exact value of its separator-free spelling. The `_` byte SHALL
+keep its identifier meaning everywhere else, so a spelling beginning with `_` remains one
+identifier.
+
+#### Scenario: Separate the digits of an integer literal
+
+- **WHEN** the source bytes spell `1_000 1_048_576 0b1010_0000 0xff_ff`
+- **THEN** the stream contains exactly four integer literal tokens whose slices retain their separators, with no lexical diagnostic
+
+#### Scenario: Separate the digits of a float literal
+
+- **WHEN** the source bytes spell `1_000.5 1.000_5 1e1_0`
+- **THEN** the stream contains exactly three floating-point literal tokens, with no lexical diagnostic
+
+#### Scenario: Preserve the value of a separated literal
+
+- **WHEN** a compiled program compares `1_000` with `1000` and `1.000_5` with `1.0005`
+- **THEN** each pair is equal on every execution engine
+
+#### Scenario: Reject a misplaced separator
+
+- **WHEN** the source bytes spell any of `1_`, `1__0`, `0x_ff`, `1_.5`, `1._5`, `1_e5`, or `1e_5`
+- **THEN** the lexer emits one invalid token covering the literal and exactly one lexical diagnostic
+
+#### Scenario: Keep a leading underscore an identifier
+
+- **WHEN** the source bytes spell `_1` followed by `x_1`
+- **THEN** both spellings remain single identifier tokens

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -1,6 +1,7 @@
 import * as Option from 'effect/Option'
 import * as Diagnostic from './Diagnostic.js'
 import * as Intrinsic from './Intrinsic.js'
+import * as DigitSeparator from './internal/DigitSeparator.js'
 import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import type * as ModuleClosure from './ModuleClosure.js'
 import * as SourceFile from './SourceFile.js'
@@ -626,7 +627,7 @@ const constantLiteral = (
   if (initializer.kind === 'FloatingLiteralExpression') {
     const token = SyntaxTree.directToken(initializer, 'DecimalFloat')
     if (token === undefined) return Object.freeze({ _tag: 'Unavailable', syntax: initializer })
-    const literal = spelling(source, token)
+    const literal = DigitSeparator.strip(spelling(source, token))
     return Object.freeze({
       _tag: 'FloatingLiteral',
       spelling: `${SyntaxTree.directToken(initializer, 'Minus') === undefined ? '' : '-'}${literal}`,

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -25,6 +25,9 @@ export const unterminatedStaticLiteralCode = 'LEX0003' as const
 /** Stable code for an integer-literal base prefix that no digit follows. */
 export const missingBaseDigitsCode = 'LEX0004' as const
 
+/** Stable code for a number-literal digit separator outside a position between two digits. */
+export const invalidDigitSeparatorCode = 'LEX0005' as const
+
 /** Stable code for one required token that is absent at its insertion position. */
 export const missingTokenCode = 'PAR0001' as const
 
@@ -203,6 +206,7 @@ export type Code =
   | typeof unknownLiteralModifierCode
   | typeof unterminatedStaticLiteralCode
   | typeof missingBaseDigitsCode
+  | typeof invalidDigitSeparatorCode
   | typeof missingTokenCode
   | typeof unexpectedTokensCode
   | typeof reservedTemplateSyntaxCode
@@ -344,6 +348,7 @@ export type Reason =
       readonly delimiterWidth: 1 | 3
     }
   | { readonly _tag: 'MissingBaseDigits'; readonly radix: 2 | 8 | 16 }
+  | { readonly _tag: 'InvalidDigitSeparator' }
   | { readonly _tag: 'MissingToken'; readonly expected: Token.TokenKind }
   | {
       readonly _tag: 'UnexpectedTokens'
@@ -807,6 +812,18 @@ export const missingBaseDigits = (radix: 2 | 8 | 16, span: SourceSpan.SourceSpan
     severity: 'error',
     message: `Base-${radix} integer literal without digits`,
     reason: Object.freeze({ _tag: 'MissingBaseDigits', radix }),
+    span,
+  })
+
+/** Creates the lexical diagnostic for one number literal whose `_` is not between two digits. */
+export const invalidDigitSeparator = (span: SourceSpan.SourceSpan): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'lexical',
+    code: invalidDigitSeparatorCode,
+    severity: 'error',
+    message: 'Digit separator must sit between two digits',
+    reason: Object.freeze({ _tag: 'InvalidDigitSeparator' }),
     span,
   })
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -5,6 +5,7 @@ import * as Diagnostic from './Diagnostic.js'
 import * as FloatingPoint from './FloatingPoint.js'
 import * as Hir from './Hir.js'
 import * as Intrinsic from './Intrinsic.js'
+import * as DigitSeparator from './internal/DigitSeparator.js'
 import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import * as LiteralForm from './LiteralForm.js'
 import * as Match from './Match.js'
@@ -1220,7 +1221,7 @@ const analyzeFloating = (
     SourceFile.slice(source, token.span),
     () => new RangeError(`Semantic float span does not belong to source ${source.id}`),
   )
-  const unsigned = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('')
+  const unsigned = DigitSeparator.strip(bytes)
   const spelling = directToken(node, 'Minus') === undefined ? unsigned : `-${unsigned}`
   const selected = Scalar.isFloatSpelling(expected) ? expected : Scalar.defaultFloat.spelling
   const encoded = FloatingPoint.fromDecimal(spelling, selected === 'f32' ? 32 : 64)

--- a/packages/compiler/src/Lexer.ts
+++ b/packages/compiler/src/Lexer.ts
@@ -1,5 +1,6 @@
 import * as Option from 'effect/Option'
 import * as Diagnostic from './Diagnostic.js'
+import * as DigitSeparator from './internal/DigitSeparator.js'
 import * as IntegerLiteral from './internal/IntegerLiteral.js'
 import * as LiteralForm from './LiteralForm.js'
 import type * as SourceFile from './SourceFile.js'
@@ -237,6 +238,44 @@ const punctuationKind = (byte: number | undefined): Token.TokenKind => {
   }
 }
 
+/** One maximal run of digits and digit separators, with its separator placement already judged. */
+interface DigitRun {
+  readonly end: number
+  readonly digits: boolean
+  readonly separated: boolean
+}
+
+/**
+ * Consumes the longest run of base digits and `_` separators beginning at `from`.
+ *
+ * The run is taken greedily so that a misplaced separator stays inside the literal it belongs to
+ * rather than starting an identifier, which is what lets one diagnostic carry the literal's span.
+ * A separator is well placed only with a digit of the same run on each side.
+ */
+const scanDigitRun = (
+  bytes: ReadonlyArray<number>,
+  base: IntegerLiteral.Base,
+  from: number,
+): DigitRun => {
+  let at = from
+  let digits = false
+  let separated = true
+  let afterSeparator = false
+  while (at < bytes.length) {
+    if (IntegerLiteral.isDigit(base, bytes[at])) {
+      digits = true
+      afterSeparator = false
+      at += 1
+      continue
+    }
+    if (!DigitSeparator.isSeparator(bytes[at])) break
+    if (at === from || afterSeparator) separated = false
+    afterSeparator = true
+    at += 1
+  }
+  return Object.freeze({ end: at, digits, separated: separated && !afterSeparator })
+}
+
 const spanAt = (source: SourceFile.SourceFile, start: number, end: number): SourceSpan.SourceSpan =>
   Option.getOrThrowWith(
     SourceSpan.make(source, start, end),
@@ -324,28 +363,43 @@ export const lex = (source: SourceFile.SourceFile): LexicalResult => {
       const base = IntegerLiteral.recognize(bytes, index)
       if (base.radix !== 10) {
         index += base.width
-        const digits = index
-        while (index < bytes.length && IntegerLiteral.isDigit(base, bytes[index])) index += 1
-        const empty = index === digits
-        const span = pushToken(empty ? 'Invalid' : 'DecimalInteger', start, index)
-        if (empty) diagnostics.push(Diagnostic.missingBaseDigits(base.radix, span))
+        const run = scanDigitRun(bytes, base, index)
+        index = run.end
+        const span = pushToken(
+          run.digits && run.separated ? 'DecimalInteger' : 'Invalid',
+          start,
+          index,
+        )
+        if (!run.digits) diagnostics.push(Diagnostic.missingBaseDigits(base.radix, span))
+        else if (!run.separated) diagnostics.push(Diagnostic.invalidDigitSeparator(span))
         continue
       }
-      index += 1
-      while (index < bytes.length && isDecimalDigit(bytes[index])) index += 1
+      const whole = scanDigitRun(bytes, base, index)
+      index = whole.end
+      let separated = whole.separated
       let floating = false
-      if (bytes[index] === 0x2e && bytes[index + 1] !== 0x2e && isDecimalDigit(bytes[index + 1])) {
-        floating = true
-        index += 1
-        while (index < bytes.length && isDecimalDigit(bytes[index])) index += 1
+      if (bytes[index] === 0x2e && bytes[index + 1] !== 0x2e) {
+        const fraction = scanDigitRun(bytes, base, index + 1)
+        if (fraction.digits) {
+          floating = true
+          index = fraction.end
+          separated = separated && fraction.separated
+        }
       }
       if (bytes[index] === 0x65 || bytes[index] === 0x45) {
         floating = true
         index += 1
         if (bytes[index] === 0x2b || bytes[index] === 0x2d) index += 1
-        while (index < bytes.length && isDecimalDigit(bytes[index])) index += 1
+        const exponent = scanDigitRun(bytes, base, index)
+        index = exponent.end
+        separated = separated && exponent.separated
       }
-      pushToken(floating ? 'DecimalFloat' : 'DecimalInteger', start, index)
+      const span = pushToken(
+        !separated ? 'Invalid' : floating ? 'DecimalFloat' : 'DecimalInteger',
+        start,
+        index,
+      )
+      if (!separated) diagnostics.push(Diagnostic.invalidDigitSeparator(span))
       continue
     }
 

--- a/packages/compiler/src/internal/DigitSeparator.ts
+++ b/packages/compiler/src/internal/DigitSeparator.ts
@@ -1,0 +1,22 @@
+/** Source storage accepted for one complete number-literal slice. */
+export type Digits = ReadonlyArray<number> | Uint8Array | string
+
+/** The `_` byte that groups the digits of one number literal without changing its value. */
+export const byte = 0x5f
+
+/** Reports whether one byte is the digit separator. */
+export const isSeparator = (candidate: number | undefined): boolean => candidate === byte
+
+/**
+ * Reads one number-literal slice as text with every separator removed.
+ *
+ * A separator carries no value, so every conversion reading a literal as a number reads the
+ * separator-free text rather than the source spelling.
+ */
+export const strip = (digits: Digits): string => {
+  const text =
+    typeof digits === 'string'
+      ? digits
+      : Array.from(digits, (code) => String.fromCharCode(code)).join('')
+  return text.includes('_') ? text.split('_').join('') : text
+}

--- a/packages/compiler/src/internal/IntegerLiteral.ts
+++ b/packages/compiler/src/internal/IntegerLiteral.ts
@@ -1,3 +1,5 @@
+import * as DigitSeparator from './DigitSeparator.js'
+
 /** The numeric base an integer literal's digits are read in. */
 export type Radix = 2 | 8 | 10 | 16
 
@@ -79,13 +81,16 @@ export const isDigit = (self: Base, byte: number | undefined): boolean => {
  * Reads the exact unsigned magnitude of one complete integer-literal slice.
  *
  * The slice carries its own base, so a conversion never assumes decimal for a prefixed literal.
+ * Digit separators group the digits without carrying value, so they are skipped.
  */
 export const magnitude = (digits: Digits): bigint => {
   const base = recognize(digits, 0)
   const radix = BigInt(base.radix)
   let value = 0n
   for (let index = base.width; index < digits.length; index += 1) {
-    value = value * radix + BigInt(digitValue(codeAt(digits, index)))
+    const code = codeAt(digits, index)
+    if (DigitSeparator.isSeparator(code)) continue
+    value = value * radix + BigInt(digitValue(code))
   }
   return value
 }

--- a/packages/compiler/test/DigitSeparatorAcceptance.test.ts
+++ b/packages/compiler/test/DigitSeparatorAcceptance.test.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-digit-separator-acceptance-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const parity = `const maximumBytes: i32 = 1_048_576
+const flags: i32 = 0b1010_0000_1111_0001
+const ratio: f64 = 3.141_592
+
+fn identity(value: i32) -> i32 { return value }
+
+pub fn main() -> i32 {
+  let separated = 1_000
+  let plain = 1000
+  let hexadecimal = 0xff_ff
+  let octal = 0o1_7
+  if separated == plain {} else { return 1 }
+  if maximumBytes == 1048576 {} else { return 2 }
+  if flags == 41201 {} else { return 3 }
+  if hexadecimal == 65535 {} else { return 4 }
+  if octal == 15 {} else { return 5 }
+  if ratio == 3.141592 {} else { return 6 }
+  return identity(separated) - 958
+}`
+
+it.effect(
+  'reads separated literals as their separator-free values on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'digit-separator/parity',
+        ascii(parity),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(
+        evaluated._tag,
+        'Completed',
+        JSON.stringify(evaluated, (_, value) =>
+          typeof value === 'bigint' ? value.toString() : value,
+        ),
+      )
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
+
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make('digit-separator/parity', ascii(parity)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'parity'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 42, run.stderr)
+    }),
+  60_000,
+)
+
+it.effect('keeps a separated float equal to its separator-free spelling', () =>
+  Effect.gen(function* () {
+    const source = `pub fn main() -> i32 {
+  let separated = 1.000_5
+  let plain = 1.0005
+  if separated == plain {} else { return 1 }
+  return 42
+}`
+    const snapshot = yield* Analysis.ofSourceRealized('digit-separator/float', ascii(source))
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+  }),
+)
+
+it.effect('rejects a misplaced separator before parsing', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'digit-separator/trailing',
+      ascii('pub fn main() -> i32 { return 1_ }'),
+    )
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'LEX0005',
+    )
+    assert.strictEqual(
+      Analysis.diagnostics(snapshot).filter((diagnostic) => diagnostic.code === 'LEX0005').length,
+      1,
+    )
+  }),
+)

--- a/packages/compiler/test/IntegerLiteral.test.ts
+++ b/packages/compiler/test/IntegerLiteral.test.ts
@@ -1,4 +1,5 @@
 import { assert, it } from '@effect/vitest'
+import * as DigitSeparator from '../src/internal/DigitSeparator.js'
 import * as IntegerLiteral from '../src/internal/IntegerLiteral.js'
 
 const ascii = (value: string): Uint8Array =>
@@ -45,4 +46,20 @@ it('reads the exact magnitude of every base without losing precision', () => {
     IntegerLiteral.magnitude('340282366920938463463374607431768211455'),
     340282366920938463463374607431768211455n,
   )
+})
+
+it('reads a separated literal as the value of its separator-free spelling', () => {
+  assert.strictEqual(IntegerLiteral.magnitude('1_000'), IntegerLiteral.magnitude('1000'))
+  assert.strictEqual(IntegerLiteral.magnitude('1_048_576'), 1048576n)
+  assert.strictEqual(IntegerLiteral.magnitude(ascii('0b1010_0000')), 160n)
+  assert.strictEqual(IntegerLiteral.magnitude('0xff_ff'), 65535n)
+  assert.strictEqual(IntegerLiteral.magnitude('0o1_7'), 15n)
+})
+
+it('removes every separator from one literal spelling', () => {
+  assert.strictEqual(DigitSeparator.strip('1_048_576'), '1048576')
+  assert.strictEqual(DigitSeparator.strip(ascii('3.141_592')), '3.141592')
+  assert.strictEqual(DigitSeparator.strip('1000'), '1000')
+  assert.isTrue(DigitSeparator.isSeparator('_'.charCodeAt(0)))
+  assert.isFalse(DigitSeparator.isSeparator(undefined))
 })

--- a/packages/compiler/test/Lexer.test.ts
+++ b/packages/compiler/test/Lexer.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from '@effect/vitest'
 import * as Option from 'effect/Option'
+import * as IntegerLiteral from '../src/internal/IntegerLiteral.js'
 import * as Lexer from '../src/Lexer.js'
 import * as SourceFile from '../src/SourceFile.js'
 import type * as Token from '../src/Token.js'
@@ -273,6 +274,109 @@ it('diagnoses a base prefix without digits exactly once and resumes lexing', () 
       { code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 2 } },
       { code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 8 } },
     ],
+  )
+})
+
+it('accepts a digit separator between two digits of every base', () => {
+  const source = SourceFile.make(
+    'memory://digit-separators.silk',
+    ascii('1_000 1_048_576 0b1010_0000 0xff_ff 0o1_7'),
+  )
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'DecimalInteger', start: 0, end: 5, slice: '1_000' },
+      { kind: 'DecimalInteger', start: 6, end: 15, slice: '1_048_576' },
+      { kind: 'DecimalInteger', start: 16, end: 27, slice: '0b1010_0000' },
+      { kind: 'DecimalInteger', start: 28, end: 35, slice: '0xff_ff' },
+      { kind: 'DecimalInteger', start: 36, end: 41, slice: '0o1_7' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+  assert.strictEqual(IntegerLiteral.magnitude('1_000'), IntegerLiteral.magnitude('1000'))
+})
+
+it('accepts a digit separator between two digits of a float literal', () => {
+  const source = SourceFile.make('memory://separated-floats.silk', ascii('1_000.5 1.000_5 1e1_0'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'DecimalFloat', start: 0, end: 7, slice: '1_000.5' },
+      { kind: 'DecimalFloat', start: 8, end: 15, slice: '1.000_5' },
+      { kind: 'DecimalFloat', start: 16, end: 21, slice: '1e1_0' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('keeps a leading underscore an identifier rather than a separated literal', () => {
+  const source = SourceFile.make('memory://leading-separator.silk', ascii('_1 x_1'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace' && token.kind !== 'EndOfFile')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'Identifier', start: 0, end: 2, slice: '_1' },
+      { kind: 'Identifier', start: 3, end: 6, slice: 'x_1' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('diagnoses every misplaced digit separator exactly once over the literal span', () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ['1_', '1_'],
+    ['1__0', '1__0'],
+    ['0x_ff', '0x_ff'],
+    ['1_.5', '1_.5'],
+    ['1._5', '1._5'],
+    ['1_e5', '1_e5'],
+    ['1e_5', '1e_5'],
+    ['1e+_5', '1e+_5'],
+    ['1.5_', '1.5_'],
+  ]
+  for (const [spelling, expected] of cases) {
+    const source = SourceFile.make(`memory://misplaced-${spelling}.silk`, ascii(spelling))
+    const result = Lexer.lex(source)
+    assert.deepEqual(
+      result.diagnostics.map(({ code, reason }) => ({ code, reason })),
+      [{ code: 'LEX0005', reason: { _tag: 'InvalidDigitSeparator' } }],
+      spelling,
+    )
+    const invalid = result.tokens.filter((token) => token.kind === 'Invalid')
+    assert.deepEqual(
+      invalid.map((token) => tokenView(source, token).slice),
+      [expected],
+      spelling,
+    )
+    assert.deepEqual(
+      result.diagnostics.map((diagnostic) => [diagnostic.span.start, diagnostic.span.end]),
+      [[invalid[0]?.span.start, invalid[0]?.span.end]],
+      spelling,
+    )
+  }
+})
+
+it('keeps a base prefix followed only by separators a missing-digits diagnostic', () => {
+  const source = SourceFile.make('memory://separator-only-prefix.silk', ascii('0x_'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens.map((token) => tokenView(source, token)),
+    [
+      { kind: 'Invalid', start: 0, end: 3, slice: '0x_' },
+      { kind: 'EndOfFile', start: 3, end: 3, slice: '' },
+    ],
+  )
+  assert.deepEqual(
+    result.diagnostics.map(({ code, reason }) => ({ code, reason })),
+    [{ code: 'LEX0004', reason: { _tag: 'MissingBaseDigits', radix: 16 } }],
   )
 })
 


### PR DESCRIPTION
Closes #10

Stacked on #53 (`agent/9-hex-binary-octal-literals`) — both change the same lexer number scan. Review/merge #53 first.

The number branch now takes its digit run greedily over both base digits and `_` separators. A separator is well placed only with a digit of the same run immediately on each side, which is the single rule that rejects a leading, trailing, doubled, prefix-adjacent, point-adjacent, and exponent-adjacent separator alike. A literal whose separators are not all well placed becomes one `Invalid` token covering the literal with exactly one `LEX0005` diagnostic over that same span — the recovery shape #9 established for `LEX0004`, adding no token kind.

Note on the issue's implementation note: it suggests accepting `_` only when the next byte is a digit, which would leave `1_` lexing as `1` followed by the identifier `_` and produce **no** lexical diagnostic. That contradicts Requirements 3/8 and the `1_` acceptance criterion, so the requirements were followed: the separators are consumed into the literal and then judged.

### Acceptance criteria

- [x] The lexer produces one integer token for `1_000`.
- [x] A lexer test shows that the value of `1_000` equals the value of `1000`.
- [x] A lexer test shows that `1_` produces one lexical diagnostic.
- [x] A lexer test shows that `1__0` produces one lexical diagnostic.
- [x] A lexer test shows that `_1` stays one identifier token.
- [x] A lexer test shows that `1_000.5` and `1.000_5` are float tokens.
- [x] `openspec/specs/bootstrap-lexer/spec.md:14-15` gets an amendment for the separator.

Tests: baseline 3 failures, after 3 failures, +10 new tests

The 3 failures are the pre-existing `packages/compiler/test/Instances.test.ts` host-triple golden mismatches; re-run in isolation and unchanged. `test:native-acceptance` passes separately. Pre-existing failures in `packages/wasm` (1) and `packages/compiler-cli` (3) were confirmed identical on the base branch.

New coverage: five `Lexer.test.ts` cases (separated integers of every base, separated floats, `_1`/`x_1` identifiers, a table of nine misplaced-separator spellings asserting one diagnostic over the literal span, and `0x_` keeping `LEX0004`), two `IntegerLiteral.test.ts` cases, and `DigitSeparatorAcceptance.test.ts` with three-engine agreement (evaluator, Wasm, native) on separated integer, hex, binary, octal, and float values.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_