### PR TITLE
fix(lsp): raise the stdio poll timeout under the per-test budget

### DIFF
--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -50,7 +50,9 @@ const connect = (): Client => {
             return
           }
         }
-        if (Date.now() - startedAt > 15_000) {
+        // Kept under the 30s per-test budget: this inner poll must not be the thing that fires
+        // first, or a slow runner reports a timeout instead of the test's own limit.
+        if (Date.now() - startedAt > 25_000) {
           reject(new Error(`Timed out waiting; saw ${JSON.stringify(messages)}`))
           return
         }


### PR DESCRIPTION
## Problem

`test/Server.test.ts` failed on CI:

```
FAIL test/Server.test.ts > serves exact-version definitions and suppresses superseded diagnostics
Error: Timed out waiting; saw [...]
 ❯ Timeout.poll [as _onTimeout] test/Server.test.ts:54:18
```

This is a flake, not a regression. The same test **passed in 7122ms** on the green `main` run (`31615899206`) and exceeded 15000ms on a later run with identical code — roughly a 2.7× slower runner.

The cause is a mismatched budget. The `waitFor` helper rejects after a hardcoded 15s, but the tests that use it are declared with `{ timeout: 30_000 }`. The inner poll therefore fires first and masks the real limit, so a test that is allowed 30s effectively gets 15.

These are true end-to-end tests — they spawn a real LSP server over stdio and wait on JSON-RPC traffic — so runner speed moves them a lot. The failing run had already received the initialize response and the first `publishDiagnostics` before it gave up.

## Fix

Raises the poll timeout to 25s, still comfortably under the 30s per-test budget so the test's own limit is what governs.

Same class as the docs 5s default (#60) and the 15s codegen timeout (#62): a timeout tight enough to pass on fast hardware and fail on slow.

## Verification

- `pnpm --filter @silk-effect/lsp test` → 46/46
- `biome check` clean

Found while validating #73, which is unrelated (it only changes a workflow trigger). Kept separate so a release-config change and a test fix do not land together.