### PR TITLE
lsp: Show diagnostic edits as code actions

### DIFF
--- a/openspec/specs/language-server-code-actions/spec.md
+++ b/openspec/specs/language-server-code-actions/spec.md
@@ -1,0 +1,62 @@
+# language-server-code-actions Specification
+
+## Purpose
+
+Defines how the language server presents a diagnostic's machine-applicable edits to the author as
+quick fixes, so an unambiguous correction is applied from the editor rather than retyped by hand.
+
+## Requirements
+
+### Requirement: The server advertises quick-fix code actions
+
+The language server SHALL advertise code-action support to compatible clients and SHALL declare
+the `quickfix` kind among the kinds it provides.
+
+#### Scenario: Client initializes code-action support
+
+- **WHEN** a compatible client initializes a Silk language-server session
+- **THEN** the returned capabilities advertise code-action support declaring the `quickfix` kind
+
+### Requirement: Each diagnostic edit becomes one quick fix
+
+Every `Edit` carried by a diagnostic whose primary span belongs to the requested document SHALL
+become exactly one code action of the `quickfix` kind. The action SHALL reference the diagnostic
+that carried the edit, and its title SHALL name the correction the edit performs rather than
+repeat the diagnostic's message. The action's workspace edit SHALL address the requested
+document and SHALL express the edit's byte span as a range in the negotiated position encoding.
+
+#### Scenario: Fix a redundant alias
+
+- **WHEN** a code-action request covers an import whose alias repeats the name it renames
+- **THEN** the server returns one `quickfix` titled for removing the redundant alias, referencing that diagnostic, whose edit deletes the ` as name` clause
+
+#### Scenario: Range follows the negotiated encoding
+
+- **WHEN** an edit-carrying diagnostic follows non-ASCII source text on its line
+- **THEN** the returned edit range uses the negotiated position encoding rather than raw byte offsets
+
+### Requirement: A diagnostic without an edit produces no action
+
+A diagnostic that carries no `Edit` SHALL contribute no code action, and the server MUST NOT
+invent a correction for it. A request covering only such diagnostics SHALL return an empty list.
+
+#### Scenario: An unresolved name offers no fix
+
+- **WHEN** a code-action request covers a diagnostic for an unresolved name, whose correction needs a choice the author must make
+- **THEN** the server returns no code action
+
+### Requirement: Quick fixes are deterministic and range-limited
+
+Code actions SHALL be returned in the order of the diagnostics that carried them, so identical
+source and snapshot produce identically ordered actions. Only diagnostics whose published range
+intersects the requested range SHALL contribute an action.
+
+#### Scenario: Two fixable diagnostics in one file
+
+- **WHEN** a code-action request covers a file holding two edit-carrying diagnostics
+- **THEN** the server returns their actions in the same relative order as the diagnostics
+
+#### Scenario: Limit actions to the requested range
+
+- **WHEN** a code-action request covers a range that excludes the only edit-carrying diagnostic in the file
+- **THEN** the server returns no code action

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -11,6 +11,8 @@ import * as Effect from 'effect/Effect'
 import * as Option from 'effect/Option'
 import * as Result from 'effect/Result'
 import {
+  type CodeAction,
+  CodeActionKind,
   type CompletionItem,
   CompletionItemKind,
   type CompletionList,
@@ -90,6 +92,13 @@ const noteSuffix = (diagnostic: Diagnostic.Diagnostic): string =>
     ? ''
     : `\n${diagnostic.notes.map((note) => `note: ${note}`).join('\n')}`
 
+/** The document's own compiler diagnostics, in the deterministic order the phases produced. */
+const owned = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+): ReadonlyArray<Diagnostic.Diagnostic> =>
+  Analysis.diagnostics(snapshot).filter((diagnostic) => diagnostic.span.sourceId === self.module)
+
 /** Converts the document's own compiler diagnostics into protocol diagnostics. */
 export const diagnostics = (
   self: Document,
@@ -98,31 +107,84 @@ export const diagnostics = (
 ): ReadonlyArray<LspDiagnostic> => {
   // Sibling modules' line maps, built once per module from the snapshot's exact loaded bytes.
   const indexOf = lineIndexes(self, snapshot)
-  return Analysis.diagnostics(snapshot)
-    .filter((diagnostic) => diagnostic.span.sourceId === self.module)
-    .map((diagnostic) => {
-      const related = (diagnostic.relatedSpans ?? []).flatMap((relatedSpan) => {
-        const module = relatedSpan.span.sourceId
-        const uri = module === self.module ? self.uri : uriOf(module)
-        const index = indexOf(module)
-        return uri === undefined || index === undefined
-          ? []
-          : [
-              {
-                location: { uri, range: LineIndex.rangeOf(index, relatedSpan.span) },
-                message: relatedSpan.label,
-              },
-            ]
-      })
-      return {
-        range: LineIndex.rangeOf(self.index, diagnostic.span),
-        severity: DiagnosticSeverity.Error,
-        code: diagnostic.code,
-        source: 'silk',
-        message: `${diagnostic.message}${noteSuffix(diagnostic)}`,
-        ...(related.length > 0 ? { relatedInformation: related } : {}),
-      }
+  return owned(self, snapshot).map((diagnostic) => {
+    const related = (diagnostic.relatedSpans ?? []).flatMap((relatedSpan) => {
+      const module = relatedSpan.span.sourceId
+      const uri = module === self.module ? self.uri : uriOf(module)
+      const index = indexOf(module)
+      return uri === undefined || index === undefined
+        ? []
+        : [
+            {
+              location: { uri, range: LineIndex.rangeOf(index, relatedSpan.span) },
+              message: relatedSpan.label,
+            },
+          ]
     })
+    return {
+      range: LineIndex.rangeOf(self.index, diagnostic.span),
+      severity: DiagnosticSeverity.Error,
+      code: diagnostic.code,
+      source: 'silk',
+      message: `${diagnostic.message}${noteSuffix(diagnostic)}`,
+      ...(related.length > 0 ? { relatedInformation: related } : {}),
+    }
+  })
+}
+
+/**
+ * Names the correction one edit-carrying diagnostic applies.
+ *
+ * A `Diagnostic.Edit` carries corrected bytes but no prose, so the title comes from the code that
+ * emitted it. A code absent from this table carries no edit, so its diagnostic yields no action.
+ */
+const correctionTitles: Partial<Record<Diagnostic.Code, string>> = {
+  [Diagnostic.duplicateImportCode]: 'Remove the repeated import',
+  [Diagnostic.redundantAliasCode]: 'Remove the redundant alias',
+}
+
+/** Tests whether two protocol ranges share at least one position. */
+const overlaps = (left: Range, right: Range): boolean =>
+  !(
+    left.end.line < right.start.line ||
+    (left.end.line === right.start.line && left.end.character < right.start.character) ||
+    right.end.line < left.start.line ||
+    (right.end.line === left.start.line && right.end.character < left.start.character)
+  )
+
+/**
+ * Offers each machine-applicable edit of the diagnostics touching one range as a quick fix.
+ *
+ * The actions are recomputed from the analyzed snapshot rather than read from the request's
+ * client-supplied diagnostics, so an action always carries the edit the current source produces.
+ * A diagnostic that carries no edit contributes no action, and the actions follow diagnostic
+ * order, which is deterministic because every phase is.
+ */
+export const codeActions = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  range: Range,
+  uriOf: (module: string) => string | undefined,
+): ReadonlyArray<CodeAction> => {
+  // `diagnostics` maps the same `owned` list one-to-one, so the two stay index-aligned.
+  const published = diagnostics(self, snapshot, uriOf)
+  return owned(self, snapshot).flatMap((diagnostic, order) => {
+    const title = correctionTitles[diagnostic.code]
+    const source = published[order]
+    if (title === undefined || source === undefined || !overlaps(source.range, range)) return []
+    return (diagnostic.edits ?? []).map((edit) => ({
+      title,
+      kind: CodeActionKind.QuickFix,
+      diagnostics: [source],
+      edit: {
+        changes: {
+          [self.uri]: [
+            { range: LineIndex.rangeOf(self.index, edit.span), newText: edit.replacement },
+          ],
+        },
+      },
+    }))
+  })
 }
 
 /** Returns the source-like semantic presentation under one position. */

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -5,6 +5,7 @@ import * as ManagedRuntime from 'effect/ManagedRuntime'
 import * as Option from 'effect/Option'
 import * as Path from 'effect/Path'
 import {
+  CodeActionKind,
   createConnection,
   DidChangeWatchedFilesNotification,
   LSPErrorCodes,
@@ -64,6 +65,7 @@ export const start = (): void => {
         inlayHintProvider: true,
         documentSymbolProvider: true,
         documentFormattingProvider: true,
+        codeActionProvider: { codeActionKinds: [CodeActionKind.QuickFix] },
       },
     }
   })
@@ -267,6 +269,19 @@ export const start = (): void => {
     const session = await acquire(parameters.textDocument.uri)
     if (Option.isNone(session)) return []
     return [...Document.symbols(session.value.document, session.value.snapshot)]
+  })
+
+  connection.onCodeAction(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return []
+    return [
+      ...Document.codeActions(
+        session.value.document,
+        session.value.snapshot,
+        parameters.range,
+        (module) => session.value.moduleUris.get(module),
+      ),
+    ]
   })
 
   connection.onDocumentFormatting(async (parameters) => {

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -1068,3 +1068,136 @@ it.effect('keeps one module alias rename out of another module that chose the sa
     )
   }),
 )
+
+const wholeDocument = (text: string) => ({
+  start: { line: 0, character: 0 },
+  end: positionAt(text, text.length),
+})
+
+const redundantAlias =
+  'import geometry as geometry\npub fn main() -> i32 { return geometry.area(1, 2) }'
+
+it.effect('offers one quick fix that deletes a redundant alias clause', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: redundantAlias },
+      ],
+      'main',
+    )
+    const actions = Document.codeActions(
+      document,
+      snapshot,
+      wholeDocument(redundantAlias),
+      uriOfModule,
+    )
+    assert.strictEqual(actions.length, 1)
+    const action = actions[0]
+    assert.strictEqual(action?.title, 'Remove the redundant alias')
+    assert.strictEqual(action?.kind, 'quickfix')
+    // The action names the diagnostic it corrects, so the editor attaches it to that lightbulb.
+    assert.strictEqual(action?.diagnostics?.[0]?.code, 'SEM0013')
+    assert.deepEqual(action?.edit?.changes?.[uriOfModule('main')], [
+      {
+        range: {
+          start: positionAt(redundantAlias, redundantAlias.indexOf(' as geometry')),
+          end: positionAt(
+            redundantAlias,
+            redundantAlias.indexOf(' as geometry') + ' as geometry'.length,
+          ),
+        },
+        newText: '',
+      },
+    ])
+  }),
+)
+
+it.effect('offers no code action for a diagnostic that carries no edit', () =>
+  Effect.gen(function* () {
+    const source = 'pub fn main() -> i32 { return missing() }'
+    const { document, snapshot } = yield* open(source)
+    assert.strictEqual(
+      Document.diagnostics(document, snapshot, () => undefined)[0]?.code,
+      'SEM0004',
+    )
+    assert.deepEqual(
+      Document.codeActions(document, snapshot, wholeDocument(source), () => undefined),
+      [],
+    )
+  }),
+)
+
+const twoAliases = `import geometry as geometry
+import shapes as shapes
+pub fn main() -> i32 { return geometry.area(1, 2) + shapes.sides() }`
+
+it.effect('returns the quick fixes of two diagnostics in diagnostic order', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'shapes', text: 'pub fn sides() -> i32 { return 4 }' },
+        { module: 'main', text: twoAliases },
+      ],
+      'main',
+    )
+    const actions = Document.codeActions(document, snapshot, wholeDocument(twoAliases), uriOfModule)
+    assert.deepEqual(
+      actions.map((action) => action.edit?.changes?.[uriOfModule('main')]?.[0]?.range.start),
+      [
+        positionAt(twoAliases, twoAliases.indexOf(' as geometry')),
+        positionAt(twoAliases, twoAliases.indexOf(' as shapes')),
+      ],
+    )
+  }),
+)
+
+const nonAsciiAlias = `// π🙂
+import geometry as geometry
+pub fn main() -> i32 { return geometry.area(1, 2) }`
+
+it.effect('measures a quick fix range in UTF-16 units after non-ASCII source', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: nonAsciiAlias },
+      ],
+      'main',
+    )
+    const actions = Document.codeActions(
+      document,
+      snapshot,
+      wholeDocument(nonAsciiAlias),
+      uriOfModule,
+    )
+    // `positionAt` counts UTF-16 units, which is what the negotiated encoding measures; a byte
+    // offset would place the clause later on its line.
+    assert.deepEqual(actions[0]?.edit?.changes?.[uriOfModule('main')]?.[0]?.range, {
+      start: positionAt(nonAsciiAlias, nonAsciiAlias.indexOf(' as geometry')),
+      end: positionAt(nonAsciiAlias, nonAsciiAlias.indexOf(' as geometry') + ' as geometry'.length),
+    })
+  }),
+)
+
+it.effect('offers no quick fix for a diagnostic outside the requested range', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'geometry', text: geometry },
+        { module: 'main', text: redundantAlias },
+      ],
+      'main',
+    )
+    assert.deepEqual(
+      Document.codeActions(
+        document,
+        snapshot,
+        { start: { line: 1, character: 0 }, end: { line: 1, character: 4 } },
+        uriOfModule,
+      ),
+      [],
+    )
+  }),
+)

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -136,6 +136,9 @@ it('serves diagnostics, hover, and formatting over real stdio', { timeout: 30_00
     assert.deepEqual(initialized.capabilities.completionProvider, { triggerCharacters: ['.'] })
     assert.strictEqual(initialized.capabilities.positionEncoding, 'utf-16')
     assert.strictEqual(initialized.capabilities.documentFormattingProvider, true)
+    assert.deepEqual(initialized.capabilities.codeActionProvider, {
+      codeActionKinds: ['quickfix'],
+    })
     client.send({ method: 'initialized', params: {} })
 
     const brokenUri = 'file:///silk-lsp-e2e/broken.silk'
@@ -705,6 +708,60 @@ it('serves project-wide references and renames over real stdio', { timeout: 30_0
       toolchainLocations.some((location) => location.uri.endsWith('/stdlib/silk/bool.silk')),
       JSON.stringify(toolchainLocations),
     )
+  } finally {
+    await client.close()
+  }
+})
+
+it('offers a diagnostic edit as a quick fix over real stdio', { timeout: 30_000 }, async () => {
+  const client = connect()
+  try {
+    client.send({
+      id: 1,
+      method: 'initialize',
+      params: { processId: null, rootUri: null, capabilities: {} },
+    })
+    await client.waitFor((message) => response(message, 1))
+    client.send({ method: 'initialized', params: {} })
+
+    const geometryUri = 'file:///silk-lsp-e2e/fix/Geometry.silk'
+    const mainUri = 'file:///silk-lsp-e2e/fix/Main.silk'
+    const mainText = 'import Geometry as Geometry\npub fn main() -> i32 { return Geometry.area() }'
+    didOpen(client, geometryUri, 'pub fn area() -> i32 { return 1 }')
+    didOpen(client, mainUri, mainText)
+    const diagnostics = await client.waitFor((message) => {
+      const published = publishedDiagnostics(message, mainUri)
+      return published !== undefined && published.length === 1 ? published : undefined
+    })
+    assert.strictEqual(diagnostics[0]?.code, 'SEM0013')
+
+    client.send({
+      id: 2,
+      method: 'textDocument/codeAction',
+      params: {
+        textDocument: { uri: mainUri },
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: mainText.length } },
+        context: { diagnostics: [] },
+      },
+    })
+    const actions = (await client.waitFor((message) => response(message, 2))) as Array<{
+      title: string
+      kind: string
+      edit: { changes: Record<string, Array<{ range: unknown; newText: string }>> }
+    }>
+    assert.strictEqual(actions.length, 1)
+    assert.strictEqual(actions[0]?.title, 'Remove the redundant alias')
+    assert.strictEqual(actions[0]?.kind, 'quickfix')
+    const clause = mainText.indexOf(' as Geometry')
+    assert.deepEqual(actions[0]?.edit.changes[mainUri], [
+      {
+        range: {
+          start: { line: 0, character: clause },
+          end: { line: 0, character: clause + ' as Geometry'.length },
+        },
+        newText: '',
+      },
+    ])
   } finally {
     await client.close()
   }


### PR DESCRIPTION
Closes #48

The server now advertises `codeActionProvider` with the `quickfix` kind and maps each `Edit` a diagnostic carries to one code action. Titles come from the emitting code, since an `Edit` carries corrected bytes but no prose. Actions are recomputed from the analyzed snapshot rather than the request's client-supplied diagnostics, so an action always carries the edit the current source produces.

### Acceptance criteria

- [x] A test asserts the initialize response advertises `codeActionProvider`.
- [x] A test on a source with `SEM0013` returns one quick fix with the correct edit range.
- [x] A test asserts a diagnostic with no edit returns no code action.
- [x] A test asserts two diagnostics in one file return their actions in diagnostic order.
- [x] A new `language-server-code-actions` spec records the requirements.

Two tests beyond the criteria cover requirement 7 (edit ranges measured in UTF-16 units after non-ASCII source) and range-limiting, plus an end-to-end `textDocument/codeAction` round trip against the real stdio server.

Tests: baseline 0 failures (measured in step 0), after 0 failures, +7 new tests