### PR TITLE
fix(ci): repair build ordering, playwright resolution, and docs timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm --filter @silk-effect/platform-webcontainer exec playwright install --with-deps chromium
       - run: pnpm --filter @silk-effect/platform-webcontainer test:browser

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // The lab presets drive the real compiler pipeline, so a case can take tens of seconds on a
+    // cold CI runner. Matches packages/compiler.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "changeset": "changeset",
-    "check": "biome check . && turbo run typecheck test && pnpm test:scripts",
+    "check": "biome check . && turbo run build && turbo run typecheck test && pnpm test:scripts",
     "check:write": "biome check --write .",
     "dev": "turbo run dev",
     "format": "biome format --write .",

--- a/turbo.json
+++ b/turbo.json
@@ -30,10 +30,6 @@
     "test": {
       "dependsOn": ["build"],
       "outputs": []
-    },
-    "@silk-effect/docs#test": {
-      "dependsOn": ["^build"],
-      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Problem

CI is red on every branch — `main`, the release workflow, and all four agent branches. Three independent causes.

### 1. Build ordering race (`validate`)

`pnpm check` ran `turbo run typecheck test` as a single graph, and `turbo.json` overrode `@silk-effect/docs#test` to depend on `^build` instead of `build`.

Two things then went wrong together:

- `apps/docs` tests could start before `@silk-effect/compiler` was built, failing with `Cannot find package '@silk-effect/compiler/Analysis'`.
- `compiler#build` begins with `pnpm clean`, which `rmSync`s `dist/`. The determinism fixtures import that directory directly from spawned subprocesses (`test/fixtures/*.mjs` → `../../dist/Analysis.js`), so a rebuild triggered by another task deletes files mid-read and the fixtures die with `ERR_MODULE_NOT_FOUND`.

Whichever task lost the race reported the failure, which is why it moved between `@silk-effect/docs#test` and `@silk-effect/compiler#test` between runs. Both packages pass on their own.

Fixed by building to completion before typecheck/test, and removing the `docs#test` override so it depends on `docs#build` like every other test task.

### 2. Playwright not resolvable (`webcontainer-browser`)

The job ran `pnpm exec playwright install` from the repo root, but `playwright` is a devDependency of `@silk-effect/platform-webcontainer`. Under pnpm's isolated store it is not on the root's path:

```
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "playwright" not found
```

Now runs through the same `--filter` as the `test:browser` step directly below it.

### 3. Docs test timeouts (`Release`)

`apps/docs` had no vitest config, so it inherited the 5s default while its lab presets drive the real compiler pipeline. Two cases timed out on cold runners:

- `exposes portable logging through the coordinated facade panes`
- `projects every owned-sequence preset through the coordinated analysis panes`

Several neighbouring cases already carry explicit `60_000` timeouts; these two were simply missed, and about twenty others still rely on the default. Rather than patch two call sites and leave the rest one slow runner away from failing, this adds `apps/docs/vitest.config.ts` with the same 30s timeout `packages/compiler` already uses.

## Verification

Reproduced in a clean clone with `pnpm install --frozen-lockfile` and all caches cleared, which is what finally surfaced the race — it does not reproduce in a warm tree.

Cold, cache-cleared runs of both CI jobs' exact commands:

- `pnpm check` → exit 0 (10/10 build tasks, 30/30 typecheck+test tasks)
- `pnpm release:candidate` → exit 0
- `pnpm --filter @silk-effect/platform-webcontainer exec playwright install --with-deps chromium` → succeeds
- `pnpm --filter @silk-effect/platform-webcontainer test:browser` → 1/1 passed

`packages/compiler` stays at 1005/1005, and `apps/docs` at 26/26 for `presets.test.ts` (slowest case 1.8s locally, against the new 30s ceiling).

No test assertions or source behavior changed — this is build orchestration and configuration only.