### PR TITLE
chore(ci): disable the Release workflow while the project is internal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Release
 
+# Disabled while the project is internal and the package names are not settled — publishing now
+# would squat names that are about to change. Re-enable by restoring the `push` trigger below.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why

The `Release` workflow triggered on every push to `main` and runs changesets with `publish: pnpm release:publish:ci`, so a merge could publish packages to npm.

The project is still internal and the package names are expected to change. Publishing now would squat names that are about to be renamed — and with "Allow GitHub Actions to create and approve pull requests" now enabled, the next push to `main` would have proceeded past the point where it previously failed.

## Change

Replaces the `push: branches: [main]` trigger with `workflow_dispatch`. One file, three lines.

The workflow body is untouched, so it stays manually runnable from the Actions tab and re-enabling is a one-line revert of the trigger.

## Notes

- `ci.yml` is untouched — normal CI on `main` and pull requests is unaffected.
- `publish.yml` is the only workflow that can publish; `.github/scripts/publish-with-oidc-guard.mjs` is reachable only from it.
- The `changeset-release/main` branch pushed by the last run is still on the remote. Nothing consumes it now, and it can be deleted or used to cut a release by hand.
- `pnpm test:scripts` passes (8/8).

This is the last red workflow on `main`. `CI` is green as of 6652be4 after the six fixes in #60, #62, and #66; `Release` was failing only at the changesets step.