### PR TITLE
name-resolution: Accept a borrow argument in a namespace-qualified call

### DIFF
--- a/openspec/specs/bootstrap-hir/spec.md
+++ b/openspec/specs/bootstrap-hir/spec.md
@@ -158,6 +158,13 @@ MUST NOT carry import aliases, module traversal state, runtime namespace objects
 cross-module call operation. Missing, conflicting, unknown-member, and inaccessible-member lookups
 SHALL remain explicit unavailable HIR expressions carrying their originating diagnostic cause.
 
+Every qualifier form that resolves a call SHALL supply that callee's declared parameter types as the
+expected types of the call's arguments, including a qualifier that names a nominal struct or
+interface acting as its module's actor. An argument whose meaning depends on the expected type — a
+borrow above all, which is well-formed only where a reference or slice is wanted — SHALL therefore
+elaborate identically under every spelling of one call. A qualified call and the selected-member
+call it duplicates SHALL produce identical lowered MIR.
+
 #### Scenario: Elaborate a selected imported call
 
 - **WHEN** root `main` calls a uniquely selected public `answer()` from module `library/Answer`
@@ -167,6 +174,16 @@ SHALL remain explicit unavailable HIR expressions carrying their originating dia
 
 - **WHEN** root imports `library.Answer as Answers` and calls `Answers.answer()`
 - **THEN** HIR contains the same canonical call target as the selective form while retaining the qualified call's source span
+
+#### Scenario: Pass a borrow to a nominal actor's operation
+
+- **WHEN** a call qualified by a nominal type passes a shared or exclusive borrow to a parameter declared as a reference
+- **THEN** the borrow elaborates as it does through the selected-member spelling and the two calls lower to identical MIR
+
+#### Scenario: Keep an invalid borrow position invalid
+
+- **WHEN** a qualified call passes a borrow to a parameter that declares an owned type
+- **THEN** the invalid-borrow-position diagnostic is still reported
 
 #### Scenario: Elaborate a private local call
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -2954,6 +2954,27 @@ function analyzeArguments(
       qualifier.declaration._tag === 'ServiceDeclaration'
     ) {
       target = serviceOperation(qualifier.declaration, memberSpelling)
+    } else if (
+      qualifier._tag === 'Resolved' &&
+      (qualifier.declaration._tag === 'StructDeclaration' ||
+        qualifier.declaration._tag === 'InterfaceDeclaration') &&
+      qualifier.declaration.canonical._tag === 'Canonical'
+    ) {
+      // A nominal type doubles as an actor: `Vector.length(...)` names a public function of the
+      // module that declares `Vector`. The call itself already resolves that way, but arguments are
+      // analyzed first, and without the same lookup they get no expected types — which reads to a
+      // borrow argument as "no borrow is wanted here" and rejects it as an invalid borrow position.
+      const member = DeclarationIndex.lookup(
+        resolution.index,
+        qualifier.declaration.canonical.id.module,
+        memberSpelling,
+      )
+      target =
+        member._tag === 'Resolved' &&
+        member.declaration._tag === 'FunctionDeclaration' &&
+        member.declaration.visibility === 'Public'
+          ? member.declaration
+          : undefined
     }
   }
   const declaredTypeParameters =

--- a/packages/compiler/test/QualifiedBorrowArgument.test.ts
+++ b/packages/compiler/test/QualifiedBorrowArgument.test.ts
@@ -1,0 +1,120 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Mir from '../src/Mir.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const codes = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code)
+
+/**
+ * The qualified and imported spellings name one function through two syntaxes, so they are held to
+ * one standard: the same diagnostics and, since the module identity is the same, the same MIR.
+ * Only the reference form differs between the two sources.
+ */
+const shared = `import silk.vector { Vector, make }
+
+pub fn main() -> usize {
+  let values = Vector.make<i32>()
+  let count = Vector.length<i32>(&values)
+  drop values
+  return count
+}`
+
+const importedShared = `import silk.vector { Vector, make, length }
+
+pub fn main() -> usize {
+  let values = make<i32>()
+  let count = length<i32>(&values)
+  drop values
+  return count
+}`
+
+const exclusive = `import silk.vector { Vector, make }
+
+pub fn main() -> usize {
+  let mut values = Vector.make<i32>()
+  let slice = Vector.asMutSlice<i32>(&mut values)
+  drop slice
+  let count = Vector.length<i32>(&values)
+  drop values
+  return count
+}`
+
+const importedExclusive = `import silk.vector { Vector, make, length, asMutSlice }
+
+pub fn main() -> usize {
+  let mut values = make<i32>()
+  let slice = asMutSlice<i32>(&mut values)
+  drop slice
+  let count = length<i32>(&values)
+  drop values
+  return count
+}`
+
+/** A borrow in a position that wants an owned value is still an invalid borrow position. */
+const ownedPosition = `import silk.vector { Vector, make }
+
+pub fn main() -> usize {
+  let values = Vector.make<i32>()
+  let taken = Vector.get<i32>(&values, &values)
+  drop taken
+  drop values
+  return 0
+}`
+
+it.effect('accepts a shared borrow through the qualified spelling', () =>
+  Effect.gen(function* () {
+    const qualified = yield* Analysis.ofSourceRealized('borrow/program', ascii(shared))
+    const imported = yield* Analysis.ofSourceRealized('borrow/program', ascii(importedShared))
+    assert.deepEqual(codes(qualified), [])
+    assert.deepEqual(codes(imported), [])
+    // One call, one lowering: the qualifier is a spelling, not a different operation.
+    assert.strictEqual(
+      Mir.encode(Analysis.loweredMir(qualified)),
+      Mir.encode(Analysis.loweredMir(imported)),
+    )
+  }),
+)
+
+it.effect('accepts an exclusive borrow through the qualified spelling', () =>
+  Effect.gen(function* () {
+    const qualified = yield* Analysis.ofSourceRealized('borrow/exclusive', ascii(exclusive))
+    const imported = yield* Analysis.ofSourceRealized('borrow/exclusive', ascii(importedExclusive))
+    assert.deepEqual(codes(qualified), [])
+    assert.deepEqual(codes(imported), [])
+    assert.strictEqual(
+      Mir.encode(Analysis.loweredMir(qualified)),
+      Mir.encode(Analysis.loweredMir(imported)),
+    )
+  }),
+)
+
+it.effect('still rejects a borrow where the parameter wants an owned value', () =>
+  Effect.gen(function* () {
+    // `get`'s second parameter is a `usize`, so the borrow has no reference type to take.
+    const snapshot = yield* Analysis.ofSourceRealized('borrow/owned', ascii(ownedPosition))
+    assert.include(codes(snapshot), 'SEM0055')
+  }),
+)
+
+/**
+ * The shape issue #70 was filed on: no import at all. The manifest namespace seeds `Vector`, so
+ * this is the spelling the namespace feature exists to enable, and a borrow argument is what it
+ * could not reach.
+ */
+const seeded = `pub fn main() -> usize {
+  let values = Vector.make<i32>()
+  let count = Vector.length<i32>(&values)
+  drop values
+  return count
+}`
+
+it.effect('accepts a borrow through a seeded namespace with no import', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized('borrow/seeded', ascii(seeded))
+    assert.deepEqual(codes(snapshot), [])
+  }),
+)


### PR DESCRIPTION
Closes #70

Branches from `main`; no stack.

## The defect

`Vector.length(&values)` reported `SEM0055` while the selected-member `length(&values)` compiled. Two spellings of one call disagreed, so one of them was wrong.

Argument analysis runs *before* the callee reference is resolved, and derives its own expected types from the qualifier. `analyzeArguments` handled an intrinsic qualifier, a namespace qualifier, and a service qualifier — but not a nominal struct or interface acting as its module's actor, which is the form every manifest standard-library namespace takes. With no expected type, a borrow argument has no reference type to take, and `analyzeBorrow` reads that as an invalid borrow position.

The fix looks the member up in the declaring module, exactly as the call site at `Elaboration.ts` already does for the same qualifier form, and requires the member to be public so a private one keeps producing the diagnostic it produced before.

## Why this matters for the namespace work

This is what kept #33's manifest namespaces from reaching any `&self`-style operation. With #55 merged, `Vector` is seeded into scope, and the shape the issue was filed on now compiles with no import at all:

```silk
pub fn main() -> usize {
  let values = Vector.make<i32>()
  let count = Vector.length<i32>(&values)
  drop values
  return count
}
```

PR #69 also noted it had to write its acceptance tests in the `import silk.metrics { ... }` style specifically because of this; that constraint is now lifted.

## Acceptance criteria

- [x] `Vector.length(&values)` compiles and behaves identically to the imported `length(&values)` — `accepts a shared borrow through the qualified spelling`, which asserts both spellings produce no diagnostics.
- [x] The same holds for an exclusive borrow — `accepts an exclusive borrow through the qualified spelling`, over `Vector.asMutSlice<i32>(&mut values)`.
- [x] A test pins qualified and imported spellings producing identical MIR for one call — both tests compile the two spellings under one module identity and assert `Mir.encode` equality.
- [x] Whatever legitimate case `SEM0055` exists for still reports it — `still rejects a borrow where the parameter wants an owned value`, passing a borrow to `get`'s `usize` parameter.

A fourth test, `accepts a borrow through a seeded namespace with no import`, covers the issue's original no-import example.

## Verification

Compiler suite on this branch: **1078 passed / 1078**, 140 files, no failures. `pnpm typecheck` (18/18) and `pnpm exec biome check` are clean.

Reverting `Elaboration.ts` to `main` and re-running this file fails the three capability tests and passes the `SEM0055` guard, so the guard is a genuine guard rather than a consequence of the change.

Note on the pre-existing failure set: the 3 host-triple golden mismatches earlier work quoted as baseline are gone as of #74 — the compiler package is fully green. Four failures remain outside it (3 `compiler-cli` `FormatCommand`/`FormatWorkflow`, 1 `packages/wasm` `Extended`), identical before and after this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4MGY4wkQQypzo48oiNmcY)_