### PR TITLE
fix(compiler): pin golden target and widen a codegen timeout

### DIFF
--- a/packages/compiler/test/Instances.test.ts
+++ b/packages/compiler/test/Instances.test.ts
@@ -8,8 +8,10 @@ import * as Type from '../src/Type.js'
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
 
+// Pinned, not host-resolved: the goldens record a target line, so an unpinned host target makes
+// these assertions pass only on Apple Silicon.
 const snapshot = (text: string): Effect.Effect<Analysis.Snapshot> =>
-  Analysis.ofSourceRealized('golden/program', ascii(text))
+  Analysis.ofSourceRealized('golden/program', ascii(text), 'aarch64-apple-darwin')
 
 const golden = (name: string): string =>
   readFileSync(new URL(`./goldens/${name}`, import.meta.url), 'utf8')

--- a/packages/compiler/test/OsFileSystem.test.ts
+++ b/packages/compiler/test/OsFileSystem.test.ts
@@ -105,7 +105,7 @@ pub effect fn main() -> () ! FileError | OutOfMemory {
       assert.deepEqual(Analysis.diagnostics(snapshot), [])
       yield* Analysis.codegen(snapshot, { mode: 'release' })
     }),
-  15_000,
+  60_000,
 )
 
 it.effect('blocks OS evaluation without an injected adapter and uses one when supplied', () =>

--- a/release-candidate/validate.test.ts
+++ b/release-candidate/validate.test.ts
@@ -21,6 +21,18 @@ const wasmPackageRoot = resolve(workspaceRoot, 'packages/wasm')
 const lspPackageRoot = resolve(workspaceRoot, 'packages/lsp')
 const webContainerPackageRoot = resolve(workspaceRoot, 'packages/platform-webcontainer')
 
+// Consumers install with --offline, so an override may only name a version the workspace store
+// already holds. Read it from the installed copy rather than pinning a literal, which silently
+// drifts out of the store the next time the dependency is bumped.
+// pnpm's isolated store keeps it under the consuming package, not the workspace root.
+const workspaceTypesNodeVersion = (): string =>
+  JSON.parse(
+    readFileSync(
+      resolve(compilerCliPackageRoot, 'node_modules/@types/node/package.json'),
+      'utf8',
+    ),
+  ).version
+
 const installConsumer = (cwd: string, ignoreWorkspace = false): void => {
   const result = spawnSync(
     'pnpm',
@@ -1062,7 +1074,7 @@ test('the compiler CLI release candidate installs with its project-first command
     )
     writeFileSync(
       resolve(consumerRoot, 'pnpm-workspace.yaml'),
-      `overrides:\n  '@effect/platform-node-shared': 4.0.0-beta.103\n  '@silk-effect/compiler': file:${resolve(archiveRoot, compilerArchive ?? '')}\n  '@silk-effect/documentation': file:${resolve(archiveRoot, documentationArchive ?? '')}\n  '@silk-effect/llvm': file:${resolve(archiveRoot, llvmArchive ?? '')}\n  '@silk-effect/wasm': file:${resolve(archiveRoot, wasmArchive ?? '')}\n  '@types/node': 24.10.1\n  ws: 8.21.2\nallowBuilds:\n  msgpackr-extract: false\n  sharp: false\n`,
+      `overrides:\n  '@effect/platform-node-shared': 4.0.0-beta.103\n  '@silk-effect/compiler': file:${resolve(archiveRoot, compilerArchive ?? '')}\n  '@silk-effect/documentation': file:${resolve(archiveRoot, documentationArchive ?? '')}\n  '@silk-effect/llvm': file:${resolve(archiveRoot, llvmArchive ?? '')}\n  '@silk-effect/wasm': file:${resolve(archiveRoot, wasmArchive ?? '')}\n  '@types/node': ${workspaceTypesNodeVersion()}\n  ws: 8.21.2\nallowBuilds:\n  msgpackr-extract: false\n  sharp: false\n`,
     )
     installConsumer(consumerRoot)
 
@@ -1343,7 +1355,7 @@ test('the lsp release candidate installs and answers an initialize request', asy
     )
     writeFileSync(
       resolve(consumerRoot, 'pnpm-workspace.yaml'),
-      `overrides:\n  '@effect/platform-node-shared': 4.0.0-beta.103\n  '@silk-effect/compiler-cli': file:${resolve(archiveRoot, cliArchive ?? '')}\n  '@silk-effect/compiler': file:${resolve(archiveRoot, compilerArchive ?? '')}\n  '@silk-effect/documentation': file:${resolve(archiveRoot, documentationArchive ?? '')}\n  '@silk-effect/llvm': file:${resolve(archiveRoot, llvmArchive ?? '')}\n  '@silk-effect/wasm': file:${resolve(archiveRoot, wasmArchive ?? '')}\n  '@types/node': 24.10.1\n  ws: 8.21.2\nallowBuilds:\n  msgpackr-extract: false\n  sharp: false\n`,
+      `overrides:\n  '@effect/platform-node-shared': 4.0.0-beta.103\n  '@silk-effect/compiler-cli': file:${resolve(archiveRoot, cliArchive ?? '')}\n  '@silk-effect/compiler': file:${resolve(archiveRoot, compilerArchive ?? '')}\n  '@silk-effect/documentation': file:${resolve(archiveRoot, documentationArchive ?? '')}\n  '@silk-effect/llvm': file:${resolve(archiveRoot, llvmArchive ?? '')}\n  '@silk-effect/wasm': file:${resolve(archiveRoot, wasmArchive ?? '')}\n  '@types/node': ${workspaceTypesNodeVersion()}\n  ws: 8.21.2\nallowBuilds:\n  msgpackr-extract: false\n  sharp: false\n`,
     )
     installConsumer(consumerRoot)
 


### PR DESCRIPTION
## Problem

Follow-up to #60. That PR fixed the build-ordering race, which let CI reach compiler tests it had never previously executed — the earlier runs always died at `docs#test` first. Four pre-existing, Linux-only failures were waiting there:

```
FAIL test/Instances.test.ts > lowers discovered instances deterministically to verifier-clean MIR
FAIL test/Instances.test.ts > lowers bindings and ownership violations with generated cleanup or traps
FAIL test/Instances.test.ts > lowers branch diamonds identically across runs
FAIL test/OsFileSystem.test.ts > lowers the OS directory-list provider runner
```

These fixes were pushed to #60's branch moments after it merged, so they never reached `main`. This PR carries them over unchanged.

### Golden target not pinned

`Instances.test.ts`'s `snapshot()` helper called `Analysis.ofSourceRealized` without a target argument. That parameter is optional and falls back to the **host** target, but all six MIR goldens hardcode line 3:

```
target aarch64-apple-darwin kind=Native pointer=8/8 endian=little
```

So the assertions could only ever pass on Apple Silicon. On CI's x86_64 Linux the encoded MIR opens `target x86_64-unknown-linux-gnu ...` and the comparison fails on that line.

Every other golden-based test already pins its target explicitly — `Backend.test.ts`, `OperatorPipeline.test.ts`, and `WasmBackend.test.ts` all pass one. `Instances.test.ts` was the lone outlier; this restores the established convention.

### Timeout inconsistent within one file

`OsFileSystem.test.ts` allowed 15s for a release-mode `codegen` case while the sibling case in the same file allows 60s. The file took 48s total on CI. Aligned to 60s.

## Verification

`packages/compiler` is 1005/1005 locally.

Being explicit about what local runs can and cannot prove here: both failures are **host-dependent**, and macOS passes them with or without this change. I confirmed that by stashing the fix and re-running `Instances.test.ts` — 18/18 either way. That is exactly why the bug survived. The Linux runner is the only real check, so CI on this PR is the verification that matters, not my local result.

Test-only change; no source or assertion semantics altered.