### PR TITLE
syntax: Accept else if without a brace-delimited arm

### DIFF
--- a/openspec/specs/bootstrap-syntax/spec.md
+++ b/openspec/specs/bootstrap-syntax/spec.md
@@ -371,12 +371,17 @@ and the expression recovers at the existing statement and argument boundaries.
 
 The parser SHALL accept `if <expression> { <statements> } else { <statements> }` wherever a
 statement may appear, with the `else` arm optional and no parentheses around the condition, per
-the accepted surface. Each arm SHALL be a brace-delimited statement sequence (bindings,
-conditionals, and return statements), and the function body SHALL still end in exactly one
-trailing return statement after any conditionals. `true` and `false` SHALL parse as boolean
-literal expressions wherever an expression is allowed. Missing conditions, braces, and damaged
-arms SHALL remain explicit recovery data bounded by the existing statement and declaration
-anchors, and every token SHALL be retained losslessly.
+the accepted surface. The taken arm SHALL be a brace-delimited statement sequence (bindings,
+conditionals, and return statements). The `else` arm SHALL be either such a brace-delimited
+statement sequence or a chained conditional statement introduced by `if` immediately after the
+`else` keyword; the chained form SHALL be recorded as a conditional statement nested directly
+inside the conditional it continues, so a chain of conditions SHALL introduce no additional node
+kind and SHALL nest one level per arm. `if` SHALL introduce a chained arm only immediately after
+`else`. The function body SHALL still end in exactly one trailing return statement after any
+conditionals. `true` and `false` SHALL parse as boolean literal expressions wherever an expression
+is allowed. Missing conditions, braces, and damaged arms SHALL remain explicit recovery data
+bounded by the existing statement and declaration anchors, and every token SHALL be retained
+losslessly, so the formatter SHALL print a chained arm as `} else if <condition> {` on one line.
 
 #### Scenario: Parse a conditional with both arms
 
@@ -387,6 +392,21 @@ anchors, and every token SHALL be retained losslessly.
 
 - **WHEN** a body spells `if flag { return 1 } return 0`
 - **THEN** the conditional retains one arm and no else branch, and the trailing return remains a sibling statement
+
+#### Scenario: Parse a chain of three conditions
+
+- **WHEN** a body spells `if first { return 1 } else if second { return 2 } else if third { return 3 } else { return 4 } return 0`
+- **THEN** the block contains one conditional statement whose else keyword is followed by a nested conditional statement, nested once more for the third condition, with the two chained conditionals retaining one brace-delimited arm each and the innermost retaining both arms, and the trailing return remains a sibling statement
+
+#### Scenario: Print a chained arm on one line
+
+- **WHEN** the formatter prints a conditional whose else arm is a chained conditional
+- **THEN** the arm is printed as `} else if <condition> {` on one line, and printing the result again produces identical bytes
+
+#### Scenario: Recover an else arm that is neither a block nor a chained if
+
+- **WHEN** a body spells `if first { return 1 } else while second { }`
+- **THEN** the else keyword retains an explicit missing arm with one parser diagnostic, and every token stays in the tree
 
 #### Scenario: Parse boolean literals
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -6118,6 +6118,57 @@ const analyzeStatements = (
     return region
   }
 
+  const analyzeConditional = (
+    element: SyntaxTree.Node,
+    armScope: Scope,
+    armLoopStack: ReadonlyArray<Hir.LoopId>,
+  ): StatementFact => {
+    const region = nextRegion()
+    const conditionNode = statementExpressionNode(element)
+    const condition = analyzeExpression(
+      context.source,
+      conditionNode,
+      context.declarations,
+      context.declaration,
+      armScope,
+      context.resolution,
+    )
+    if (condition === undefined) {
+      throw new RangeError(`Semantic analysis cannot analyze ${conditionNode.kind}`)
+    }
+    context.diagnostics.push(...condition.diagnostics)
+    if (condition.fact.type._tag === 'Available' && condition.fact.type.type !== 'bool') {
+      context.diagnostics.push(
+        Diagnostic.conditionNotBool(
+          Type.encode(condition.fact.type.type),
+          condition.fact.syntax.span,
+        ),
+      )
+    }
+
+    const arms = SyntaxTree.directNodes(element, 'Block')
+    const taken =
+      arms.at(0) === undefined
+        ? []
+        : analyzeStatements(context, arms[0] as SyntaxTree.Node, armScope, armLoopStack)
+    const chained = SyntaxTree.directNode(element, 'ConditionalStatement')
+    const otherwiseArm = arms.at(1)
+    const otherwise =
+      chained !== undefined
+        ? [analyzeConditional(chained, armScope, armLoopStack)]
+        : otherwiseArm === undefined
+          ? []
+          : analyzeStatements(context, otherwiseArm, armScope, armLoopStack)
+    return Object.freeze({
+      _tag: 'IfStatement',
+      condition: condition.fact,
+      taken: Object.freeze([...taken]),
+      otherwise: Object.freeze([...otherwise]),
+      region,
+      syntax: element,
+    })
+  }
+
   for (const element of blockNode.children) {
     if (!SyntaxTree.isNode(element)) continue
 
@@ -6237,47 +6288,7 @@ const analyzeStatements = (
     }
 
     if (element.kind === 'ConditionalStatement') {
-      const region = nextRegion()
-      const conditionNode = statementExpressionNode(element)
-      const condition = analyzeExpression(
-        context.source,
-        conditionNode,
-        context.declarations,
-        context.declaration,
-        scope,
-        context.resolution,
-      )
-      if (condition === undefined) {
-        throw new RangeError(`Semantic analysis cannot analyze ${conditionNode.kind}`)
-      }
-      context.diagnostics.push(...condition.diagnostics)
-      if (condition.fact.type._tag === 'Available' && condition.fact.type.type !== 'bool') {
-        context.diagnostics.push(
-          Diagnostic.conditionNotBool(
-            Type.encode(condition.fact.type.type),
-            condition.fact.syntax.span,
-          ),
-        )
-      }
-
-      const arms = SyntaxTree.directNodes(element, 'Block')
-      const taken =
-        arms.at(0) === undefined
-          ? []
-          : analyzeStatements(context, arms[0] as SyntaxTree.Node, scope, loopStack)
-      const otherwiseArm = arms.at(1)
-      const otherwise =
-        otherwiseArm === undefined ? [] : analyzeStatements(context, otherwiseArm, scope, loopStack)
-      facts.push(
-        Object.freeze({
-          _tag: 'IfStatement',
-          condition: condition.fact,
-          taken: Object.freeze([...taken]),
-          otherwise: Object.freeze([...otherwise]),
-          region,
-          syntax: element,
-        }),
-      )
+      facts.push(analyzeConditional(element, scope, loopStack))
       continue
     }
 

--- a/packages/compiler/src/Parser.ts
+++ b/packages/compiler/src/Parser.ts
@@ -1408,8 +1408,11 @@ function parseConditionalStatement(initial: State): NodeResult {
   ])
 
   if (nextSignificantKind(state) === 'ElseKeyword') {
-    const elseKeyword = expect(state, 'ElseKeyword', ['LeftBrace'])
-    const otherwise = parseBlock(elseKeyword.state, false)
+    const elseKeyword = expect(state, 'ElseKeyword', ['LeftBrace', 'IfKeyword'])
+    const otherwise =
+      nextSignificantKind(elseKeyword.state) === 'IfKeyword'
+        ? parseConditionalStatement(elseKeyword.state)
+        : parseBlock(elseKeyword.state, false)
     state = otherwise.state
     children = Object.freeze([...children, ...elseKeyword.elements, otherwise.node])
   }

--- a/packages/compiler/test/ElseIfAcceptance.test.ts
+++ b/packages/compiler/test/ElseIfAcceptance.test.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-else-if-acceptance-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const chained = `fn classify(value: i32) -> i32 {
+  if value < 0 {
+    return 0
+  } else if value < 10 {
+    return 1
+  } else if value < 100 {
+    return 2
+  } else {
+    return 3
+  }
+  return 4
+}
+
+pub fn main() -> i32 {
+  if classify(0 - 5) == 0 {} else { return 1 }
+  if classify(5) == 1 {} else { return 2 }
+  if classify(50) == 2 {} else { return 3 }
+  if classify(500) == 3 {} else { return 4 }
+  return 42
+}`
+
+it.effect(
+  'takes the first matching arm of a chain on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'else-if/chain',
+        ascii(chained),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(
+        evaluated._tag,
+        'Completed',
+        JSON.stringify(evaluated, (_, value) =>
+          typeof value === 'bigint' ? value.toString() : value,
+        ),
+      )
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
+
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make('else-if/chain', ascii(chained)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'chain'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 42, run.stderr)
+    }),
+  60_000,
+)
+
+it.effect('keeps a chained arm equal to the same chain written as nested blocks', () =>
+  Effect.gen(function* () {
+    const nested = `fn classify(value: i32) -> i32 {
+  if value < 0 {
+    return 0
+  } else {
+    if value < 10 {
+      return 1
+    } else {
+      if value < 100 {
+        return 2
+      } else {
+        return 3
+      }
+    }
+  }
+  return 4
+}
+
+pub fn main() -> i32 {
+  if classify(0 - 5) == 0 {} else { return 1 }
+  if classify(5) == 1 {} else { return 2 }
+  if classify(50) == 2 {} else { return 3 }
+  if classify(500) == 3 {} else { return 4 }
+  return 42
+}`
+
+    for (const [name, source] of [
+      ['else-if/chained', chained],
+      ['else-if/nested', nested],
+    ] as const) {
+      const snapshot = yield* Analysis.ofSourceRealized(name, ascii(source))
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(evaluated._tag, 'Completed')
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42)
+    }
+  }),
+)
+
+it.effect('reports a chained arm whose condition is not a boolean', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'else-if/condition-type',
+      ascii(`pub fn main() -> i32 {
+  if false {
+    return 1
+  } else if 2 {
+    return 2
+  }
+  return 0
+}`),
+    )
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'SEM0011',
+    )
+  }),
+)

--- a/packages/compiler/test/Formatter.test.ts
+++ b/packages/compiler/test/Formatter.test.ts
@@ -276,6 +276,47 @@ fn main() -> i32 {
   }),
 )
 
+it.effect('formats a chained else if arm on one line and idempotently', () =>
+  Effect.gen(function* () {
+    const first = yield* Formatter.format(
+      parse(
+        'memory://else-if-format.silk',
+        'pub fn classify(value:i32)->i32 { if value<0 { return 0 } else   if value<10 { return 1 } else if value<100 { return 2 } else { return 3 } return 4 }',
+      ),
+    )
+    const text = formattedText(first)
+    assert.strictEqual(
+      text,
+      `pub fn classify(value: i32) -> i32 {
+  if value < 0 {
+    return 0
+  } else if value < 10 {
+    return 1
+  } else if value < 100 {
+    return 2
+  } else {
+    return 3
+  }
+  return 4
+}
+`,
+    )
+    // The chained arm never gains a line break, so each condition stays at the
+    // indentation of the conditional it continues.
+    for (const line of text.split('\n')) {
+      if (line.includes('else if')) assert.match(line, /^ {2}} else if .+ \{$/)
+    }
+
+    const reparsed = parse('memory://else-if-format.silk', text)
+    assert.deepEqual(reparsed.lexicalDiagnostics, [])
+    assert.deepEqual(reparsed.parserDiagnostics, [])
+    const second = yield* Formatter.format(reparsed)
+    assert.strictEqual(formattedText(second), text)
+    assert.deepEqual(second.bytes, first.bytes)
+    assert.strictEqual(second.changed, false)
+  }),
+)
+
 it.effect('formats unsafe blocks and conformance declarations canonically and idempotently', () =>
   Effect.gen(function* () {
     const source =

--- a/packages/compiler/test/Parser.test.ts
+++ b/packages/compiler/test/Parser.test.ts
@@ -1746,6 +1746,59 @@ it('parses conditionals with both arms and boolean literals', () => {
   assert.deepEqual(booleans.parserDiagnostics, [])
 })
 
+it('parses a chain of three conditions as nested conditional statements', () => {
+  const result = parseText(
+    'fixture://else-if-chain.silk',
+    'pub fn main() -> i32 { if first { return 1 } else if second { return 2 } else if third { return 3 } else { return 4 } return 0 }',
+  )
+  const fn = directFunctionDeclarations(result.root).at(0)
+  const block = fn === undefined ? undefined : SyntaxTree.directNode(fn, 'Block')
+  const outer =
+    block === undefined ? undefined : SyntaxTree.directNode(block, 'ConditionalStatement')
+
+  assert.notStrictEqual(outer, undefined)
+  if (outer === undefined) return
+  const statements = (block?.children ?? []).filter(SyntaxTree.isNode).map((node) => node.kind)
+  assert.deepEqual(statements, ['ConditionalStatement', 'ReturnStatement'])
+
+  // Each chained arm is the same node kind nested one level deeper, so no new
+  // node kind carries the chain and the tree stays lossless.
+  const middle = SyntaxTree.directNode(outer, 'ConditionalStatement')
+  assert.notStrictEqual(middle, undefined)
+  if (middle === undefined) return
+  const inner = SyntaxTree.directNode(middle, 'ConditionalStatement')
+  assert.notStrictEqual(inner, undefined)
+  if (inner === undefined) return
+  assert.strictEqual(SyntaxTree.directNode(inner, 'ConditionalStatement'), undefined)
+
+  for (const conditional of [outer, middle, inner]) {
+    assert.notStrictEqual(SyntaxTree.directToken(conditional, 'IfKeyword'), undefined)
+    assert.notStrictEqual(SyntaxTree.directToken(conditional, 'ElseKeyword'), undefined)
+    assert.notStrictEqual(SyntaxTree.directNode(conditional, 'IdentifierExpression'), undefined)
+  }
+
+  // A chained arm keeps only its taken block; the final arm keeps both blocks.
+  assert.strictEqual(SyntaxTree.directNodes(outer, 'Block').length, 1)
+  assert.strictEqual(SyntaxTree.directNodes(middle, 'Block').length, 1)
+  assert.strictEqual(SyntaxTree.directNodes(inner, 'Block').length, 2)
+
+  assert.deepEqual(result.parserDiagnostics, [])
+  assertOriginalTokenTraversal(result)
+})
+
+it('keeps an else arm that is not a chained if anchored to its brace', () => {
+  const result = parseText(
+    'fixture://else-not-if.silk',
+    'pub fn main() -> i32 { if first { return 1 } else while second { } return 0 }',
+  )
+
+  assert.include(
+    result.parserDiagnostics.map((diagnostic) => diagnostic.code),
+    'PAR0001',
+  )
+  assertOriginalTokenTraversal(result)
+})
+
 it('recovers a missing condition before the arm brace', () => {
   const result = parseText(
     'fixture://missing-condition.silk',


### PR DESCRIPTION
Closes #5

Stacked on #58 (`agent/10-digit-separator`), which is itself stacked on #9. Review/merge that one first; this PR targets `agent/10-digit-separator`, not `main`.

Lets an `if` follow the `else` keyword directly, so a chain of conditions reads at one indentation level. A chained arm is recorded as a `ConditionalStatement` nested directly inside the conditional it continues — the same tree shape the equivalent nested-block spelling already produced — so no node kind is added and the formatter needed no change at all to print `} else if condition {` on one line.

### Acceptance criteria

- [x] The parser accepts `else if` and makes a nested conditional statement. `parseConditionalStatement` recurses when an `IfKeyword` follows `else`; `IfKeyword` joins `LeftBrace` as a recovery anchor, so an `else` arm that is neither stays the existing bounded recovery.
- [x] A parser test shows a chain of three conditions. `parses a chain of three conditions as nested conditional statements` asserts three nesting levels, one `Block` per chained arm and two on the innermost, no fourth level, and lossless token traversal.
- [x] The formatter prints `} else if condition {` on one line. Satisfied by the existing `ConditionalStatement` printer, since the chained arm is just that node kind printed with a space prefix — no formatter change was required.
- [x] A formatter test shows that the output is stable after two runs. `formats a chained else if arm on one line and idempotently` asserts the exact bytes, that every `else if` line matches `} else if … {`, then reparses and reformats asserting identical bytes and `changed === false`.
- [x] `openspec/specs/bootstrap-syntax/spec.md` gets an amendment for the new arm form. The "Conditional statements parse losslessly" requirement now specifies the chained arm form, that it introduces no additional node kind and nests one level per arm, that `if` introduces a chained arm only immediately after `else`, and the one-line printing rule — plus three scenarios (three-condition chain, one-line printing, and recovery of an `else` arm that is neither a block nor a chained `if`).

### Note on scope

The Requirements cover parser, tree, and formatter only, but `Elaboration` selected conditional arms with `directNodes(element, 'Block')`, which finds no second block for a chained arm. Left alone, `else if` would have parsed cleanly and then elaborated with an empty else, silently dropping every arm after the first — accepted syntax that miscompiles. The conditional branch of `analyzeStatements` is therefore extracted into a recursive helper so a chained arm elaborates to a nested `IfStatement` fact in the `otherwise` list, identical to what the nested-block spelling already produced. Region allocation order is unchanged, so lowering and determinism goldens are untouched.

Also worth recording: the issue's Example has no trailing `return` after the chain, which trips the pre-existing "function body ends in exactly one trailing return" rule (`PAR0004`) — that rule is unrelated to this issue and unchanged here, so the tests spell the trailing return.

Tests: baseline 3 failures, after 3 failures, +6 new tests

New `packages/compiler/test/ElseIfAcceptance.test.ts` gives the three-engine agreement (interpreter, WebAssembly, native via clang): a chain selecting each of its four arms, that chain proved equal to the same logic written as nested blocks, and a `SEM0011` non-boolean condition on a chained arm. The 3 remaining failures are the documented `Instances.test.ts` host-triple goldens (recorded for `aarch64-apple-darwin`, run here on `x86_64-unknown-linux-gnu`). `compiler-cli` still shows only its 3 pre-existing `FormatCommand`/`FormatWorkflow` failures. `pnpm typecheck` and `biome check .` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_