### PR TITLE
operators: Add bitwise operator spellings for &amp; | ^ ~

### DIFF
--- a/examples/language-pressure/lexer/main.silk
+++ b/examples/language-pressure/lexer/main.silk
@@ -11,6 +11,8 @@ const tokenConst: u8 = 67
 const tokenInvalidStaticLiteral: u8 = 68
 const tokenService: u8 = 69
 const tokenInterface: u8 = 70
+const tokenCaret: u8 = 71
+const tokenTilde: u8 = 72
 
 struct Token {
   kind: u8
@@ -114,6 +116,8 @@ fn isPunctuation(byte: u8) -> bool {
   if byte == 62 { return true }
   if byte == 124 { return true }
   if byte == 38 { return true }
+  if byte == 94 { return true }
+  if byte == 126 { return true }
   return byte == 46
 }
 
@@ -204,6 +208,8 @@ fn punctuationKind(byte: u8) -> u8 {
   if byte == 62 { return 57 }
   if byte == 124 { return 59 }
   if byte == 38 { return 61 }
+  if byte == 94 { return tokenCaret }
+  if byte == 126 { return tokenTilde }
   if byte == 46 { return 62 }
   return 65
 }

--- a/openspec/specs/bootstrap-lexer/spec.md
+++ b/openspec/specs/bootstrap-lexer/spec.md
@@ -154,10 +154,10 @@ spelling SHALL remain one identifier token.
 
 ### Requirement: Expression operators use deterministic longest tokens
 
-The lexer SHALL recognize `+`, `-`, `*`, `/`, `%`, `!`, `<`, `<=`, `>`, `>=`, `==`, `!=`, and
-`|>` as distinct operator tokens with exact source spans. Longest recognition SHALL prefer `->`
-over `-`, `<=` over `<`, `>=` over `>`, `==` over `=`, `!=` over `!`, and `|>` over unsupported
-prefix fragments. `//` SHALL continue to begin a line comment while a single `/` SHALL be the
+The lexer SHALL recognize `+`, `-`, `*`, `/`, `%`, `!`, `<`, `<=`, `>`, `>=`, `==`, `!=`, `&`,
+`|`, `^`, `~`, and `|>` as distinct operator tokens with exact source spans. Longest recognition
+SHALL prefer `->` over `-`, `<=` over `<`, `>=` over `>`, `==` over `=`, `!=` over `!`, and `|>`
+over a bare `|`. `//` SHALL continue to begin a line comment while a single `/` SHALL be the
 division token. Operator recognition SHALL preserve the existing lossless coverage and invalid-byte
 recovery guarantees.
 
@@ -165,6 +165,11 @@ recovery guarantees.
 
 - **WHEN** source contains the complete operator vocabulary separated by trivia
 - **THEN** each spelling produces one supported token with its exact span and source slice
+
+#### Scenario: Lex the bitwise operator bytes
+
+- **WHEN** source contains `& | ^ ~ |>`
+- **THEN** the four bitwise spellings are punctuation tokens, `|>` still wins over a bare `|`, and no unsupported-byte diagnostic is reported
 
 #### Scenario: Prefer comments over division pairs
 

--- a/openspec/specs/bootstrap-operator-semantics/spec.md
+++ b/openspec/specs/bootstrap-operator-semantics/spec.md
@@ -7,7 +7,7 @@ data-first behavior while giving source programs conventional precedence and pip
 ## Requirements
 ### Requirement: Operators resolve homogeneously across integers
 
-Arithmetic and comparison operators SHALL resolve only for compatible operands of the same integer type. They SHALL select that type's signed or unsigned checked semantics without implicit conversion, overload lookup, truthiness, or operand reordering. Prefix negation SHALL support signed integers only; logical negation SHALL support `bool` only.
+Arithmetic, bitwise, and comparison operators SHALL resolve only for compatible operands of the same integer type. They SHALL select that type's signed or unsigned checked semantics without implicit conversion, overload lookup, truthiness, or operand reordering. Prefix negation SHALL support signed integers only; logical negation SHALL support `bool` only; bitwise complement SHALL support integers only. Each bitwise operator SHALL select exactly the operation its named counterpart selects — `&` selects `bitAnd`, `|` selects `bitOr`, `^` selects `bitXor`, and prefix `~` selects `bitNot` — without introducing an intrinsic of its own.
 
 #### Scenario: Resolve unsigned multiplication
 
@@ -19,15 +19,38 @@ Arithmetic and comparison operators SHALL resolve only for compatible operands o
 - **WHEN** operands have types `i32` and `i64`
 - **THEN** operator analysis rejects them without conversion
 
+#### Scenario: Resolve a bitwise operator to its named operation
+
+- **WHEN** both operands of `&` are `u32`
+- **THEN** the operator selects `u32.bitAnd` and `a & b` evaluates to the same value as `u32.bitAnd(a, b)`
+
+#### Scenario: Reject a mixed-width bitwise operand pair
+
+- **WHEN** operands of `&` have types `u32` and `i32`
+- **THEN** operator analysis rejects them exactly as it rejects the same pair passed to `u32.bitAnd`
+
 ### Requirement: The bootstrap operator surface is closed and ordered
 
-The language SHALL recognize prefix `-` and `!`; multiplicative `*`, `/`, and `%`; additive `+`
-and `-`; relational `<`, `<=`, `>`, and `>=`; equality `==` and `!=`; and pipeline `|>`. Grouping
-parentheses SHALL override precedence. Primary and grouped expressions SHALL bind most tightly,
+The language SHALL recognize prefix `-`, `!`, and `~`; multiplicative `*`, `/`, and `%`; additive
+`+` and `-`; relational `<`, `<=`, `>`, and `>=`; equality `==` and `!=`; bitwise `&`, `^`, and
+`|`; and pipeline `|>`. Grouping parentheses SHALL override precedence.
+Primary and grouped expressions SHALL bind most tightly,
 followed by right-associative prefix operators, left-associative multiplicative operators,
 left-associative additive operators, non-associative relational operators, non-associative equality
-operators, and left-associative pipelines. Chaining a non-associative comparison without explicit
+operators, left-associative bitwise operators, and left-associative pipelines. The three bitwise
+operators SHALL share one precedence level, so `a | b & c` groups as `(a | b) & c` and only
+grouping parentheses may reorder them. Chaining a non-associative comparison without explicit
 grouping SHALL be a parser error rather than an implicit multi-way comparison.
+
+#### Scenario: Bind bitwise operators below equality and above pipelines
+
+- **WHEN** a body spells `a & b |> f`
+- **THEN** the expression groups as `(a & b) |> f`, and `a & b == c` groups as `a & (b == c)`
+
+#### Scenario: Apply bitwise left associativity
+
+- **WHEN** a body returns `8 | 1 & 2`
+- **THEN** the expression groups as `(8 | 1) & 2` and evaluates to `0`
 
 #### Scenario: Apply arithmetic precedence
 

--- a/openspec/specs/bootstrap-operator-semantics/spec.md
+++ b/openspec/specs/bootstrap-operator-semantics/spec.md
@@ -36,21 +36,28 @@ The language SHALL recognize prefix `-`, `!`, and `~`; multiplicative `*`, `/`, 
 `|`; and pipeline `|>`. Grouping parentheses SHALL override precedence.
 Primary and grouped expressions SHALL bind most tightly,
 followed by right-associative prefix operators, left-associative multiplicative operators,
-left-associative additive operators, non-associative relational operators, non-associative equality
-operators, left-associative bitwise operators, and left-associative pipelines. The three bitwise
-operators SHALL share one precedence level, so `a | b & c` groups as `(a | b) & c` and only
-grouping parentheses may reorder them. Chaining a non-associative comparison without explicit
+left-associative additive operators, the three left-associative bitwise operators, non-associative
+relational operators, non-associative equality operators, and left-associative pipelines. The
+bitwise operators SHALL occupy three distinct precedence levels that bind tighter than every
+comparison and looser than every additive operator, ordered `&` tighter than `^` and `^` tighter
+than `|`, so `a | b & c` groups as `a | (b & c)` and `a & b == c` groups as `(a & b) == c`.
+Chaining a non-associative comparison without explicit
 grouping SHALL be a parser error rather than an implicit multi-way comparison.
 
-#### Scenario: Bind bitwise operators below equality and above pipelines
+#### Scenario: Bind bitwise operators above comparison and above pipelines
 
 - **WHEN** a body spells `a & b |> f`
-- **THEN** the expression groups as `(a & b) |> f`, and `a & b == c` groups as `a & (b == c)`
+- **THEN** the expression groups as `(a & b) |> f`, and `a & b == c` groups as `(a & b) == c`
+
+#### Scenario: Order the three bitwise levels against one another
+
+- **WHEN** a body returns `8 | 1 ^ 3 & 2`
+- **THEN** the expression groups as `8 | (1 ^ (3 & 2))` and evaluates to `11`
 
 #### Scenario: Apply bitwise left associativity
 
 - **WHEN** a body returns `8 | 1 & 2`
-- **THEN** the expression groups as `(8 | 1) & 2` and evaluates to `0`
+- **THEN** the expression groups as `8 | (1 & 2)` and evaluates to `8`
 
 #### Scenario: Apply arithmetic precedence
 

--- a/packages/compiler/src/Lexer.ts
+++ b/packages/compiler/src/Lexer.ts
@@ -58,6 +58,8 @@ const isPunctuation = (byte: number | undefined): boolean =>
   byte === 0x3e ||
   byte === 0x7c ||
   byte === 0x26 ||
+  byte === 0x5e ||
+  byte === 0x7e ||
   byte === 0x2e
 
 const compoundPunctuationKind = (
@@ -231,6 +233,10 @@ const punctuationKind = (byte: number | undefined): Token.TokenKind => {
       return 'Pipe'
     case 0x26:
       return 'Ampersand'
+    case 0x5e:
+      return 'Caret'
+    case 0x7e:
+      return 'Tilde'
     case 0x2e:
       return 'Dot'
     default:

--- a/packages/compiler/src/Operator.ts
+++ b/packages/compiler/src/Operator.ts
@@ -67,6 +67,24 @@ const infixByToken: Readonly<Partial<Record<Token.TokenKind, InfixInfo>>> = Obje
     precedence: 40,
     associativity: 'Left',
   }),
+  Ampersand: Object.freeze({
+    operator: 'BitAnd',
+    spelling: '&',
+    precedence: 37,
+    associativity: 'Left',
+  }),
+  Caret: Object.freeze({
+    operator: 'BitXor',
+    spelling: '^',
+    precedence: 35,
+    associativity: 'Left',
+  }),
+  Pipe: Object.freeze({
+    operator: 'BitOr',
+    spelling: '|',
+    precedence: 33,
+    associativity: 'Left',
+  }),
   Less: Object.freeze({
     operator: 'LessThan',
     spelling: '<',
@@ -102,24 +120,6 @@ const infixByToken: Readonly<Partial<Record<Token.TokenKind, InfixInfo>>> = Obje
     spelling: '!=',
     precedence: 20,
     associativity: 'None',
-  }),
-  Ampersand: Object.freeze({
-    operator: 'BitAnd',
-    spelling: '&',
-    precedence: 15,
-    associativity: 'Left',
-  }),
-  Caret: Object.freeze({
-    operator: 'BitXor',
-    spelling: '^',
-    precedence: 15,
-    associativity: 'Left',
-  }),
-  Pipe: Object.freeze({
-    operator: 'BitOr',
-    spelling: '|',
-    precedence: 15,
-    associativity: 'Left',
   }),
 })
 

--- a/packages/compiler/src/Operator.ts
+++ b/packages/compiler/src/Operator.ts
@@ -2,7 +2,7 @@ import * as Scalar from './Scalar.js'
 import type * as Token from './Token.js'
 
 /** Prefix operators supported by the bootstrap expression grammar. */
-export type Prefix = 'Negate' | 'Not'
+export type Prefix = 'Negate' | 'Not' | 'BitNot'
 
 /** Infix operators supported by the bootstrap expression grammar. */
 export type Infix =
@@ -17,6 +17,9 @@ export type Infix =
   | 'GreaterOrEqual'
   | 'Equals'
   | 'NotEquals'
+  | 'BitAnd'
+  | 'BitOr'
+  | 'BitXor'
 
 /** The associativity used when parsing one infix precedence level. */
 export type Associativity = 'Left' | 'None'
@@ -100,12 +103,31 @@ const infixByToken: Readonly<Partial<Record<Token.TokenKind, InfixInfo>>> = Obje
     precedence: 20,
     associativity: 'None',
   }),
+  Ampersand: Object.freeze({
+    operator: 'BitAnd',
+    spelling: '&',
+    precedence: 15,
+    associativity: 'Left',
+  }),
+  Caret: Object.freeze({
+    operator: 'BitXor',
+    spelling: '^',
+    precedence: 15,
+    associativity: 'Left',
+  }),
+  Pipe: Object.freeze({
+    operator: 'BitOr',
+    spelling: '|',
+    precedence: 15,
+    associativity: 'Left',
+  }),
 })
 
 /** Returns the prefix operator represented by one token kind. */
 export const prefix = (kind: Token.TokenKind): Prefix | undefined => {
   if (kind === 'Minus') return 'Negate'
   if (kind === 'Bang') return 'Not'
+  if (kind === 'Tilde') return 'BitNot'
   return undefined
 }
 
@@ -113,7 +135,8 @@ export const prefix = (kind: Token.TokenKind): Prefix | undefined => {
 export const infix = (kind: Token.TokenKind): InfixInfo | undefined => infixByToken[kind]
 
 /** Returns the canonical source spelling of one prefix operator. */
-export const prefixSpelling = (self: Prefix): string => (self === 'Negate' ? '-' : '!')
+export const prefixSpelling = (self: Prefix): string =>
+  self === 'Negate' ? '-' : self === 'Not' ? '!' : '~'
 
 const operationByOperator: Readonly<
   Record<Exclude<Prefix | Infix, 'Equals' | 'NotEquals'>, string>
@@ -129,7 +152,22 @@ const operationByOperator: Readonly<
   LessOrEqual: 'lessOrEqual',
   GreaterThan: 'greaterThan',
   GreaterOrEqual: 'greaterOrEqual',
+  BitAnd: 'bitAnd',
+  BitOr: 'bitOr',
+  BitXor: 'bitXor',
+  BitNot: 'bitNot',
 })
+
+/**
+ * True only for the operators that spell an integer bitwise operation.
+ *
+ * Only integers carry `bitAnd`, `bitOr`, `bitXor`, and `bitNot`, so a bitwise operator over a
+ * float or Boolean operand selects the default integer instead. Analysis then reports the same
+ * operand-type diagnostic the named function reports, rather than looking up an actor operation
+ * that does not exist.
+ */
+const isBitwise = (self: Prefix | Infix): boolean =>
+  self === 'BitAnd' || self === 'BitOr' || self === 'BitXor' || self === 'BitNot'
 
 /** Returns the canonical actor operation for an operator and its selected equality actor. */
 export const target = (
@@ -160,7 +198,8 @@ export const target = (
             selected.category === 'Boolean' ||
             (self === 'Negate' &&
               selected.category === 'Integer' &&
-              selected.signedness !== 'Signed')
+              selected.signedness !== 'Signed') ||
+            (isBitwise(self) && selected.category !== 'Integer')
           ? Scalar.defaultInteger.spelling
           : equalityActor,
     operation: operationByOperator[self],

--- a/packages/compiler/src/Parser.ts
+++ b/packages/compiler/src/Parser.ts
@@ -203,6 +203,7 @@ const expressionStarts: ReadonlyArray<Token.TokenKind> = Object.freeze([
   'FalseKeyword',
   'Minus',
   'Bang',
+  'Tilde',
   'LeftParenthesis',
   'LeftBracket',
   'MatchKeyword',
@@ -422,7 +423,7 @@ const primaryKind = (
         : significantKindAfter(state, 1) === 'DecimalFloat'
           ? 'Floating'
           : 'Prefix'
-    if (token.kind === 'Bang') return 'Prefix'
+    if (token.kind === 'Bang' || token.kind === 'Tilde') return 'Prefix'
     if (token.kind === 'TrueKeyword' || token.kind === 'FalseKeyword') return 'Boolean'
     if (token.kind === 'MoveKeyword') return 'Move'
     if (token.kind === 'EffectKeyword' && significantKindAfter(state, 1) === 'LeftBrace')
@@ -1159,7 +1160,8 @@ function parsePrefixExpression(
     return parseProjectionChain(
       parsePrimaryExpression(initial, reservedForEnclosingCalls, recoveryKind, allowStructLiteral),
     )
-  const tokenKind = nextSignificantKind(initial) === 'Bang' ? 'Bang' : 'Minus'
+  const nextKind = nextSignificantKind(initial)
+  const tokenKind = nextKind === 'Bang' || nextKind === 'Tilde' ? nextKind : 'Minus'
   const operator = expect(initial, tokenKind, [...expressionStarts, ...expressionFollowing])
   const operand = parsePrefixExpression(
     operator.state,

--- a/packages/compiler/src/Token.ts
+++ b/packages/compiler/src/Token.ts
@@ -68,6 +68,8 @@ export type TokenKind =
   | 'Pipe'
   | 'PipeGreater'
   | 'Ampersand'
+  | 'Caret'
+  | 'Tilde'
   | 'Dot'
   | 'DotDot'
   | 'Arrow'
@@ -141,6 +143,8 @@ const descriptions: Readonly<Record<TokenKind, string>> = Object.freeze({
   Pipe: '`|`',
   PipeGreater: '`|>`',
   Ampersand: '`&`',
+  Caret: '`^`',
+  Tilde: '`~`',
   Dot: '`.`',
   DotDot: '`..`',
   Arrow: '`->`',

--- a/packages/compiler/test/BitwiseOperatorAcceptance.test.ts
+++ b/packages/compiler/test/BitwiseOperatorAcceptance.test.ts
@@ -1,0 +1,164 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-bitwise-operator-acceptance-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const parity = `pub fn checksum(value: u32, mask: u32) -> u32 {
+  let masked = value & mask
+  let flipped = ~masked
+  return flipped ^ mask
+}
+
+fn named(value: u32, mask: u32) -> u32 {
+  return u32.bitXor(u32.bitNot(u32.bitAnd(value, mask)), mask)
+}
+
+fn agrees(a: u32, b: u32) -> u32 {
+  if (a & b) == u32.bitAnd(a, b) {} else { return 1 }
+  if (a | b) == u32.bitOr(a, b) {} else { return 2 }
+  if (a ^ b) == u32.bitXor(a, b) {} else { return 3 }
+  if ~a == u32.bitNot(a) {} else { return 4 }
+  if checksum(a, b) == named(a, b) {} else { return 5 }
+  return 0
+}
+
+fn leftAssociative(a: u32, b: u32, c: u32) -> u32 { return a | b & c }
+
+fn doubled(value: u32) -> u32 { return value * 2 }
+
+fn piped(a: u32, b: u32) -> u32 { return a & b |> doubled }
+
+pub fn main() -> i32 {
+  if agrees(3988292384, 255) == 0 {} else { return 1 }
+  if agrees(0xff, 0x0f) == 0 {} else { return 2 }
+  if agrees(0b1010, 0b0110) == 0 {} else { return 3 }
+  if agrees(1_0, 3) == 0 {} else { return 4 }
+  if leftAssociative(8, 1, 2) == u32.bitAnd(u32.bitOr(8, 1), 2) {} else { return 5 }
+  if leftAssociative(8, 1, 2) == 0 {} else { return 6 }
+  if piped(12, 10) == 16 {} else { return 7 }
+  if checksum(12, 10) == 4294967293 {} else { return 8 }
+  return 42
+}`
+
+it.effect(
+  'compiles the four bitwise operators to their named operations on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'bitwise-operator/parity',
+        ascii(parity),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(
+        evaluated._tag,
+        'Completed',
+        JSON.stringify(evaluated, (_, value) =>
+          typeof value === 'bigint' ? value.toString() : value,
+        ),
+      )
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
+
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make('bitwise-operator/parity', ascii(parity)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'parity'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 42, run.stderr)
+    }),
+  60_000,
+)
+
+it.effect('gives `a & b` the value the named operation gives', () =>
+  Effect.gen(function* () {
+    const source = `fn viaOperator(a: u32, b: u32) -> u32 { return a & b }
+fn viaFunction(a: u32, b: u32) -> u32 { return u32.bitAnd(a, b) }
+
+pub fn main() -> i32 {
+  if viaOperator(3988292384, 255) == viaFunction(3988292384, 255) {} else { return 1 }
+  if viaOperator(3988292384, 255) == 32 {} else { return 2 }
+  return 42
+}`
+    const snapshot = yield* Analysis.ofSourceRealized('bitwise-operator/bit-and', ascii(source))
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+  }),
+)
+
+it.effect('rejects mixed operand types exactly as the named operation rejects them', () =>
+  Effect.gen(function* () {
+    const viaOperator = yield* Analysis.ofSourceRealized(
+      'bitwise-operator/mixed-operator',
+      ascii(`fn mixed(a: u32, b: i32) -> u32 { return a & b }
+pub fn main() -> i32 { return 0 }`),
+    )
+    const viaFunction = yield* Analysis.ofSourceRealized(
+      'bitwise-operator/mixed-function',
+      ascii(`fn mixed(a: u32, b: i32) -> u32 { return u32.bitAnd(a, b) }
+pub fn main() -> i32 { return 0 }`),
+    )
+
+    const operatorCodes = Analysis.diagnostics(viaOperator).map((diagnostic) => diagnostic.code)
+    assert.notStrictEqual(operatorCodes.length, 0)
+    assert.deepEqual(
+      operatorCodes,
+      Analysis.diagnostics(viaFunction).map((diagnostic) => diagnostic.code),
+    )
+  }),
+)
+
+it.effect('binds the bitwise operators below equality', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'bitwise-operator/equality-binding',
+      ascii(`fn f(a: u32, b: u32, c: u32) -> u32 { return a & b == c }
+pub fn main() -> i32 { return 0 }`),
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      ['SEM0012'],
+      '`a & b == c` groups as `a & (b == c)`, so the right operand is a bool',
+    )
+  }),
+)
+
+it.effect('reports a type diagnostic instead of failing on a float bitwise operand', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'bitwise-operator/float',
+      ascii(`fn f(a: f64, b: f64) -> f64 { return a & b }
+fn g(a: f64) -> f64 { return ~a }
+pub fn main() -> i32 { return 0 }`),
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      ['SEM0012', 'SEM0012'],
+    )
+  }),
+)

--- a/packages/compiler/test/BitwiseOperatorAcceptance.test.ts
+++ b/packages/compiler/test/BitwiseOperatorAcceptance.test.ts
@@ -6,14 +6,69 @@ import { afterAll, assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
 import * as Driver from '../src/Driver.js'
+import * as Lexer from '../src/Lexer.js'
+import * as Parser from '../src/Parser.js'
 import * as SourceFile from '../src/SourceFile.js'
 import * as SourceResolver from '../src/SourceResolver.js'
+import * as SyntaxTree from '../src/SyntaxTree.js'
+import type * as Token from '../src/Token.js'
 
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
 
 const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-bitwise-operator-acceptance-'))
 afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const infixOperatorKinds: ReadonlyArray<Token.TokenKind> = Object.freeze([
+  'Star',
+  'Slash',
+  'Percent',
+  'Plus',
+  'Minus',
+  'Ampersand',
+  'Caret',
+  'Pipe',
+  'Less',
+  'LessEqual',
+  'Greater',
+  'GreaterEqual',
+  'EqualEqual',
+  'BangEqual',
+])
+
+const outermostInfix = (element: SyntaxTree.Element): SyntaxTree.Node | undefined => {
+  if (!SyntaxTree.isNode(element)) return undefined
+  if (element.kind === 'InfixExpression') return element
+  for (const child of element.children) {
+    const found = outermostInfix(child)
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
+type InfixShape = string | readonly [string, InfixShape, InfixShape]
+
+const shapeOf = (element: SyntaxTree.Element): InfixShape => {
+  if (!SyntaxTree.isNode(element) || element.kind !== 'InfixExpression') return 'operand'
+  const kind = infixOperatorKinds.find(
+    (candidate) => SyntaxTree.directToken(element, candidate) !== undefined,
+  )
+  const operands = element.children.filter(SyntaxTree.isNode)
+  const left = operands.at(0)
+  const right = operands.at(-1)
+  return [
+    kind ?? 'unknown',
+    left === undefined ? 'operand' : shapeOf(left),
+    right === undefined || operands.length < 2 ? 'operand' : shapeOf(right),
+  ]
+}
+
+/** Returns the nested operator shape of the first infix expression one source spells. */
+const infixShape = (source: string): InfixShape => {
+  const file = Parser.parse(Lexer.lex(SourceFile.make('bitwise-operator/shape', ascii(source))))
+  const outermost = outermostInfix(file.root)
+  return outermost === undefined ? 'operand' : shapeOf(outermost)
+}
 
 const parity = `pub fn checksum(value: u32, mask: u32) -> u32 {
   let masked = value & mask
@@ -34,7 +89,13 @@ fn agrees(a: u32, b: u32) -> u32 {
   return 0
 }
 
-fn leftAssociative(a: u32, b: u32, c: u32) -> u32 { return a | b & c }
+fn tiered(a: u32, b: u32, c: u32) -> u32 { return a | b & c }
+
+fn tieredThree(a: u32, b: u32, c: u32, d: u32) -> u32 { return a | b ^ c & d }
+
+fn leftAssociative(a: u32, b: u32, c: u32) -> u32 { return a | b | c }
+
+fn aboveComparison(a: u32, b: u32, c: u32) -> bool { return a & b == c }
 
 fn doubled(value: u32) -> u32 { return value * 2 }
 
@@ -45,10 +106,15 @@ pub fn main() -> i32 {
   if agrees(0xff, 0x0f) == 0 {} else { return 2 }
   if agrees(0b1010, 0b0110) == 0 {} else { return 3 }
   if agrees(1_0, 3) == 0 {} else { return 4 }
-  if leftAssociative(8, 1, 2) == u32.bitAnd(u32.bitOr(8, 1), 2) {} else { return 5 }
-  if leftAssociative(8, 1, 2) == 0 {} else { return 6 }
-  if piped(12, 10) == 16 {} else { return 7 }
-  if checksum(12, 10) == 4294967293 {} else { return 8 }
+  if tiered(8, 1, 2) == u32.bitOr(8, u32.bitAnd(1, 2)) {} else { return 5 }
+  if tiered(8, 1, 2) == 8 {} else { return 6 }
+  if tieredThree(8, 1, 3, 2) == u32.bitOr(8, u32.bitXor(1, u32.bitAnd(3, 2))) {} else { return 7 }
+  if tieredThree(8, 1, 3, 2) == 11 {} else { return 8 }
+  if leftAssociative(8, 1, 2) == 11 {} else { return 9 }
+  if aboveComparison(12, 10, 8) {} else { return 10 }
+  if aboveComparison(12, 10, 9) == false {} else { return 11 }
+  if piped(12, 10) == 16 {} else { return 12 }
+  if checksum(12, 10) == 4294967293 {} else { return 13 }
   return 42
 }`
 
@@ -133,17 +199,59 @@ pub fn main() -> i32 { return 0 }`),
   }),
 )
 
-it.effect('binds the bitwise operators below equality', () =>
+it.effect('binds the bitwise operators above comparison', () =>
   Effect.gen(function* () {
     const snapshot = yield* Analysis.ofSourceRealized(
-      'bitwise-operator/equality-binding',
-      ascii(`fn f(a: u32, b: u32, c: u32) -> u32 { return a & b == c }
-pub fn main() -> i32 { return 0 }`),
+      'bitwise-operator/comparison-binding',
+      ascii(`fn masked(a: u32, b: u32, c: u32) -> bool { return a & b == c }
+
+pub fn main() -> i32 {
+  if masked(12, 10, 8) {} else { return 1 }
+  if masked(12, 10, 9) == false {} else { return 2 }
+  return 42
+}`),
     )
     assert.deepEqual(
-      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-      ['SEM0012'],
-      '`a & b == c` groups as `a & (b == c)`, so the right operand is a bool',
+      Analysis.diagnostics(snapshot),
+      [],
+      '`a & b == c` groups as `(a & b) == c`, so both comparison operands are `u32`',
+    )
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+
+    assert.deepEqual(
+      infixShape('fn masked(a: u32, b: u32, c: u32) -> bool { return a & b == c }'),
+      ['EqualEqual', ['Ampersand', 'operand', 'operand'], 'operand'],
+      '`a & b == c` nests the bitwise operator inside equality',
+    )
+  }),
+)
+
+it.effect('orders `&` inside `^` inside `|`', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'bitwise-operator/tier-order',
+      ascii(`fn tiered(a: u32, b: u32, c: u32, d: u32) -> u32 { return a | b ^ c & d }
+fn grouped(a: u32, b: u32, c: u32, d: u32) -> u32 { return a | (b ^ (c & d)) }
+
+pub fn main() -> i32 {
+  if tiered(8, 1, 3, 2) == grouped(8, 1, 3, 2) {} else { return 1 }
+  if tiered(8, 1, 3, 2) == 11 {} else { return 2 }
+  return 42
+}`),
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+
+    assert.deepEqual(
+      infixShape('fn tiered(a: u32, b: u32, c: u32, d: u32) -> u32 { return a | b ^ c & d }'),
+      ['Pipe', 'operand', ['Caret', 'operand', ['Ampersand', 'operand', 'operand']]],
+      '`a | b ^ c & d` nests as `a | (b ^ (c & d))`',
     )
   }),
 )

--- a/packages/compiler/test/Formatter.test.ts
+++ b/packages/compiler/test/Formatter.test.ts
@@ -317,6 +317,34 @@ it.effect('formats a chained else if arm on one line and idempotently', () =>
   }),
 )
 
+it.effect('formats the bitwise operators with canonical spacing and idempotently', () =>
+  Effect.gen(function* () {
+    const first = yield* Formatter.format(
+      parse(
+        'memory://bitwise-format.silk',
+        'pub fn checksum(value:u32,mask:u32)->u32 { let masked = value&mask let flipped = ~masked return flipped^mask|masked }',
+      ),
+    )
+    const text = formattedText(first)
+    assert.strictEqual(
+      text,
+      `pub fn checksum(value: u32, mask: u32) -> u32 {
+  let masked = value & mask
+  let flipped = ~masked
+  return flipped ^ mask | masked
+}
+`,
+    )
+
+    const reparsed = parse('memory://bitwise-format.silk', text)
+    assert.deepEqual(reparsed.lexicalDiagnostics, [])
+    assert.deepEqual(reparsed.parserDiagnostics, [])
+    const second = yield* Formatter.format(reparsed)
+    assert.strictEqual(formattedText(second), text)
+    assert.strictEqual(second.changed, false)
+  }),
+)
+
 it.effect('formats unsafe blocks and conformance declarations canonically and idempotently', () =>
   Effect.gen(function* () {
     const source =

--- a/packages/compiler/test/Lexer.test.ts
+++ b/packages/compiler/test/Lexer.test.ts
@@ -792,6 +792,47 @@ it('lexes the closed operator vocabulary with longest match', () => {
   assert.deepEqual(result.diagnostics, [])
 })
 
+it('lexes all four bitwise bytes as punctuation without an unsupported-byte diagnostic', () => {
+  const source = SourceFile.make('memory/bitwise-operators', ascii('& | ^ ~ |>'))
+  const result = Lexer.lex(source)
+
+  assert.deepEqual(
+    result.tokens.filter((token) => token.kind !== 'Whitespace').map((token) => token.kind),
+    ['Ampersand', 'Pipe', 'Caret', 'Tilde', 'PipeGreater', 'EndOfFile'],
+  )
+  assert.deepEqual(result.diagnostics, [])
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind === 'Caret' || token.kind === 'Tilde')
+      .map((token) => [token.span.start, token.span.end]),
+    [
+      [4, 5],
+      [6, 7],
+    ],
+  )
+})
+
+it('keeps base-prefixed and separated literals intact around the bitwise bytes', () => {
+  const source = SourceFile.make('memory/bitwise-literals', ascii('0xff ^ 0x0f ~0b1010 1_0 ^ 2'))
+  const result = Lexer.lex(source)
+
+  assert.deepEqual(
+    result.tokens.filter((token) => token.kind !== 'Whitespace').map((token) => token.kind),
+    [
+      'DecimalInteger',
+      'Caret',
+      'DecimalInteger',
+      'Tilde',
+      'DecimalInteger',
+      'DecimalInteger',
+      'Caret',
+      'DecimalInteger',
+      'EndOfFile',
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
 it('distinguishes division from line comments', () => {
   const source = SourceFile.make('memory/operator-comments', ascii('/ // comment\n/'))
   const result = Lexer.lex(source)

--- a/packages/compiler/test/LexerPressure.test.ts
+++ b/packages/compiler/test/LexerPressure.test.ts
@@ -83,6 +83,8 @@ const tokenKinds = [
   'Pipe',
   'PipeGreater',
   'Ampersand',
+  'Caret',
+  'Tilde',
   'Dot',
   'DotDot',
   'Arrow',
@@ -166,6 +168,8 @@ const tokenCode: Readonly<Record<Token.TokenKind, number>> = Object.freeze({
   InvalidStaticLiteral: 68,
   ServiceKeyword: 69,
   InterfaceKeyword: 70,
+  Caret: 71,
+  Tilde: 72,
 })
 
 interface ExpectedToken {
@@ -270,7 +274,7 @@ const corpus = [
   }),
   Object.freeze({
     id: 'punctuation',
-    input: '( ) { } [ ] : ; , = == => - + * / % ! != ? @ < <= > >= | |> & . .. ->',
+    input: '( ) { } [ ] : ; , = == => - + * / % ! != ? @ < <= > >= | |> & ^ ~ . .. ->',
   }),
   Object.freeze({ id: 'invalid', input: '#~ pub \u0000? $x' }),
 ] as const

--- a/packages/compiler/test/Operator.test.ts
+++ b/packages/compiler/test/Operator.test.ts
@@ -11,7 +11,9 @@ it('publishes the closed prefix vocabulary', () => {
   assert.strictEqual(Operator.prefixSpelling('BitNot'), '~')
 })
 
-it('orders the bitwise level below equality and above the pipeline', () => {
+it('orders the three bitwise levels between additive and relational operators', () => {
+  const additive = Operator.infix('Plus')
+  const relational = Operator.infix('Less')
   const equality = Operator.infix('EqualEqual')
   const and = Operator.infix('Ampersand')
   const or = Operator.infix('Pipe')
@@ -20,7 +22,15 @@ it('orders the bitwise level below equality and above the pipeline', () => {
   assert.notStrictEqual(and, undefined)
   assert.notStrictEqual(or, undefined)
   assert.notStrictEqual(xor, undefined)
-  if (equality === undefined || and === undefined || or === undefined || xor === undefined) return
+  if (
+    additive === undefined ||
+    relational === undefined ||
+    equality === undefined ||
+    and === undefined ||
+    or === undefined ||
+    xor === undefined
+  )
+    return
 
   assert.deepEqual(
     [and.operator, or.operator, xor.operator],
@@ -29,17 +39,19 @@ it('orders the bitwise level below equality and above the pipeline', () => {
   )
   assert.deepEqual([and.spelling, or.spelling, xor.spelling], ['&', '|', '^'])
   for (const info of [and, or, xor]) {
-    assert.strictEqual(info.precedence < equality.precedence, true)
+    assert.strictEqual(info.precedence < additive.precedence, true)
+    assert.strictEqual(info.precedence > relational.precedence, true)
+    assert.strictEqual(info.precedence > equality.precedence, true)
     assert.strictEqual(info.precedence > Operator.pipelinePrecedence, true)
+    assert.strictEqual(info.precedence < Operator.prefixPrecedence, true)
     assert.strictEqual(info.associativity, 'Left')
     assert.strictEqual(Object.isFrozen(info), true)
   }
   assert.strictEqual(
-    and.precedence === or.precedence && or.precedence === xor.precedence,
+    and.precedence > xor.precedence && xor.precedence > or.precedence,
     true,
-    'the three bitwise spellings share one precedence level',
+    '`&` binds tighter than `^`, which binds tighter than `|`',
   )
-  assert.strictEqual(and.precedence < Operator.prefixPrecedence, true)
 })
 
 it('targets the named bitwise operation of the selected integer actor', () => {

--- a/packages/compiler/test/Operator.test.ts
+++ b/packages/compiler/test/Operator.test.ts
@@ -7,6 +7,53 @@ it('publishes the closed prefix vocabulary', () => {
   assert.strictEqual(Operator.prefix('Plus'), undefined)
   assert.strictEqual(Operator.prefixSpelling('Negate'), '-')
   assert.strictEqual(Operator.prefixSpelling('Not'), '!')
+  assert.strictEqual(Operator.prefix('Tilde'), 'BitNot')
+  assert.strictEqual(Operator.prefixSpelling('BitNot'), '~')
+})
+
+it('orders the bitwise level below equality and above the pipeline', () => {
+  const equality = Operator.infix('EqualEqual')
+  const and = Operator.infix('Ampersand')
+  const or = Operator.infix('Pipe')
+  const xor = Operator.infix('Caret')
+
+  assert.notStrictEqual(and, undefined)
+  assert.notStrictEqual(or, undefined)
+  assert.notStrictEqual(xor, undefined)
+  if (equality === undefined || and === undefined || or === undefined || xor === undefined) return
+
+  assert.deepEqual(
+    [and.operator, or.operator, xor.operator],
+    ['BitAnd', 'BitOr', 'BitXor'],
+    'the three spellings map to the three named bitwise operations',
+  )
+  assert.deepEqual([and.spelling, or.spelling, xor.spelling], ['&', '|', '^'])
+  for (const info of [and, or, xor]) {
+    assert.strictEqual(info.precedence < equality.precedence, true)
+    assert.strictEqual(info.precedence > Operator.pipelinePrecedence, true)
+    assert.strictEqual(info.associativity, 'Left')
+    assert.strictEqual(Object.isFrozen(info), true)
+  }
+  assert.strictEqual(
+    and.precedence === or.precedence && or.precedence === xor.precedence,
+    true,
+    'the three bitwise spellings share one precedence level',
+  )
+  assert.strictEqual(and.precedence < Operator.prefixPrecedence, true)
+})
+
+it('targets the named bitwise operation of the selected integer actor', () => {
+  assert.deepEqual(Operator.target('BitAnd', 'u32'), { actor: 'u32', operation: 'bitAnd' })
+  assert.deepEqual(Operator.target('BitOr', 'u32'), { actor: 'u32', operation: 'bitOr' })
+  assert.deepEqual(Operator.target('BitXor', 'u64'), { actor: 'u64', operation: 'bitXor' })
+  assert.deepEqual(Operator.target('BitNot', 'i64'), { actor: 'i64', operation: 'bitNot' })
+  assert.deepEqual(Operator.target('BitAnd'), { actor: 'i32', operation: 'bitAnd' })
+  assert.deepEqual(
+    Operator.target('BitAnd', 'f64'),
+    { actor: 'i32', operation: 'bitAnd' },
+    'a non-integer actor falls back to the default integer so analysis reports a type diagnostic',
+  )
+  assert.deepEqual(Operator.target('BitNot', 'bool'), { actor: 'i32', operation: 'bitNot' })
 })
 
 it('orders infix operators by immutable precedence metadata', () => {

--- a/packages/compiler/test/fixtures/BootstrapParserFixture.ts
+++ b/packages/compiler/test/fixtures/BootstrapParserFixture.ts
@@ -72,8 +72,8 @@ export const acceptedShape: ExpectedNodeShape = Object.freeze({
 
 export const missingNameSource = 'pub fn () -> i32 { return 42 }'
 export const missingRightBraceSource = 'pub fn main() -> i32 { return 42'
-export const unexpectedPunctuationSource = 'pub fn ^ main() -> i32 { return 42 }'
-export const whollyUnrelatedSource = '^^^'
+export const unexpectedPunctuationSource = 'pub fn $ main() -> i32 { return 42 }'
+export const whollyUnrelatedSource = '$$$'
 export const twoFunctionSource = `pub fn answer() -> i32 { return 42 }
 pub fn main() -> i32 { return 0 }`
 export const threeFunctionSource = `pub fn one() -> i32 { return 1 }
@@ -82,7 +82,7 @@ pub fn three() -> i32 { return 3 }`
 export const missingFirstRightBraceSource = `pub fn answer() -> i32 { return 42
 pub fn main() -> i32 { return 0 }`
 export const interFunctionPunctuationSource = `pub fn answer() -> i32 { return 42 }
-^^
+$$
 pub fn main() -> i32 { return 0 }`
 export const trailingTriviaSource = `pub fn main() -> i32 { return 42 }
 // trailing source trivia

--- a/packages/language/src/CodeMirror.ts
+++ b/packages/language/src/CodeMirror.ts
@@ -94,6 +94,8 @@ const categories: Record<Token.TokenKind, Category | undefined> = {
   Pipe: operator,
   PipeGreater: operator,
   Ampersand: operator,
+  Caret: operator,
+  Tilde: operator,
   Arrow: operator,
   DotDot: punctuation,
   Invalid: { name: 'invalid', tags: [tags.invalid] },

--- a/packages/language/src/TextMate.ts
+++ b/packages/language/src/TextMate.ts
@@ -224,7 +224,7 @@ export const grammar: Grammar = {
       name: 'punctuation.definition.type-arguments.end.silk',
       match: '(?<=[A-Za-z0-9_>\\]\\)])>(?=\\s*(?:>|\\(|\\{|\\[|,|\\)|->|[A-Z][A-Za-z0-9_]*\\b))',
     },
-    { name: 'keyword.operator.silk', match: '=>|->|\\|>|\\||[=!<>]=|[-+*/%!<>=&]' },
+    { name: 'keyword.operator.silk', match: '=>|->|\\|>|\\||[=!<>]=|[-+*/%!<>=&^~]' },
     { name: 'punctuation.definition.pattern.rest.silk', match: '\\.\\.' },
     { name: 'punctuation.silk', match: '[(){}\\[\\]:,.]' },
   ],

--- a/packages/language/test/CodeMirror.test.ts
+++ b/packages/language/test/CodeMirror.test.ts
@@ -43,7 +43,11 @@ it('highlights Markdown links and nested Silk examples inside documentation', ()
 })
 
 it('marks invalid bytes', () => {
-  assert.deepStrictEqual(spellings('let ^', 'invalid'), ['^'])
+  assert.deepStrictEqual(spellings('let $', 'invalid'), ['$'])
+})
+
+it('classifies the bitwise operator spellings as operators', () => {
+  assert.deepStrictEqual(spellings('a & b ^ c | ~d', 'operator'), ['&', '^', '|', '~'])
 })
 
 it('highlights every single-line and multiline literal from compiler token ranges', () => {
@@ -179,6 +183,6 @@ it('the state field re-lexes on edit', () => {
 })
 
 it('invalid tokens carry a distinct stable class', () => {
-  const state = EditorState.create({ doc: 'let ^', extensions: [CodeMirror.extension()] })
+  const state = EditorState.create({ doc: 'let $', extensions: [CodeMirror.extension()] })
   assert.isTrue(stateClasses(state).some((cls) => cls.includes('cm-silk-invalid')))
 })

--- a/packages/language/test/TextMate.test.ts
+++ b/packages/language/test/TextMate.test.ts
@@ -139,6 +139,9 @@ it('assigns keyword, numeric, and comment scopes via a TextMate tokenizer', asyn
   assert.include(scopesAt(match, 'match'), 'keyword.control.silk')
   assert.include(scopesAt(match, '&'), 'keyword.operator.silk')
   assert.include(scopesAt(match, '=>'), 'keyword.operator.silk')
+  const bitwise = 'fn f(a: u32, b: u32) -> u32 { return a & b ^ ~b }'
+  assert.include(scopesAt(bitwise, '^'), 'keyword.operator.silk')
+  assert.include(scopesAt(bitwise, '~'), 'keyword.operator.silk')
   assert.include(scopesAt(match, '..'), 'punctuation.definition.pattern.rest.silk')
   assert.include(scopesAt(match, 'Token'), 'entity.name.type.silk')
   assert.include(scopesAt(match, '_'), 'variable.language.wildcard.silk')

--- a/packages/vscode/syntaxes/silk.tmLanguage.json
+++ b/packages/vscode/syntaxes/silk.tmLanguage.json
@@ -282,7 +282,7 @@
     },
     {
       "name": "keyword.operator.silk",
-      "match": "=>|->|\\|>|\\||[=!<>]=|[-+*/%!<>=&]"
+      "match": "=>|->|\\|>|\\||[=!<>]=|[-+*/%!<>=&^~]"
     },
     {
       "name": "punctuation.definition.pattern.rest.silk",


### PR DESCRIPTION
Closes #6

**Stacked on #59** (`agent/5-else-if`), which is itself stacked on #58 → #53. Review/merge in that order; this PR's base is `agent/5-else-if`, not `main`.

## What changed

`&`, `|`, `^`, and prefix `~` now spell the integer operations that were previously reachable only through `u32.bitAnd`, `bitOr`, `bitXor`, and `bitNot`. No new intrinsic: the operator table points at the operations that already exist in `Scalar.ts`.

- `Lexer.ts` / `Token.ts` — `^` (0x5e) and `~` (0x7e) join the punctuation vocabulary as `Caret` and `Tilde`. Both previously reached the invalid-byte path and produced `LEX0001`. `&` and `|` already lexed.
- `Operator.ts` — `Ampersand`/`Caret`/`Pipe` map to `BitAnd`/`BitXor`/`BitOr` at precedences 37/35/33, left-associative; `Tilde` maps to prefix `BitNot`.
- `Parser.ts` — `~` joins `-` and `!` as a prefix-expression start.
- Spec amendments in `openspec/specs/bootstrap-operator-semantics/spec.md` and `openspec/specs/bootstrap-lexer/spec.md`.

## Precedence

**This deviates from issue #6's Requirement 6 by maintainer decision.** Requirement 6 asks for one bitwise level "below equality, above the pipeline" and does not order the three operators against each other. The maintainer decided to adopt the Rust model instead: three distinct levels, all **above** comparison.

The three infix spellings get three left-associative levels between additive (40) and relational (30) — `&` = 37, `^` = 35, `|` = 33 — so `&` binds tighter than `^`, which binds tighter than `|`, and all three bind tighter than every comparison. Rust orders them exactly this way, and Go, Python, and Swift also place bitwise operators above comparison. The gap above `&` leaves room for `<<` and `>>` when they gain spellings; they remain out of scope here. Prefix `~` is unaffected. Consequences, all pinned by tests and written into the spec:

- `a & b == c` groups as `(a & b) == c` — both comparison operands are `u32`, and it compiles. This avoids the C precedence gotcha rather than reproducing it.
- `a | b & c` groups as `a | (b & c)`, matching C, Rust, Go, Python, and Swift.
- `a | b ^ c & d` groups as `a | (b ^ (c & d))`.
- `a & b |> f` groups as `(a & b) |> f`, unchanged — the pipeline still sits below everything.

`Parser.ts` needed no change for the tiering: it is a precedence-climbing parser driven entirely by the `Operator.ts` table.

## Note on scope

Two changes go past a literal reading of the Requirements, both to avoid accepted source that miscompiles or crashes:

1. **Non-integer actor fallback.** `Operator.target` previously assumed every scalar actor carries every operator's operation. Floats carry no `bitAnd`, so `a & b` over `f64` would have looked up `f64.bitAnd`, found nothing, and thrown `RangeError: Compiler operator table is inconsistent` out of analysis. Bitwise operators now fall back to the default integer when the actor is not an integer, which produces the same `SEM0012` the named function produces. Covered by a test.
2. **Silk-language lexer fixture.** `examples/language-pressure/lexer/main.silk` reimplements the lexer in Silk and is diffed against the canonical one by `LexerPressure.test.ts`. It needed the two new bytes or the corpus fingerprints diverged.

Three parser fixtures used `^` as their canonical unsupported byte (`'pub fn ^ main()...'`, `'^^^'`, `'^^'` between declarations). Since `^` is now valid, they were switched to `$`, which keeps each test exercising invalid-byte recovery as written. Editor surfaces (`CodeMirror.ts`, `TextMate.ts`, and the generated `packages/vscode` grammar) classify the new spellings as operators.

## Acceptance criteria

- [x] The lexer produces tokens for `^` and `~` instead of `LEX0001`.
- [x] A lexer test shows all four bytes as punctuation tokens.
- [x] The four operators compile to the same result as the named functions — three-engine parity (interpreter, Wasm, native clang) in `BitwiseOperatorAcceptance.test.ts`.
- [x] A test shows that `a & b` and `u32.bitAnd(a, b)` give the same value.
- [x] Mixed operand types produce a diagnostic, as the named functions do — the test asserts the operator's diagnostic codes equal the named function's on the same operand pair.
- [x] `openspec/specs/bootstrap-operator-semantics/spec.md` gets an amendment. The `bootstrap-lexer` spec's operator-vocabulary requirement was amended too, since it enumerates exactly which bytes the lexer recognizes and would otherwise be false.
- [x] Requirement 6's ordering is superseded by the maintainer decision above; the spec states the new ordering rather than the one the ticket asked for.

Out of scope per the ticket and untouched here: `<<` and `>>`, the rotates.

Tests: baseline 3 failures, after 3 failures, +12 new tests

The 3 are the pre-existing host-triple golden mismatches in `Instances.test.ts` (goldens target `aarch64-apple-darwin`, host is `x86_64-unknown-linux-gnu`). No golden or fixture moved as a result of the precedence change. `pnpm typecheck` and `pnpm exec biome check .` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_