### PR TITLE
lsp: Add find-all-references and rename

### DIFF
--- a/openspec/specs/language-server-navigation/spec.md
+++ b/openspec/specs/language-server-navigation/spec.md
@@ -155,3 +155,72 @@ because its body calls an intrinsic.
 
 - **WHEN** definition is requested on `Intrinsic.i32Add`
 - **THEN** no source location is invented and the intrinsic semantic identity remains available
+
+### Requirement: References enumerate one semantic identity across the project
+
+The language server SHALL advertise references support and SHALL answer a references request with
+every occurrence in the accepted project revision whose semantic identity equals the identity
+selected at the request position, rather than every token that shares its spelling. Occurrences
+SHALL be returned in canonical module order and, within a module, in source order. The
+declaration-site occurrence SHALL be included when the client sets `includeDeclaration` and
+excluded otherwise. A position with no available semantic occurrence SHALL produce no references.
+
+#### Scenario: Client initializes the server
+
+- **WHEN** a compatible client initializes a Silk language-server session
+- **THEN** the returned capabilities advertise references support
+
+#### Scenario: Uses in another module
+
+- **WHEN** references are requested on a declaration used from a second module
+- **THEN** the response contains that module's uses at their exact ranges together with the uses in the declaring module
+
+#### Scenario: Selected member and its local alias
+
+- **WHEN** references are requested through an aliased selected-member import
+- **THEN** the response contains the declaration, the imported source name, the local alias, and every use of that alias, because all of them carry one semantic identity
+
+#### Scenario: Declaration excluded on request
+
+- **WHEN** a references request clears `includeDeclaration`
+- **THEN** the declaration-site occurrence is the only occurrence removed from the response
+
+### Requirement: Rename rewrites one semantic identity in one workspace edit
+
+The language server SHALL advertise rename support with `prepareProvider` enabled. A prepare-rename
+request SHALL return the range of the selected name token, and SHALL fail for a token with no
+source-backed declaration, including keywords, trivia, and intrinsics that have no Silk
+declaration. A rename SHALL return one `WorkspaceEdit` covering every module of the accepted
+project revision, and SHALL edit only the occurrences whose analyzed spelling equals the selected
+name so that an aliased import keeps the local name its own module chose. A rename SHALL be refused
+rather than partially applied when an occurrence cannot be placed in a document.
+
+Because Silk has one flat non-shadowing module namespace, a rename of a name that occupies that
+namespace SHALL be refused when the new spelling is already bound in any module whose flat namespace
+the rename would extend. The refusal SHALL carry the existing `SEM0016` binding-collision code and
+message rather than a rename-specific diagnostic.
+
+#### Scenario: Client initializes the server
+
+- **WHEN** a compatible client initializes a Silk language-server session
+- **THEN** the returned capabilities advertise rename support with prepare support enabled
+
+#### Scenario: Prepare a rename on a keyword
+
+- **WHEN** a prepare-rename request selects a keyword token
+- **THEN** the request fails instead of returning a range
+
+#### Scenario: Rename a declaration used in another module
+
+- **WHEN** a top-level declaration used from a second module is renamed
+- **THEN** one workspace edit changes the declaration and every use in both modules
+
+#### Scenario: Rename an imported source name
+
+- **WHEN** a declaration reached through an aliased selected-member import is renamed
+- **THEN** the imported source name changes and the local alias and its uses keep their own spelling
+
+#### Scenario: Rename onto an existing top-level name
+
+- **WHEN** a rename would give a declaration a spelling already bound in a module's flat namespace
+- **THEN** the rename is refused with the `SEM0016` collision reason and no edit is returned

--- a/openspec/specs/language-server-navigation/spec.md
+++ b/openspec/specs/language-server-navigation/spec.md
@@ -195,6 +195,21 @@ project revision, and SHALL edit only the occurrences whose analyzed spelling eq
 name so that an aliased import keeps the local name its own module chose. A rename SHALL be refused
 rather than partially applied when an occurrence cannot be placed in a document.
 
+The accepted project revision is the rename's outer bound: the open documents that serve as roots
+plus every module they transitively import, closed project files included, resolved from disk. A
+closed module that imports the renamed declaration but is reachable from no open root is therefore
+outside that revision and SHALL NOT be edited. Rooting analysis at open documents is what the
+`language-server-synchronization` capability specifies, so widening the root set is a change to
+synchronization rather than to navigation. The resulting failure is visible — the unedited module
+stops compiling — rather than silent.
+
+Within that revision, an `as` clause binds a name in one module only, so a rename selected through
+such a binding SHALL be confined to the module that wrote the clause. Two modules that alias one
+declaration to the same spelling agree on both identity and spelling, and neither owns the other's
+choice of name. The declaration site and the source half of an import clause name the declaration
+itself and SHALL stay project-wide. This confinement applies to rename alone; references are
+read-only and SHALL continue to report every occurrence of the identity.
+
 Because Silk has one flat non-shadowing module namespace, a rename of a name that occupies that
 namespace SHALL be refused when the new spelling is already bound in any module whose flat namespace
 the rename would extend. The refusal SHALL carry the existing `SEM0016` binding-collision code and
@@ -219,6 +234,16 @@ message rather than a rename-specific diagnostic.
 
 - **WHEN** a declaration reached through an aliased selected-member import is renamed
 - **THEN** the imported source name changes and the local alias and its uses keep their own spelling
+
+#### Scenario: Two modules alias one declaration to the same spelling
+
+- **WHEN** an alias is renamed in a module while a second module aliases the same declaration to the same spelling
+- **THEN** only the selecting module's clause and uses change, and the second module keeps the name it chose
+
+#### Scenario: Rename a project alias of a standard-library member
+
+- **WHEN** a project module's alias of a standard-library member is renamed and the installation aliases that member to the same spelling
+- **THEN** the edit covers the project module alone and reaches no file inside the installed toolchain
 
 #### Scenario: Rename onto an existing top-level name
 

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -306,11 +306,51 @@ interface RenameSubject {
 }
 
 /**
- * Resolves the occurrences one rename request would rewrite. An imported member and its local
- * alias share a single identity, so the selected spelling is what separates them: renaming the
- * alias `eq` of `equals as eq` edits the `eq` occurrences alone, all of them owned by the module
- * that chose the alias. Narrowing here, before any refusal is decided, is what lets prepare and
- * rename answer from the same facts.
+ * Tests whether one spelling names, in one module, a declaration the module reaches through its own
+ * `as` clause. Such an alias is the importing module's own name for a declaration it does not own:
+ * the clause introduces it, Silk's one flat module namespace makes the spelling resolve to it
+ * throughout that module, and no other module can see it. A member imported under the declaration's
+ * own spelling introduces no separate name, so the source half of `make as vectorMake` — and a
+ * plain `{ equals }` — still reach the declaration itself.
+ */
+const bindsLocalAlias = (
+  snapshot: Analysis.FrontendSnapshot,
+  module: string,
+  spelling: string,
+  identity: SemanticOccurrence.Identity,
+): boolean => {
+  const key = SemanticOccurrence.identityKey(identity)
+  for (const imported of Analysis.moduleScope(snapshot, module)?.imports ?? []) {
+    if (imported._tag !== 'Available') continue
+    for (const binding of imported.bindings) {
+      if (binding._tag !== 'ImportedMember') continue
+      if (binding.spelling !== spelling || binding.spelling === binding.sourceSpelling) continue
+      const bound = SemanticOccurrence.identityKey(
+        Object.freeze({ _tag: 'DeclarationIdentity', id: binding.declaration }),
+      )
+      if (bound === key) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Resolves the occurrences one rename request would rewrite. A declaration's identity is canonical
+ * and module-independent, so it alone cannot say which occurrences a rename owns; two narrowings
+ * finish the job.
+ *
+ * The selected spelling separates an imported member from its local alias, which share that one
+ * identity: renaming the alias `eq` of `equals as eq` edits the `eq` occurrences alone.
+ *
+ * Spelling is not enough on its own, because unrelated modules pick the same alias for the same
+ * declaration all the time — `silk/bytes` and a project module both writing `make as vectorMake`
+ * agree on identity *and* spelling. An `as` clause binds a name in one module only, so when the
+ * selection resolves through such a binding the rename is confined to the module that wrote it.
+ * The declaration site and the source half of an import clause name the declaration itself and
+ * stay project-wide.
+ *
+ * Narrowing here, before any refusal is decided, is what lets prepare and rename answer from the
+ * same facts.
  */
 const renameSubjectAt = (
   self: Document,
@@ -327,12 +367,15 @@ const renameSubjectAt = (
   const spelling = spellingOf(snapshot, self.module, occurrence.span)
   if (spelling === undefined) return undefined
   const identity = occurrence.resolution.identity
+  const aliased = bindsLocalAlias(snapshot, self.module, spelling, identity)
   return Object.freeze({
     occurrence,
     identity,
     spelling,
     matches: matchesOfIdentity(snapshot, identity).filter(
-      (match) => spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
+      (match) =>
+        (!aliased || match.module === self.module) &&
+        spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
     ),
   })
 }

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -1,11 +1,14 @@
 import * as Analysis from '@silk-effect/compiler/Analysis'
-import type * as Diagnostic from '@silk-effect/compiler/Diagnostic'
+import * as Diagnostic from '@silk-effect/compiler/Diagnostic'
 import * as FormattedDocument from '@silk-effect/compiler/FormattedDocument'
 import * as Formatter from '@silk-effect/compiler/Formatter'
+import * as SemanticOccurrence from '@silk-effect/compiler/SemanticOccurrence'
 import * as SourceFile from '@silk-effect/compiler/SourceFile'
+import * as SourceSpan from '@silk-effect/compiler/SourceSpan'
 import * as SyntaxTree from '@silk-effect/compiler/SyntaxTree'
 import * as Documentation from '@silk-effect/documentation/Document'
 import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
 import * as Result from 'effect/Result'
 import {
   type CompletionItem,
@@ -16,12 +19,14 @@ import {
   type Hover,
   type InlayHint,
   InlayHintKind,
+  type Location,
   type LocationLink,
   type Diagnostic as LspDiagnostic,
   type Position,
   type Range,
   SymbolKind,
   type TextEdit,
+  type WorkspaceEdit,
 } from 'vscode-languageserver-types'
 import * as LineIndex from './LineIndex.js'
 
@@ -59,6 +64,27 @@ export const make = (options: {
     index: LineIndex.make(options.bytes),
   })
 
+/**
+ * Resolves any project module's line map from the snapshot's exact analyzed bytes, memoizing
+ * siblings so one request builds each foreign module's map at most once.
+ */
+const lineIndexes = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+): ((module: string) => LineIndex.LineIndex | undefined) => {
+  const siblingIndexes = new Map<string, LineIndex.LineIndex>()
+  return (module) => {
+    if (module === self.module) return self.index
+    const existing = siblingIndexes.get(module)
+    if (existing !== undefined) return existing
+    const source = Analysis.sources(snapshot).get(module)
+    if (source === undefined) return undefined
+    const index = LineIndex.make(SourceFile.toUint8Array(source))
+    siblingIndexes.set(module, index)
+    return index
+  }
+}
+
 const noteSuffix = (diagnostic: Diagnostic.Diagnostic): string =>
   diagnostic.notes === undefined || diagnostic.notes.length === 0
     ? ''
@@ -71,17 +97,7 @@ export const diagnostics = (
   uriOf: (module: string) => string | undefined,
 ): ReadonlyArray<LspDiagnostic> => {
   // Sibling modules' line maps, built once per module from the snapshot's exact loaded bytes.
-  const siblingIndexes = new Map<string, LineIndex.LineIndex>()
-  const indexOf = (module: string): LineIndex.LineIndex | undefined => {
-    if (module === self.module) return self.index
-    const existing = siblingIndexes.get(module)
-    if (existing !== undefined) return existing
-    const source = Analysis.sources(snapshot).get(module)
-    if (source === undefined) return undefined
-    const index = LineIndex.make(SourceFile.toUint8Array(source))
-    siblingIndexes.set(module, index)
-    return index
-  }
+  const indexOf = lineIndexes(self, snapshot)
   return Analysis.diagnostics(snapshot)
     .filter((diagnostic) => diagnostic.span.sourceId === self.module)
     .map((diagnostic) => {
@@ -173,6 +189,202 @@ export const definition = (
     targetRange: LineIndex.rangeOf(targetIndex, location.span),
     targetSelectionRange: LineIndex.rangeOf(targetIndex, location.selectionSpan),
   }
+}
+
+/** One project-wide occurrence sharing the semantic identity selected by a request. */
+interface Match {
+  readonly module: string
+  readonly occurrence: SemanticOccurrence.SemanticOccurrence
+}
+
+/**
+ * Collects every occurrence of one semantic identity across the whole analyzed project. The
+ * occurrence index spans every module of the accepted project revision even though a root view's
+ * closure names one root, so this reads the same index go-to-definition reads, in reverse.
+ */
+const matchesOfIdentity = (
+  snapshot: Analysis.FrontendSnapshot,
+  identity: SemanticOccurrence.Identity,
+): ReadonlyArray<Match> => {
+  const key = SemanticOccurrence.identityKey(identity)
+  const sources = Analysis.sources(snapshot)
+  const modules = [...sources.keys()].sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  )
+  const seen = new Set<string>()
+  const matches: Array<Match> = []
+  for (const module of modules) {
+    const source = sources.get(module)
+    if (source === undefined) continue
+    const whole = Option.getOrUndefined(SourceSpan.make(source, 0, SourceFile.length(source)))
+    if (whole === undefined) continue
+    for (const occurrence of Analysis.semanticOccurrencesInRange(snapshot, module, whole)) {
+      if (occurrence.resolution._tag !== 'Available') continue
+      if (SemanticOccurrence.identityKey(occurrence.resolution.identity) !== key) continue
+      const at = `${module}:${occurrence.span.start}:${occurrence.span.end}`
+      if (seen.has(at)) continue
+      seen.add(at)
+      matches.push(Object.freeze({ module, occurrence }))
+    }
+  }
+  return Object.freeze(matches)
+}
+
+/** Returns one span's exact analyzed spelling, or `undefined` for an unloaded module. */
+const spellingOf = (
+  snapshot: Analysis.FrontendSnapshot,
+  module: string,
+  span: SourceSpan.SourceSpan,
+): string | undefined => {
+  const source = Analysis.sources(snapshot).get(module)
+  return source === undefined ? undefined : Option.getOrUndefined(SourceFile.spelling(source, span))
+}
+
+/** Returns every project occurrence of the semantic identity selected at one position. */
+export const references = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+  includeDeclaration: boolean,
+  uriOf: (module: string) => string | undefined,
+): ReadonlyArray<Location> | undefined => {
+  const occurrence = Analysis.semanticOccurrenceAt(
+    snapshot,
+    self.module,
+    LineIndex.offsetOf(self.index, position),
+  )
+  if (occurrence?.resolution._tag !== 'Available') return undefined
+  const indexOf = lineIndexes(self, snapshot)
+  return Object.freeze(
+    matchesOfIdentity(snapshot, occurrence.resolution.identity).flatMap((match) => {
+      if (!includeDeclaration && match.occurrence.role === 'Declaration') return []
+      const uri = match.module === self.module ? self.uri : uriOf(match.module)
+      const index = indexOf(match.module)
+      return uri === undefined || index === undefined
+        ? []
+        : [{ uri, range: LineIndex.rangeOf(index, match.occurrence.span) }]
+    }),
+  )
+}
+
+/** The renameable name token under one position and the spelling an editor should preselect. */
+export interface PreparedRename {
+  readonly range: Range
+  readonly placeholder: string
+}
+
+/** One refused rename carrying the compiler diagnostic that explains the refusal. */
+export interface RenameRefusal {
+  readonly _tag: 'RenameRefusal'
+  readonly code: string
+  readonly message: string
+}
+
+/** One accepted rename covering every module of the analyzed project. */
+export interface RenameEdit {
+  readonly _tag: 'RenameEdit'
+  readonly edit: WorkspaceEdit
+}
+
+export type Rename = RenameEdit | RenameRefusal
+
+/**
+ * Returns the name token a rename would replace. A token with no source-backed declaration, such
+ * as a keyword, trivia, or an intrinsic with no Silk declaration, has no renameable name.
+ */
+export const prepareRename = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+): PreparedRename | undefined => {
+  const occurrence = Analysis.semanticOccurrenceAt(
+    snapshot,
+    self.module,
+    LineIndex.offsetOf(self.index, position),
+  )
+  if (occurrence?.resolution._tag !== 'Available' || occurrence.declaration === undefined)
+    return undefined
+  const placeholder = spellingOf(snapshot, self.module, occurrence.span)
+  return placeholder === undefined
+    ? undefined
+    : Object.freeze({ range: LineIndex.rangeOf(self.index, occurrence.span), placeholder })
+}
+
+/** Silk's one flat module namespace holds top-level declarations and import bindings only. */
+const occupiesFlatNamespace = (identity: SemanticOccurrence.Identity): boolean =>
+  identity._tag === 'DeclarationIdentity' || identity._tag === 'ImportNamespaceIdentity'
+
+/**
+ * Refuses a new spelling already claimed in a flat namespace the rename would extend. Only the
+ * declaration site and import bindings put a name into a module's flat namespace, so a module that
+ * merely reaches the declaration through a qualifier keeps its own unrelated top-level names.
+ */
+const flatNamespaceRefusal = (
+  snapshot: Analysis.FrontendSnapshot,
+  identity: SemanticOccurrence.Identity,
+  matches: ReadonlyArray<Match>,
+  newName: string,
+  span: SourceSpan.SourceSpan,
+): RenameRefusal | undefined => {
+  if (!occupiesFlatNamespace(identity)) return undefined
+  for (const match of matches) {
+    if (match.occurrence.role !== 'Declaration' && match.occurrence.role !== 'Import') continue
+    if (Analysis.lookupName(snapshot, match.module, newName)._tag === 'Missing') continue
+    const diagnostic = Diagnostic.bindingConflict(newName, span)
+    return Object.freeze({
+      _tag: 'RenameRefusal',
+      code: diagnostic.code,
+      message: diagnostic.message,
+    })
+  }
+  return undefined
+}
+
+/**
+ * Renames one semantic identity across every module of the analyzed project. Only occurrences
+ * whose analyzed spelling equals the selected name are edited: an imported member and its local
+ * alias share one identity, so an alias keeps the local name its own module chose. The rename is
+ * refused rather than partially applied when any occurrence cannot be placed in a document.
+ */
+export const rename = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+  newName: string,
+  uriOf: (module: string) => string | undefined,
+): Rename | undefined => {
+  const occurrence = Analysis.semanticOccurrenceAt(
+    snapshot,
+    self.module,
+    LineIndex.offsetOf(self.index, position),
+  )
+  if (occurrence?.resolution._tag !== 'Available' || occurrence.declaration === undefined)
+    return undefined
+  const spelling = spellingOf(snapshot, self.module, occurrence.span)
+  if (spelling === undefined) return undefined
+  const identity = occurrence.resolution.identity
+  const matches = matchesOfIdentity(snapshot, identity).filter(
+    (match) => spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
+  )
+  const refusal = flatNamespaceRefusal(snapshot, identity, matches, newName, occurrence.span)
+  if (refusal !== undefined) return refusal
+  const indexOf = lineIndexes(self, snapshot)
+  const changes: Record<string, Array<TextEdit>> = {}
+  for (const match of matches) {
+    const uri = match.module === self.module ? self.uri : uriOf(match.module)
+    const index = indexOf(match.module)
+    if (uri === undefined || index === undefined)
+      return Object.freeze({
+        _tag: 'RenameRefusal',
+        code: 'LSP0001',
+        message: `Module ${match.module} has no document to rename ${spelling} in`,
+      })
+    const edits = changes[uri]
+    const edit = { range: LineIndex.rangeOf(index, match.occurrence.span), newText: newName }
+    if (edits === undefined) changes[uri] = [edit]
+    else edits.push(edit)
+  }
+  return Object.freeze({ _tag: 'RenameEdit', edit: { changes } })
 }
 
 /** Converts compiler-owned inferred local types into standard protocol inlay hints. */

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -230,6 +230,14 @@ const matchesOfIdentity = (
   return Object.freeze(matches)
 }
 
+/**
+ * Tests whether one module's exact bytes came from the installed compiler toolchain. Origin is the
+ * only trustworthy signal: a module-name prefix such as `silk/` is spoofable by a project module
+ * and would miss toolchain sources shipped outside the reserved namespace.
+ */
+const isToolchainModule = (snapshot: Analysis.FrontendSnapshot, module: string): boolean =>
+  Analysis.sources(snapshot).get(module)?.origin._tag === 'ToolchainFile'
+
 /** Returns one span's exact analyzed spelling, or `undefined` for an unloaded module. */
 const spellingOf = (
   snapshot: Analysis.FrontendSnapshot,
@@ -290,7 +298,9 @@ export type Rename = RenameEdit | RenameRefusal
 
 /**
  * Returns the name token a rename would replace. A token with no source-backed declaration, such
- * as a keyword, trivia, or an intrinsic with no Silk declaration, has no renameable name.
+ * as a keyword, trivia, or an intrinsic with no Silk declaration, has no renameable name. A
+ * declaration the installed toolchain owns has none either, so no editor offers the rename UI for
+ * a name the request would only refuse.
  */
 export const prepareRename = (
   self: Document,
@@ -304,6 +314,7 @@ export const prepareRename = (
   )
   if (occurrence?.resolution._tag !== 'Available' || occurrence.declaration === undefined)
     return undefined
+  if (isToolchainModule(snapshot, occurrence.declaration.module)) return undefined
   const placeholder = spellingOf(snapshot, self.module, occurrence.span)
   return placeholder === undefined
     ? undefined
@@ -344,7 +355,9 @@ const flatNamespaceRefusal = (
  * Renames one semantic identity across every module of the analyzed project. Only occurrences
  * whose analyzed spelling equals the selected name are edited: an imported member and its local
  * alias share one identity, so an alias keeps the local name its own module chose. The rename is
- * refused rather than partially applied when any occurrence cannot be placed in a document.
+ * refused rather than partially applied when any occurrence cannot be placed in a document, or
+ * when any occurrence lives in a source the installed toolchain owns: editors apply a workspace
+ * edit unprompted, and the standard library belongs to the installation, not to one project.
  */
 export const rename = (
   self: Document,
@@ -362,6 +375,13 @@ export const rename = (
     return undefined
   const spelling = spellingOf(snapshot, self.module, occurrence.span)
   if (spelling === undefined) return undefined
+  const declaringModule = occurrence.declaration.module
+  if (isToolchainModule(snapshot, declaringModule))
+    return Object.freeze({
+      _tag: 'RenameRefusal',
+      code: 'LSP0002',
+      message: `${spelling} is declared in ${declaringModule}, which the installed toolchain owns and cannot be renamed`,
+    })
   const identity = occurrence.resolution.identity
   const matches = matchesOfIdentity(snapshot, identity).filter(
     (match) => spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
@@ -371,6 +391,14 @@ export const rename = (
   const indexOf = lineIndexes(self, snapshot)
   const changes: Record<string, Array<TextEdit>> = {}
   for (const match of matches) {
+    // A project-declared identity should never reach a toolchain source, but an edit aimed at the
+    // installation is damaging enough that the whole rename is refused rather than trimmed.
+    if (isToolchainModule(snapshot, match.module))
+      return Object.freeze({
+        _tag: 'RenameRefusal',
+        code: 'LSP0002',
+        message: `Renaming ${spelling} would edit ${match.module}, which the installed toolchain owns`,
+      })
     const uri = match.module === self.module ? self.uri : uriOf(match.module)
     const index = indexOf(match.module)
     if (uri === undefined || index === undefined)

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -296,17 +296,27 @@ export interface RenameEdit {
 
 export type Rename = RenameEdit | RenameRefusal
 
+/** Everything a rename request derives from one position, shared by prepare and rename. */
+interface RenameSubject {
+  readonly occurrence: SemanticOccurrence.SemanticOccurrence
+  readonly identity: SemanticOccurrence.Identity
+  readonly spelling: string
+  /** Every occurrence the rename would edit: the identity's, narrowed to the selected spelling. */
+  readonly matches: ReadonlyArray<Match>
+}
+
 /**
- * Returns the name token a rename would replace. A token with no source-backed declaration, such
- * as a keyword, trivia, or an intrinsic with no Silk declaration, has no renameable name. A
- * declaration the installed toolchain owns has none either, so no editor offers the rename UI for
- * a name the request would only refuse.
+ * Resolves the occurrences one rename request would rewrite. An imported member and its local
+ * alias share a single identity, so the selected spelling is what separates them: renaming the
+ * alias `eq` of `equals as eq` edits the `eq` occurrences alone, all of them owned by the module
+ * that chose the alias. Narrowing here, before any refusal is decided, is what lets prepare and
+ * rename answer from the same facts.
  */
-export const prepareRename = (
+const renameSubjectAt = (
   self: Document,
   snapshot: Analysis.FrontendSnapshot,
   position: Position,
-): PreparedRename | undefined => {
+): RenameSubject | undefined => {
   const occurrence = Analysis.semanticOccurrenceAt(
     snapshot,
     self.module,
@@ -314,11 +324,61 @@ export const prepareRename = (
   )
   if (occurrence?.resolution._tag !== 'Available' || occurrence.declaration === undefined)
     return undefined
-  if (isToolchainModule(snapshot, occurrence.declaration.module)) return undefined
-  const placeholder = spellingOf(snapshot, self.module, occurrence.span)
-  return placeholder === undefined
-    ? undefined
-    : Object.freeze({ range: LineIndex.rangeOf(self.index, occurrence.span), placeholder })
+  const spelling = spellingOf(snapshot, self.module, occurrence.span)
+  if (spelling === undefined) return undefined
+  const identity = occurrence.resolution.identity
+  return Object.freeze({
+    occurrence,
+    identity,
+    spelling,
+    matches: matchesOfIdentity(snapshot, identity).filter(
+      (match) => spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
+    ),
+  })
+}
+
+/**
+ * Refuses a rename that would rewrite a source the installed toolchain owns. Ownership is decided
+ * by where the edits land, never by where the identity was declared: a project module's own alias
+ * of a standard-library member is the project's name to change, while the member's own spelling
+ * reaches the declaration inside the installation and stays untouchable. Editors apply a workspace
+ * edit unprompted, so a request that reaches the installation is refused whole, never trimmed.
+ */
+const toolchainRefusal = (
+  snapshot: Analysis.FrontendSnapshot,
+  matches: ReadonlyArray<Match>,
+  spelling: string,
+): RenameRefusal | undefined => {
+  for (const match of matches) {
+    if (!isToolchainModule(snapshot, match.module)) continue
+    return Object.freeze({
+      _tag: 'RenameRefusal',
+      code: 'LSP0002',
+      message: `Renaming ${spelling} would edit ${match.module}, which the installed toolchain owns`,
+    })
+  }
+  return undefined
+}
+
+/**
+ * Returns the name token a rename would replace. A token with no source-backed declaration, such
+ * as a keyword, trivia, or an intrinsic with no Silk declaration, has no renameable name. A name
+ * whose rename would reach the installed toolchain has none either: prepare answers from the same
+ * occurrences and the same refusal `rename` uses, so no editor greys out a rename that would
+ * succeed, nor offers one that only ever fails.
+ */
+export const prepareRename = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+): PreparedRename | undefined => {
+  const subject = renameSubjectAt(self, snapshot, position)
+  if (subject === undefined) return undefined
+  if (toolchainRefusal(snapshot, subject.matches, subject.spelling) !== undefined) return undefined
+  return Object.freeze({
+    range: LineIndex.rangeOf(self.index, subject.occurrence.span),
+    placeholder: subject.spelling,
+  })
 }
 
 /** Silk's one flat module namespace holds top-level declarations and import bindings only. */
@@ -356,8 +416,9 @@ const flatNamespaceRefusal = (
  * whose analyzed spelling equals the selected name are edited: an imported member and its local
  * alias share one identity, so an alias keeps the local name its own module chose. The rename is
  * refused rather than partially applied when any occurrence cannot be placed in a document, or
- * when any occurrence lives in a source the installed toolchain owns: editors apply a workspace
- * edit unprompted, and the standard library belongs to the installation, not to one project.
+ * when any occurrence lives in a source the installed toolchain owns. Toolchain ownership is
+ * decided first: no replacement spelling can make such a rename legal, so reporting a name
+ * collision instead would send the user looking for a fix that does not exist.
  */
 export const rename = (
   self: Document,
@@ -366,33 +427,18 @@ export const rename = (
   newName: string,
   uriOf: (module: string) => string | undefined,
 ): Rename | undefined => {
-  const occurrence = Analysis.semanticOccurrenceAt(
-    snapshot,
-    self.module,
-    LineIndex.offsetOf(self.index, position),
-  )
-  if (occurrence?.resolution._tag !== 'Available' || occurrence.declaration === undefined)
-    return undefined
-  const spelling = spellingOf(snapshot, self.module, occurrence.span)
-  if (spelling === undefined) return undefined
-  const declaringModule = occurrence.declaration.module
-  if (isToolchainModule(snapshot, declaringModule))
-    return Object.freeze({
-      _tag: 'RenameRefusal',
-      code: 'LSP0002',
-      message: `${spelling} is declared in ${declaringModule}, which the installed toolchain owns and cannot be renamed`,
-    })
-  const identity = occurrence.resolution.identity
-  const matches = matchesOfIdentity(snapshot, identity).filter(
-    (match) => spellingOf(snapshot, match.module, match.occurrence.span) === spelling,
-  )
+  const subject = renameSubjectAt(self, snapshot, position)
+  if (subject === undefined) return undefined
+  const { identity, matches, occurrence, spelling } = subject
+  const owned = toolchainRefusal(snapshot, matches, spelling)
+  if (owned !== undefined) return owned
   const refusal = flatNamespaceRefusal(snapshot, identity, matches, newName, occurrence.span)
   if (refusal !== undefined) return refusal
   const indexOf = lineIndexes(self, snapshot)
   const changes: Record<string, Array<TextEdit>> = {}
   for (const match of matches) {
-    // A project-declared identity should never reach a toolchain source, but an edit aimed at the
-    // installation is damaging enough that the whole rename is refused rather than trimmed.
+    // `toolchainRefusal` already cleared every match, but an edit aimed at the installation is
+    // damaging enough that the guard stays here too, where the edits are actually built.
     if (isToolchainModule(snapshot, match.module))
       return Object.freeze({
         _tag: 'RenameRefusal',

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -7,7 +7,9 @@ import * as Path from 'effect/Path'
 import {
   createConnection,
   DidChangeWatchedFilesNotification,
+  LSPErrorCodes,
   ProposedFeatures,
+  ResponseError,
   TextDocumentSyncKind,
   TextDocuments,
 } from 'vscode-languageserver/node.js'
@@ -56,6 +58,8 @@ export const start = (): void => {
         textDocumentSync: TextDocumentSyncKind.Incremental,
         hoverProvider: true,
         definitionProvider: true,
+        referencesProvider: true,
+        renameProvider: { prepareProvider: true },
         completionProvider: { triggerCharacters: ['.'] },
         inlayHintProvider: true,
         documentSymbolProvider: true,
@@ -195,6 +199,54 @@ export const start = (): void => {
       (module) => session.value.moduleUris.get(module),
     )
     return definition === undefined ? null : [definition]
+  })
+
+  connection.onReferences(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return null
+    const locations = Document.references(
+      session.value.document,
+      session.value.snapshot,
+      parameters.position,
+      parameters.context.includeDeclaration,
+      (module) => session.value.moduleUris.get(module),
+    )
+    return locations === undefined ? null : [...locations]
+  })
+
+  const unrenameable = (): ResponseError<void> =>
+    new ResponseError<void>(
+      LSPErrorCodes.RequestFailed,
+      'The selected token has no renameable declaration',
+    )
+
+  connection.onPrepareRename(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return unrenameable()
+    const prepared = Document.prepareRename(
+      session.value.document,
+      session.value.snapshot,
+      parameters.position,
+    )
+    return prepared === undefined
+      ? unrenameable()
+      : { range: prepared.range, placeholder: prepared.placeholder }
+  })
+
+  connection.onRenameRequest(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return unrenameable()
+    const renamed = Document.rename(
+      session.value.document,
+      session.value.snapshot,
+      parameters.position,
+      parameters.newName,
+      (module) => session.value.moduleUris.get(module),
+    )
+    if (renamed === undefined) return unrenameable()
+    return renamed._tag === 'RenameEdit'
+      ? renamed.edit
+      : new ResponseError<void>(LSPErrorCodes.RequestFailed, `${renamed.code}: ${renamed.message}`)
   })
 
   connection.languages.inlayHint.on(async (parameters) => {

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -2,8 +2,12 @@ import { assert, it } from '@effect/vitest'
 import * as Analysis from '@silk-effect/compiler/Analysis'
 import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
 import * as SourceFile from '@silk-effect/compiler/SourceFile'
+import * as SourceOrigin from '@silk-effect/compiler/SourceOrigin'
 import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
+import * as Stdlib from '@silk-effect/compiler/Stdlib'
 import * as Effect from 'effect/Effect'
+import * as Layer from 'effect/Layer'
+import * as Option from 'effect/Option'
 import { SymbolKind } from 'vscode-languageserver-types'
 import * as Document from '../src/Document.js'
 
@@ -600,7 +604,43 @@ interface ProjectModule {
   readonly text: string
 }
 
-const uriOfModule = (module: string): string => `file:///project/${module}.silk`
+/**
+ * Mirrors `Workspace.uriOf`: a toolchain-shipped module answers with its real installed
+ * `file://` href, so an edit aimed at the standard library is visible as such in a test.
+ */
+const uriOfModule = (module: string): string =>
+  Stdlib.find(module)?.sourceUrl.href ?? `file:///project/${module}.silk`
+
+/**
+ * Mirrors the installed toolchain resolver: project modules come from memory while reserved
+ * standard-library modules carry the `ToolchainFile` origin a real installation reports.
+ */
+const toolchainResolver = (
+  sources: ReadonlyMap<string, Uint8Array>,
+): Layer.Layer<SourceResolver.SourceResolver> =>
+  Layer.succeed(SourceResolver.SourceResolver, {
+    resolve: (module) => {
+      const bytes = sources.get(module)
+      return Effect.succeed(
+        bytes === undefined
+          ? Option.none()
+          : Option.some(SourceResolver.resolved(bytes, SourceOrigin.memory())),
+      )
+    },
+    resolveStandardLibrary: (module) => {
+      const entry = Stdlib.find(module)
+      return Effect.succeed(
+        entry === undefined
+          ? Option.none()
+          : Option.some(
+              SourceResolver.resolved(
+                entry.bytes,
+                SourceOrigin.toolchainFile(entry.sourceUrl.href),
+              ),
+            ),
+      )
+    },
+  })
 
 /** Opens several modules as one analyzed project and focuses one of them as the request document. */
 const openProject = (
@@ -616,7 +656,7 @@ const openProject = (
     )
     const project = yield* ProjectAnalysis.make(
       modules.map(({ module }) => SourceFile.make(module, bytes.get(module) ?? new Uint8Array())),
-    ).pipe(Effect.provide(SourceResolver.memory(bytes)))
+    ).pipe(Effect.provide(toolchainResolver(bytes)))
     const snapshot = ProjectAnalysis.view(project, focus)
     if (snapshot === undefined) throw new Error(`Project analysis lost focused root ${focus}`)
     return {
@@ -790,6 +830,88 @@ it.effect('renames the imported source name without disturbing a local alias', (
         newText: edit.newText,
       })),
       [{ line: 0, character: aliased.indexOf('area'), newText: 'surface' }],
+    )
+  }),
+)
+
+const toolchainUri = Stdlib.find('silk/bool')?.sourceUrl.href
+const boolConsumer =
+  'import silk.bool { equals }\npub fn main() -> bool { return equals(true, true) }'
+
+it.effect('refuses to rename a declaration the installed toolchain owns', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [{ module: 'main', text: boolConsumer }],
+      'main',
+    )
+    assert.isDefined(toolchainUri)
+    // The import binding and the call site both reach the same toolchain-owned declaration.
+    for (const occurrence of [0, 1]) {
+      const position = positionOf(boolConsumer, 'equals', occurrence)
+      const renamed = Document.rename(document, snapshot, position, 'sameAs', uriOfModule)
+      assert.strictEqual(renamed?._tag, 'RenameRefusal')
+      if (renamed?._tag !== 'RenameRefusal') return
+      assert.strictEqual(renamed.code, 'LSP0002')
+      assert.include(renamed.message, 'silk/bool')
+      // The editor is never offered the rename UI for a toolchain-owned declaration either.
+      assert.isUndefined(Document.prepareRename(document, snapshot, position))
+    }
+  }),
+)
+
+const boolHelper =
+  'import silk.bool { equals }\npub fn same(left: bool, right: bool) -> bool { return equals(left, right) }'
+const boolCaller = 'import helper { same }\npub fn main() -> bool { return same(true, true) }'
+
+it.effect('renames a project declaration used beside toolchain imports without touching them', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'helper', text: boolHelper },
+        { module: 'main', text: boolCaller },
+      ],
+      'helper',
+    )
+    const renamed = Document.rename(
+      document,
+      snapshot,
+      positionOf(boolHelper, 'same'),
+      'identical',
+      uriOfModule,
+    )
+    assert.strictEqual(renamed?._tag, 'RenameEdit')
+    if (renamed?._tag !== 'RenameEdit') return
+    const changes = renamed.edit.changes ?? {}
+    assert.deepEqual(Object.keys(changes).sort(), [uriOfModule('helper'), uriOfModule('main')])
+    // No edit may land in the toolchain installation, whatever the project's closure contains.
+    assert.isEmpty(
+      Object.keys(changes).filter((uri) => uri === toolchainUri || uri.includes('/stdlib/')),
+    )
+  }),
+)
+
+it.effect('still lists the toolchain declaration among a standard-library name references', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [{ module: 'main', text: boolConsumer }],
+      'main',
+    )
+    const locations = Document.references(
+      document,
+      snapshot,
+      positionOf(boolConsumer, 'equals'),
+      true,
+      uriOfModule,
+    )
+    assert.isDefined(locations)
+    // References stay read-only and complete: the toolchain declaration is useful to show.
+    assert.include(
+      locations?.map(({ uri }) => uri),
+      toolchainUri,
+    )
+    assert.include(
+      locations?.map(({ uri }) => uri),
+      uriOfModule('main'),
     )
   }),
 )

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from '@effect/vitest'
 import * as Analysis from '@silk-effect/compiler/Analysis'
+import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
 import * as SourceFile from '@silk-effect/compiler/SourceFile'
 import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
 import * as Effect from 'effect/Effect'
@@ -590,6 +591,205 @@ it.effect('returns no definition for unavailable targets and trivia', () =>
     )
     assert.isUndefined(
       Document.definition(document, snapshot, { line: 0, character: 3 }, () => undefined),
+    )
+  }),
+)
+
+interface ProjectModule {
+  readonly module: string
+  readonly text: string
+}
+
+const uriOfModule = (module: string): string => `file:///project/${module}.silk`
+
+/** Opens several modules as one analyzed project and focuses one of them as the request document. */
+const openProject = (
+  modules: ReadonlyArray<ProjectModule>,
+  focus: string,
+): Effect.Effect<{
+  readonly document: Document.Document
+  readonly snapshot: Analysis.FrontendSnapshot
+}> =>
+  Effect.gen(function* () {
+    const bytes = new Map(
+      modules.map(({ module, text }) => [module, encoder.encode(text)] as const),
+    )
+    const project = yield* ProjectAnalysis.make(
+      modules.map(({ module }) => SourceFile.make(module, bytes.get(module) ?? new Uint8Array())),
+    ).pipe(Effect.provide(SourceResolver.memory(bytes)))
+    const snapshot = ProjectAnalysis.view(project, focus)
+    if (snapshot === undefined) throw new Error(`Project analysis lost focused root ${focus}`)
+    return {
+      document: Document.make({
+        uri: uriOfModule(focus),
+        version: 1,
+        workspace: 'project:/project/silk.toml',
+        module: focus,
+        sourceRoot: '/project',
+        bytes: bytes.get(focus) ?? new Uint8Array(),
+      }),
+      snapshot,
+    }
+  })
+
+const geometry = 'pub fn area(width: i32, height: i32) -> i32 { return width }'
+const consumer =
+  'import geometry\npub fn main() -> i32 { return geometry.area(2, 3) + geometry.area(4, 5) }'
+
+it.effect('finds every use of one declaration across two modules', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: consumer },
+      ],
+      'geometry',
+    )
+    const position = positionOf(geometry, 'area')
+    assert.deepEqual(
+      Document.references(document, snapshot, position, true, uriOfModule)?.map(
+        ({ uri, range }) => ({ uri, line: range.start.line, character: range.start.character }),
+      ),
+      [
+        { uri: uriOfModule('geometry'), line: 0, character: geometry.indexOf('area') },
+        { uri: uriOfModule('main'), line: 1, character: consumer.split('\n')[1]?.indexOf('area') },
+        {
+          uri: uriOfModule('main'),
+          line: 1,
+          character: consumer.split('\n')[1]?.indexOf('area', 40),
+        },
+      ],
+    )
+    // Excluding the declaration drops exactly the declaration-site occurrence.
+    assert.deepEqual(
+      Document.references(document, snapshot, position, false, uriOfModule)?.map(({ uri }) => uri),
+      [uriOfModule('main'), uriOfModule('main')],
+    )
+  }),
+)
+
+it.effect('renames a declaration with one workspace edit covering both modules', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: consumer },
+      ],
+      'geometry',
+    )
+    const renamed = Document.rename(
+      document,
+      snapshot,
+      positionOf(geometry, 'area'),
+      'surface',
+      uriOfModule,
+    )
+    assert.strictEqual(renamed?._tag, 'RenameEdit')
+    if (renamed?._tag !== 'RenameEdit') return
+    const changes = renamed.edit.changes ?? {}
+    assert.deepEqual(Object.keys(changes).sort(), [uriOfModule('geometry'), uriOfModule('main')])
+    assert.deepEqual(
+      changes[uriOfModule('geometry')]?.map((edit) => edit.newText),
+      ['surface'],
+    )
+    assert.deepEqual(
+      changes[uriOfModule('main')]?.map((edit) => edit.newText),
+      ['surface', 'surface'],
+    )
+  }),
+)
+
+it.effect('refuses a rename that collides with a top-level name in any edited module', () =>
+  Effect.gen(function* () {
+    const local = yield* openProject(
+      [{ module: 'geometry', text: `${geometry}\npub fn surface() -> i32 { return 1 }` }],
+      'geometry',
+    )
+    const refusedLocally = Document.rename(
+      local.document,
+      local.snapshot,
+      positionOf(geometry, 'area'),
+      'surface',
+      uriOfModule,
+    )
+    assert.deepEqual(refusedLocally, {
+      _tag: 'RenameRefusal',
+      code: 'SEM0016',
+      message: 'Multiple bindings claim surface',
+    })
+
+    // The importing module's flat namespace counts too: its selected member would collide there.
+    const importer = 'import geometry { area }\npub fn surface() -> i32 { return area(1, 2) }'
+    const across = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: importer },
+      ],
+      'geometry',
+    )
+    assert.deepEqual(
+      Document.rename(
+        across.document,
+        across.snapshot,
+        positionOf(geometry, 'area'),
+        'surface',
+        uriOfModule,
+      ),
+      { _tag: 'RenameRefusal', code: 'SEM0016', message: 'Multiple bindings claim surface' },
+    )
+  }),
+)
+
+it.effect('prepares a rename on a name token but fails on a keyword', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [{ module: 'geometry', text: geometry }],
+      'geometry',
+    )
+    assert.deepEqual(Document.prepareRename(document, snapshot, positionOf(geometry, 'area')), {
+      range: {
+        start: { line: 0, character: geometry.indexOf('area') },
+        end: { line: 0, character: geometry.indexOf('area') + 'area'.length },
+      },
+      placeholder: 'area',
+    })
+    assert.isUndefined(
+      Document.prepareRename(document, snapshot, positionOf(geometry, 'pub')),
+      'a keyword token has no renameable declaration',
+    )
+    assert.isUndefined(Document.prepareRename(document, snapshot, positionOf(geometry, 'return')))
+  }),
+)
+
+it.effect('renames the imported source name without disturbing a local alias', () =>
+  Effect.gen(function* () {
+    const aliased =
+      'import geometry { area as region }\npub fn main() -> i32 { return region(1, 2) }'
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: aliased },
+      ],
+      'geometry',
+    )
+    const renamed = Document.rename(
+      document,
+      snapshot,
+      positionOf(geometry, 'area'),
+      'surface',
+      uriOfModule,
+    )
+    assert.strictEqual(renamed?._tag, 'RenameEdit')
+    if (renamed?._tag !== 'RenameEdit') return
+    const changes = renamed.edit.changes ?? {}
+    // Only the `area` half of `area as region` moves; `region` and its uses keep their spelling.
+    assert.deepEqual(
+      changes[uriOfModule('main')]?.map((edit) => ({
+        line: edit.range.start.line,
+        character: edit.range.start.character,
+        newText: edit.newText,
+      })),
+      [{ line: 0, character: aliased.indexOf('area'), newText: 'surface' }],
     )
   }),
 )

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -33,12 +33,16 @@ const open = (
     return { document, snapshot }
   })
 
-const positionOf = (source: string, spelling: string, occurrence = 0) => {
-  let offset = -1
-  for (let index = 0; index <= occurrence; index += 1) offset = source.indexOf(spelling, offset + 1)
+const positionAt = (source: string, offset: number) => {
   const before = source.slice(0, offset)
   const lineStart = before.lastIndexOf('\n') + 1
   return { line: before.split('\n').length - 1, character: offset - lineStart }
+}
+
+const positionOf = (source: string, spelling: string, occurrence = 0) => {
+  let offset = -1
+  for (let index = 0; index <= occurrence; index += 1) offset = source.indexOf(spelling, offset + 1)
+  return positionAt(source, offset)
 }
 
 it.effect('publishes compiler errors as protocol diagnostics', () =>
@@ -856,6 +860,73 @@ it.effect('refuses to rename a declaration the installed toolchain owns', () =>
       // The editor is never offered the rename UI for a toolchain-owned declaration either.
       assert.isUndefined(Document.prepareRename(document, snapshot, position))
     }
+  }),
+)
+
+const boolAlias =
+  'import silk.bool { equals as eq }\npub fn main() -> bool { return eq(true, true) }'
+// `eq` never spells `equals`, so these two offsets are the whole extent of the alias.
+const aliasBinding = boolAlias.indexOf(' as eq') + ' as '.length
+const aliasCall = boolAlias.indexOf('eq(')
+
+it.effect('renames a local alias of a toolchain import, which the project owns', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject([{ module: 'main', text: boolAlias }], 'main')
+    assert.isDefined(toolchainUri)
+    // The alias is renameable from its binding and from its use: both name `main`'s own binding.
+    for (const offset of [aliasBinding, aliasCall]) {
+      const position = positionAt(boolAlias, offset)
+      const renamed = Document.rename(document, snapshot, position, 'same', uriOfModule)
+      assert.strictEqual(renamed?._tag, 'RenameEdit')
+      if (renamed?._tag !== 'RenameEdit') return
+      const changes = renamed.edit.changes ?? {}
+      // Only the project module is edited: the `equals` half of the clause keeps its spelling.
+      assert.deepEqual(Object.keys(changes), [uriOfModule('main')])
+      assert.deepEqual(
+        changes[uriOfModule('main')]?.map((edit) => ({
+          ...edit.range.start,
+          newText: edit.newText,
+        })),
+        [
+          { ...positionAt(boolAlias, aliasBinding), newText: 'same' },
+          { ...positionAt(boolAlias, aliasCall), newText: 'same' },
+        ],
+      )
+      // Prepare must never grey out F2 where the rename itself succeeds.
+      assert.deepEqual(Document.prepareRename(document, snapshot, position), {
+        range: {
+          start: position,
+          end: { line: position.line, character: position.character + 'eq'.length },
+        },
+        placeholder: 'eq',
+      })
+    }
+  }),
+)
+
+it.effect('refuses a toolchain-owned rename before any flat-namespace collision', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [{ module: 'main', text: boolConsumer }],
+      'main',
+    )
+    // `main` already occupies this module's flat namespace, so both refusals apply at once and
+    // the toolchain one must win: no new spelling can make this rename legal.
+    const both = Document.rename(
+      document,
+      snapshot,
+      positionOf(boolConsumer, 'equals'),
+      'main',
+      uriOfModule,
+    )
+    assert.strictEqual(both?._tag, 'RenameRefusal')
+    if (both?._tag !== 'RenameRefusal') return
+    assert.strictEqual(both.code, 'LSP0002')
+    // A collision with no toolchain edit behind it still reports the binding conflict.
+    assert.deepEqual(
+      Document.rename(document, snapshot, positionOf(boolConsumer, 'main'), 'equals', uriOfModule),
+      { _tag: 'RenameRefusal', code: 'SEM0016', message: 'Multiple bindings claim equals' },
+    )
   }),
 )
 

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -986,3 +986,85 @@ it.effect('still lists the toolchain declaration among a standard-library name r
     )
   }),
 )
+
+const stdlibAliases =
+  'import silk.bytes { make as bytesMake }\nimport silk.vector { make as vectorMake }\npub fn main() -> i32 { return 0 }'
+// `make` is a prefix of neither alias, but the alias spellings repeat across the standard library,
+// so the offsets are taken from the clause itself rather than searched for by spelling.
+const vectorAliasBinding = stdlibAliases.indexOf('make as vectorMake') + 'make as '.length
+
+it.effect('renames the project alias of a standard-library member the toolchain also aliases', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [{ module: 'main', text: stdlibAliases }],
+      'main',
+    )
+    const position = positionAt(stdlibAliases, vectorAliasBinding)
+    // `silk/bytes` and `silk/os_filesystem` spell their own alias of `silk.vector.make`
+    // `vectorMake` too: identity and spelling both coincide, and only the module that wrote the
+    // clause owns this binding.
+    const renamed = Document.rename(document, snapshot, position, 'newVector', uriOfModule)
+    assert.strictEqual(renamed?._tag, 'RenameEdit')
+    if (renamed?._tag !== 'RenameEdit') return
+    const changes = renamed.edit.changes ?? {}
+    assert.deepEqual(Object.keys(changes), [uriOfModule('main')])
+    assert.deepEqual(
+      changes[uriOfModule('main')]?.map((edit) => ({ ...edit.range.start, newText: edit.newText })),
+      [{ ...position, newText: 'newVector' }],
+    )
+    // No edit may reach the installation under any module name it ships.
+    assert.isEmpty(Object.keys(changes).filter((uri) => uri.includes('/stdlib/')))
+    // Prepare answers from the same facts, so the editor offers the rename it will accept.
+    assert.deepEqual(Document.prepareRename(document, snapshot, position), {
+      range: {
+        start: position,
+        end: { line: position.line, character: position.character + 'vectorMake'.length },
+      },
+      placeholder: 'vectorMake',
+    })
+    // Confining the *rename* leaves the read-only reference list whole: every occurrence of the
+    // declaration, standard-library ones included, is still worth showing.
+    const locations = Document.references(document, snapshot, position, true, uriOfModule)
+    assert.isDefined(locations)
+    assert.include(
+      locations?.map(({ uri }) => uri),
+      uriOfModule('main'),
+    )
+    assert.isNotEmpty(
+      (locations ?? []).filter(({ uri }) => uri === Stdlib.find('silk/vector')?.sourceUrl.href),
+    )
+  }),
+)
+
+const alphaAlias = 'import geometry { area as region }\npub fn one() -> i32 { return region(1, 2) }'
+const betaAlias = 'import geometry { area as region }\npub fn two() -> i32 { return region(3, 4) }'
+
+it.effect('keeps one module alias rename out of another module that chose the same alias', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'alpha', text: alphaAlias },
+        { module: 'beta', text: betaAlias },
+      ],
+      'alpha',
+    )
+    const binding = positionAt(alphaAlias, alphaAlias.indexOf('area as region') + 'area as '.length)
+    const renamed = Document.rename(document, snapshot, binding, 'zone', uriOfModule)
+    assert.strictEqual(renamed?._tag, 'RenameEdit')
+    if (renamed?._tag !== 'RenameEdit') return
+    const changes = renamed.edit.changes ?? {}
+    // `beta` chose the same spelling for the same declaration; it is not `alpha`'s name to change.
+    assert.deepEqual(Object.keys(changes), [uriOfModule('alpha')])
+    assert.deepEqual(
+      changes[uriOfModule('alpha')]?.map((edit) => ({
+        ...edit.range.start,
+        newText: edit.newText,
+      })),
+      [
+        { ...binding, newText: 'zone' },
+        { ...positionAt(alphaAlias, alphaAlias.indexOf('region(1, 2)')), newText: 'zone' },
+      ],
+    )
+  }),
+)

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -71,6 +71,14 @@ const connect = (): Client => {
 const response = (message: Record<string, unknown>, id: number): unknown =>
   message.id === id && 'result' in message ? message.result : undefined
 
+const failure = (
+  message: Record<string, unknown>,
+  id: number,
+): { readonly message: string } | undefined =>
+  message.id === id && 'error' in message
+    ? (message.error as { readonly message: string })
+    : undefined
+
 const publishedDiagnostics = (
   message: Record<string, unknown>,
   uri: string,
@@ -565,6 +573,89 @@ it('navigates to closed and unsaved cross-file targets and invalidates disk depe
       (message) => publishedDiagnosticReport(message, mainUri) !== undefined,
     ).length
     assert.strictEqual(reportsAfterUnrelated, reportsBeforeUnrelated)
+  } finally {
+    await client.close()
+  }
+})
+
+it('serves project-wide references and renames over real stdio', { timeout: 30_000 }, async () => {
+  const client = connect()
+  try {
+    client.send({
+      id: 1,
+      method: 'initialize',
+      params: { processId: null, rootUri: null, capabilities: {} },
+    })
+    const initialized = (await client.waitFor((message) => response(message, 1))) as {
+      capabilities: Record<string, unknown>
+    }
+    assert.strictEqual(initialized.capabilities.referencesProvider, true)
+    assert.deepEqual(initialized.capabilities.renameProvider, { prepareProvider: true })
+    client.send({ method: 'initialized', params: {} })
+
+    const geometryUri = 'file:///silk-lsp-e2e/rename/Geometry.silk'
+    const mainUri = 'file:///silk-lsp-e2e/rename/Main.silk'
+    const geometryText =
+      'pub fn area(width: i32, height: i32) -> i32 { return width }\npub fn perimeter() -> i32 { return 1 }'
+    const mainText = 'import Geometry\npub fn main() -> i32 { return Geometry.area(2, 3) }'
+    didOpen(client, geometryUri, geometryText)
+    didOpen(client, mainUri, mainText)
+    await client.waitFor((message) => {
+      const diagnostics = publishedDiagnostics(message, mainUri)
+      return diagnostics !== undefined && diagnostics.length === 0 ? diagnostics : undefined
+    })
+
+    const declaration = { line: 0, character: geometryText.indexOf('area') }
+    client.send({
+      id: 2,
+      method: 'textDocument/references',
+      params: {
+        textDocument: { uri: geometryUri },
+        position: declaration,
+        context: { includeDeclaration: true },
+      },
+    })
+    const locations = (await client.waitFor((message) => response(message, 2))) as Array<{
+      uri: string
+    }>
+    assert.deepEqual(
+      locations.map((location) => location.uri),
+      [geometryUri, mainUri],
+    )
+
+    client.send({
+      id: 3,
+      method: 'textDocument/rename',
+      params: {
+        textDocument: { uri: geometryUri },
+        position: declaration,
+        newName: 'surface',
+      },
+    })
+    const edit = (await client.waitFor((message) => response(message, 3))) as {
+      changes: Record<string, Array<{ newText: string }>>
+    }
+    assert.deepEqual(Object.keys(edit.changes).sort(), [geometryUri, mainUri])
+    assert.deepEqual(
+      edit.changes[mainUri]?.map((change) => change.newText),
+      ['surface'],
+    )
+
+    client.send({
+      id: 4,
+      method: 'textDocument/rename',
+      params: { textDocument: { uri: geometryUri }, position: declaration, newName: 'perimeter' },
+    })
+    const refused = await client.waitFor((message) => failure(message, 4))
+    assert.include(refused.message, 'SEM0016')
+
+    client.send({
+      id: 5,
+      method: 'textDocument/prepareRename',
+      params: { textDocument: { uri: geometryUri }, position: { line: 0, character: 1 } },
+    })
+    const unrenameable = await client.waitFor((message) => failure(message, 5))
+    assert.include(unrenameable.message, 'no renameable declaration')
   } finally {
     await client.close()
   }

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -656,6 +656,53 @@ it('serves project-wide references and renames over real stdio', { timeout: 30_0
     })
     const unrenameable = await client.waitFor((message) => failure(message, 5))
     assert.include(unrenameable.message, 'no renameable declaration')
+
+    // A name the installed toolchain declares is refused outright: applying the edit would rewrite
+    // the standard library shipped with the compiler, for this project and every other one.
+    const toolchainUri = 'file:///silk-lsp-e2e/rename/Toolchain.silk'
+    const toolchainText =
+      'import silk.bool { equals }\npub fn same() -> bool { return equals(true, true) }'
+    didOpen(client, toolchainUri, toolchainText)
+    await client.waitFor((message) => {
+      const diagnostics = publishedDiagnostics(message, toolchainUri)
+      return diagnostics !== undefined && diagnostics.length === 0 ? diagnostics : undefined
+    })
+    const imported = { line: 0, character: toolchainText.indexOf('equals') }
+
+    client.send({
+      id: 6,
+      method: 'textDocument/rename',
+      params: { textDocument: { uri: toolchainUri }, position: imported, newName: 'sameAs' },
+    })
+    const toolchainRefusal = await client.waitFor((message) => failure(message, 6))
+    assert.include(toolchainRefusal.message, 'LSP0002')
+    assert.include(toolchainRefusal.message, 'silk/bool')
+
+    client.send({
+      id: 7,
+      method: 'textDocument/prepareRename',
+      params: { textDocument: { uri: toolchainUri }, position: imported },
+    })
+    const unofferable = await client.waitFor((message) => failure(message, 7))
+    assert.include(unofferable.message, 'no renameable declaration')
+
+    // References stay read-only, so the toolchain declaration is still listed for the same name.
+    client.send({
+      id: 8,
+      method: 'textDocument/references',
+      params: {
+        textDocument: { uri: toolchainUri },
+        position: imported,
+        context: { includeDeclaration: true },
+      },
+    })
+    const toolchainLocations = (await client.waitFor((message) => response(message, 8))) as Array<{
+      uri: string
+    }>
+    assert.isTrue(
+      toolchainLocations.some((location) => location.uri.endsWith('/stdlib/silk/bool.silk')),
+      JSON.stringify(toolchainLocations),
+    )
   } finally {
     await client.close()
   }


### PR DESCRIPTION
Closes #46

Stacked on #56 (`agent/45-diagnostic-edits`) — the LSP lane shares `packages/lsp/src/`, so this branches from that PR rather than `main`. Review the two-commit delta on top of #56.

## What this does

`Document.references`, `Document.prepareRename`, and `Document.rename` read the same token-level occurrence index that backs go-to-definition, in the opposite direction: every occurrence whose `SemanticOccurrence.identityKey` equals the identity selected at the request position. `Server.ts` advertises `referencesProvider` and `renameProvider: { prepareProvider: true }` and wires the three handlers, failing prepare-rename and refused renames with `LSPErrorCodes.RequestFailed`.

Two correctness devices are worth calling out, since a rename that edits some but not all references is worse than no rename at all:

- **Project-wide, not root-scoped.** A root view's `closure.rootModule` names one root, but `ModuleClosure.view` keeps the whole project's `modules` and `sources`, and the occurrence index spans every module of the accepted project revision. Enumerating `Analysis.sources` therefore reaches every module, not just the request document's import closure.
- **Spelling-filtered rename.** An imported member and its local alias share one semantic identity, so `area` and `region` in `import geometry { area as region }` are the same identity with different spellings. References returns both (they *are* the same identity). Rename edits only the occurrences whose analyzed spelling equals the selected name, so renaming the source name yields `import geometry { surface as region }` with `region`'s uses untouched, and renaming the alias leaves the declaration alone. A rename that cannot place some occurrence in a document is refused outright rather than emitted partially.

The `SEM0016` check runs against each module whose *flat namespace* the rename would extend — the declaration site and import bindings — via `Analysis.lookupName` plus `Diagnostic.bindingConflict`. A module that reaches the declaration only through a qualifier (`geometry.area`) keeps its own unrelated top-level names, which is why the check is scoped by occurrence role rather than applied to every edited module.

## Note on scope

Requirement 8 says the `WorkspaceEdit` must cover "every module in the project". The server's project is the accepted project revision: open documents as roots plus every module they transitively import (closed project files included, resolved from disk). A *closed* module that imports the renamed declaration is not part of that closure and is not edited, because rooting analysis at open documents is what `language-server-synchronization`'s "Open documents form project-scoped overlays" requirement specifies; widening the root set is a synchronization change, not a navigation one. The spec text added here says "every module of the accepted project revision" so the boundary is stated rather than implied. This is a visible failure mode (the closed module stops compiling), not a silent one, and the issue puts renames across a project that does not compile out of scope.

## Acceptance criteria

- [x] A test asserts that the initialize response advertises `referencesProvider` and `renameProvider` — `serves project-wide references and renames over real stdio` in `packages/lsp/test/Server.test.ts`.
- [x] A test finds every use of one declaration across two modules — `finds every use of one declaration across two modules`, which also asserts `includeDeclaration: false` removes exactly the declaration-site occurrence.
- [x] A test renames a declaration and asserts the `WorkspaceEdit` covers both modules — `renames a declaration with one workspace edit covering both modules`, plus the stdio test.
- [x] A test rejects a rename to a name that already exists at the top level — `refuses a rename that collides with a top-level name in any edited module`, covering both a collision in the declaring module and one in an importing module's flat namespace.
- [x] A test asserts a prepare-rename request on a keyword token fails — `prepares a rename on a name token but fails on a keyword`, over the wire too.
- [x] The `language-server-navigation` spec gets a requirement for references and one for rename — two requirements with nine scenarios in `openspec/specs/language-server-navigation/spec.md`.

One extra test beyond the criteria, `renames the imported source name without disturbing a local alias`, guards the aliased-import case described above.

Tests: baseline 3 failures, after 3 failures, +6 new tests
`packages/lsp`: before 46 passed / 0 failed, after 52 passed / 0 failed

The 3 baseline failures are the pre-existing `packages/compiler/test/Instances.test.ts` host-triple golden mismatches (goldens recorded for `aarch64-apple-darwin`, host here is `x86_64-unknown-linux-gnu`); this change touches no compiler source. `test/OsFileSystem.test.ts > lowers the OS directory-list provider runner` failed once under parallel load and passes in isolation (`--maxWorkers=1`, 10/10). `pnpm typecheck` and `pnpm exec biome check .` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_