### PR TITLE
lexer: A malformed float exponent is silently accepted and compiles

### DIFF
--- a/examples/language-pressure/lexer/main.silk
+++ b/examples/language-pressure/lexer/main.silk
@@ -327,6 +327,7 @@ fn scanNumber(source: &[u8], start: usize) -> Decision {
       }
     }
   }
+  let mut exponentDigits = true
   let exponent = byteAtOrZero(source, index)
   if exponent == 101 {
     floating = true
@@ -334,6 +335,7 @@ fn scanNumber(source: &[u8], start: usize) -> Decision {
     let sign = byteAtOrZero(source, index)
     if sign == 43 { index = index + 1 }
     if sign == 45 { index = index + 1 }
+    exponentDigits = isDecimalDigit(byteAtOrZero(source, index))
     while index < source.length {
       if !isDecimalDigit(source[index]) { break }
       index = index + 1
@@ -345,12 +347,14 @@ fn scanNumber(source: &[u8], start: usize) -> Decision {
       let sign = byteAtOrZero(source, index)
       if sign == 43 { index = index + 1 }
       if sign == 45 { index = index + 1 }
+      exponentDigits = isDecimalDigit(byteAtOrZero(source, index))
       while index < source.length {
         if !isDecimalDigit(source[index]) { break }
         index = index + 1
       }
     }
   }
+  if !exponentDigits { return Decision { kind: 65, end: index, invalid: true } }
   if floating { return Decision { kind: 6, end: index, invalid: false } }
   return Decision { kind: 5, end: index, invalid: false }
 }

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -28,6 +28,9 @@ export const missingBaseDigitsCode = 'LEX0004' as const
 /** Stable code for a number-literal digit separator outside a position between two digits. */
 export const invalidDigitSeparatorCode = 'LEX0005' as const
 
+/** Stable code for a float-literal exponent marker that no exponent digit follows. */
+export const missingExponentDigitsCode = 'LEX0006' as const
+
 /** Stable code for one required token that is absent at its insertion position. */
 export const missingTokenCode = 'PAR0001' as const
 
@@ -182,6 +185,8 @@ export const invalidReturnedBorrowOriginCode = 'SEM0092' as const
 export const intrinsicTargetUnavailableCode = 'SEM0093' as const
 /** Stable code for wrapping the already-borrowed string view in another reference or slice. */
 export const invalidStringViewTypeCode = 'SEM0094' as const
+/** Stable code for a float literal spelling no floating-point value can represent. */
+export const invalidFloatLiteralCode = 'SEM0095' as const
 
 /** Stable code for a use of a binding after its consuming move. */
 export const useAfterMoveCode = 'OWN0001' as const
@@ -207,6 +212,7 @@ export type Code =
   | typeof unterminatedStaticLiteralCode
   | typeof missingBaseDigitsCode
   | typeof invalidDigitSeparatorCode
+  | typeof missingExponentDigitsCode
   | typeof missingTokenCode
   | typeof unexpectedTokensCode
   | typeof reservedTemplateSyntaxCode
@@ -308,6 +314,7 @@ export type Code =
   | typeof invalidReturnedBorrowOriginCode
   | typeof intrinsicTargetUnavailableCode
   | typeof invalidStringViewTypeCode
+  | typeof invalidFloatLiteralCode
   | typeof useAfterMoveCode
   | typeof partialMoveCode
   | typeof explicitMoveRequiredCode
@@ -349,6 +356,7 @@ export type Reason =
     }
   | { readonly _tag: 'MissingBaseDigits'; readonly radix: 2 | 8 | 16 }
   | { readonly _tag: 'InvalidDigitSeparator' }
+  | { readonly _tag: 'MissingExponentDigits' }
   | { readonly _tag: 'MissingToken'; readonly expected: Token.TokenKind }
   | {
       readonly _tag: 'UnexpectedTokens'
@@ -393,6 +401,7 @@ export type Reason =
     }
   | { readonly _tag: 'InvalidDropHook'; readonly detail: string }
   | { readonly _tag: 'InvalidStaticLiteral'; readonly detail: string }
+  | { readonly _tag: 'InvalidFloatLiteral'; readonly spelling: string }
   | { readonly _tag: 'InvalidConstant'; readonly detail: string }
   | { readonly _tag: 'ExpressionStatementResult'; readonly actual: string }
   | { readonly _tag: 'InvalidRequirementType'; readonly type: string }
@@ -836,6 +845,18 @@ export const invalidDigitSeparator = (span: SourceSpan.SourceSpan): Diagnostic =
     span,
   })
 
+/** Creates the lexical diagnostic for one exponent marker that no exponent digit follows. */
+export const missingExponentDigits = (span: SourceSpan.SourceSpan): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'lexical',
+    code: missingExponentDigitsCode,
+    severity: 'error',
+    message: 'Float literal exponent must have at least one digit',
+    reason: Object.freeze({ _tag: 'MissingExponentDigits' }),
+    span,
+  })
+
 /** Creates the semantic diagnostic for a static literal that cannot decode atomically. */
 export const invalidStaticLiteral = (detail: string, span: SourceSpan.SourceSpan): Diagnostic =>
   Object.freeze({
@@ -845,6 +866,18 @@ export const invalidStaticLiteral = (detail: string, span: SourceSpan.SourceSpan
     severity: 'error',
     message: `Invalid static literal: ${detail}`,
     reason: Object.freeze({ _tag: 'InvalidStaticLiteral', detail }),
+    span,
+  })
+
+/** Creates the semantic diagnostic for a float spelling no floating-point value can represent. */
+export const invalidFloatLiteral = (spelling: string, span: SourceSpan.SourceSpan): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'semantic',
+    code: invalidFloatLiteralCode,
+    severity: 'error',
+    message: `Invalid float literal: ${spelling}`,
+    reason: Object.freeze({ _tag: 'InvalidFloatLiteral', spelling }),
     span,
   })
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -1214,9 +1214,16 @@ const analyzeFloating = (
   source: SourceFile.SourceFile,
   node: SyntaxTree.Node,
   expected?: SemanticType,
-): FloatingExpressionFact => {
+): {
+  readonly fact: FloatingExpressionFact
+  readonly diagnostics: ReadonlyArray<Diagnostic.Diagnostic>
+} => {
+  const unavailable = (
+    diagnostics: ReadonlyArray<Diagnostic.Diagnostic>,
+  ): { readonly fact: FloatingExpressionFact; readonly diagnostics: typeof diagnostics } =>
+    Object.freeze({ fact: Object.freeze({ _tag: 'Unavailable', syntax: node }), diagnostics })
   const token = directToken(node, 'DecimalFloat')
-  if (token === undefined) return Object.freeze({ _tag: 'Unavailable', syntax: node })
+  if (token === undefined) return unavailable(Object.freeze([]))
   const bytes = Option.getOrThrowWith(
     SourceFile.slice(source, token.span),
     () => new RangeError(`Semantic float span does not belong to source ${source.id}`),
@@ -1225,16 +1232,21 @@ const analyzeFloating = (
   const spelling = directToken(node, 'Minus') === undefined ? unsigned : `-${unsigned}`
   const selected = Scalar.isFloatSpelling(expected) ? expected : Scalar.defaultFloat.spelling
   const encoded = FloatingPoint.fromDecimal(spelling, selected === 'f32' ? 32 : 64)
-  return encoded === undefined
-    ? Object.freeze({ _tag: 'Unavailable', syntax: node })
-    : Object.freeze({
-        _tag: 'Available',
-        type: selected,
-        bits: encoded.bits,
-        spelling,
-        token,
-        syntax: node,
-      })
+  // A spelling the lexer accepted but no float can represent must never pass silently.
+  if (encoded === undefined) {
+    return unavailable(Object.freeze([Diagnostic.invalidFloatLiteral(spelling, node.span)]))
+  }
+  return Object.freeze({
+    fact: Object.freeze({
+      _tag: 'Available',
+      type: selected,
+      bits: encoded.bits,
+      spelling,
+      token,
+      syntax: node,
+    }),
+    diagnostics: Object.freeze([]),
+  })
 }
 
 const analyzeConstant = (
@@ -5348,14 +5360,13 @@ function analyzeExpression(
 
   if (node.kind === 'FloatingLiteralExpression') {
     const floating = analyzeFloating(source, node, expected)
+    const fact = floating.fact
     const type =
-      floating._tag === 'Available'
-        ? availableExpressionType(floating.type)
-        : unavailableExpressionType
+      fact._tag === 'Available' ? availableExpressionType(fact.type) : unavailableExpressionType
     return Object.freeze({
-      fact: Object.freeze({ _tag: 'Floating', floating, type, syntax: node }),
-      diagnostics: Object.freeze([]),
-      type: floating._tag === 'Available' ? floating.type : undefined,
+      fact: Object.freeze({ _tag: 'Floating', floating: fact, type, syntax: node }),
+      diagnostics: floating.diagnostics,
+      type: fact._tag === 'Available' ? fact.type : undefined,
     })
   }
 

--- a/packages/compiler/src/Lexer.ts
+++ b/packages/compiler/src/Lexer.ts
@@ -392,20 +392,23 @@ export const lex = (source: SourceFile.SourceFile): LexicalResult => {
           separated = separated && fraction.separated
         }
       }
+      let exponentDigits = true
       if (bytes[index] === 0x65 || bytes[index] === 0x45) {
         floating = true
         index += 1
         if (bytes[index] === 0x2b || bytes[index] === 0x2d) index += 1
         const exponent = scanDigitRun(bytes, base, index)
         index = exponent.end
+        exponentDigits = exponent.digits
         separated = separated && exponent.separated
       }
       const span = pushToken(
-        !separated ? 'Invalid' : floating ? 'DecimalFloat' : 'DecimalInteger',
+        !separated || !exponentDigits ? 'Invalid' : floating ? 'DecimalFloat' : 'DecimalInteger',
         start,
         index,
       )
       if (!separated) diagnostics.push(Diagnostic.invalidDigitSeparator(span))
+      else if (!exponentDigits) diagnostics.push(Diagnostic.missingExponentDigits(span))
       continue
     }
 

--- a/packages/compiler/test/FloatingPointScalars.test.ts
+++ b/packages/compiler/test/FloatingPointScalars.test.ts
@@ -34,6 +34,40 @@ it('rounds decimal source directly to canonical IEEE bits', () => {
   })
 })
 
+it.effect('fails to compile a float literal whose exponent has no digits', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'float/malformed-exponent',
+      new TextEncoder().encode('pub fn main() -> f64 {\n  return 1e\n}'),
+      'wasm32-unknown-unknown',
+    )
+    const codes = Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code)
+    assert.include(codes, 'LEX0006')
+    assert.strictEqual(codes.filter((code) => code === 'LEX0006').length, 1)
+  }),
+)
+
+it.effect('keeps a well-formed exponent compiling to its exact value', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'float/well-formed-exponent',
+      new TextEncoder().encode(
+        'pub fn main() -> i32 {\n' +
+          '  if 1e5 != 100000.0 { return 1 }\n' +
+          '  if 1e+5 != 100000.0 { return 2 }\n' +
+          '  if 1e-5 != 0.00001 { return 3 }\n' +
+          '  if 1.5e10 != 15000000000.0 { return 4 }\n' +
+          '  return 42\n}',
+      ),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const outcome = Analysis.evaluate(snapshot)
+    assert.strictEqual(outcome._tag, 'Completed')
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
 it('publishes canonical float catalog entries', () => {
   assert.deepEqual(
     Scalar.floats().map((scalar) => scalar.spelling),

--- a/packages/compiler/test/Lexer.test.ts
+++ b/packages/compiler/test/Lexer.test.ts
@@ -1,5 +1,7 @@
 import { assert, it } from '@effect/vitest'
 import * as Option from 'effect/Option'
+import * as FloatingPoint from '../src/FloatingPoint.js'
+import * as DigitSeparator from '../src/internal/DigitSeparator.js'
 import * as IntegerLiteral from '../src/internal/IntegerLiteral.js'
 import * as Lexer from '../src/Lexer.js'
 import * as SourceFile from '../src/SourceFile.js'
@@ -189,6 +191,67 @@ it('retains decimal fractions and exponent spellings as exact float tokens', () 
       { kind: 'DecimalInteger', start: 17, end: 18, slice: '4' },
     ],
   )
+})
+
+it('rejects an exponent marker that no digit follows', () => {
+  for (const spelling of ['1e', '1e+', '1e-', '1E', '1.5e']) {
+    const source = SourceFile.make('memory://bad-exponent.silk', ascii(spelling))
+    const result = Lexer.lex(source)
+    assert.deepEqual(
+      result.tokens
+        .filter((token) => token.kind !== 'EndOfFile')
+        .map((token) => tokenView(source, token)),
+      [{ kind: 'Invalid', start: 0, end: spelling.length, slice: spelling }],
+      spelling,
+    )
+    assert.deepEqual(
+      result.diagnostics.map((diagnostic) => diagnostic.code),
+      ['LEX0006'],
+      spelling,
+    )
+  }
+})
+
+it('keeps a well-formed exponent one float token without a diagnostic', () => {
+  for (const spelling of ['1e5', '1e+5', '1e-5', '1.5e10', '0e2', '1_0e5']) {
+    const source = SourceFile.make('memory://good-exponent.silk', ascii(spelling))
+    const result = Lexer.lex(source)
+    assert.deepEqual(
+      result.tokens
+        .filter((token) => token.kind !== 'EndOfFile')
+        .map((token) => tokenView(source, token)),
+      [{ kind: 'DecimalFloat', start: 0, end: spelling.length, slice: spelling }],
+      spelling,
+    )
+    assert.deepEqual(result.diagnostics, [], spelling)
+  }
+})
+
+it('accepts as a float token only a spelling the decimal conversion can represent', () => {
+  // The lexer's float grammar and FloatingPoint.fromDecimal must agree, so no accepted
+  // literal can reach elaboration as an Unavailable fact carrying no diagnostic.
+  const wholes = ['0', '1', '12', '1_000']
+  const fractions = ['', '.5', '.0', '.1_2']
+  const exponents = ['', 'e', 'E', 'e+', 'e-', 'e5', 'E+5', 'e-5', 'e0', 'e_5', 'e5_', 'e1_0']
+  let accepted = 0
+  for (const whole of wholes) {
+    for (const fraction of fractions) {
+      for (const exponent of exponents) {
+        const spelling = `${whole}${fraction}${exponent}`
+        const source = SourceFile.make('memory://float-agreement.silk', ascii(spelling))
+        const result = Lexer.lex(source)
+        const tokens = result.tokens.filter((token) => token.kind !== 'EndOfFile')
+        if (tokens[0]?.kind !== 'DecimalFloat' || result.diagnostics.length !== 0) continue
+        accepted += 1
+        assert.notStrictEqual(
+          FloatingPoint.fromDecimal(DigitSeparator.strip(Array.from(ascii(spelling))), 64),
+          undefined,
+          spelling,
+        )
+      }
+    }
+  }
+  assert.isAbove(accepted, 0)
 })
 
 it('lexes every base prefix as one integer token with its exact slice', () => {

--- a/packages/compiler/test/Parser.test.ts
+++ b/packages/compiler/test/Parser.test.ts
@@ -110,22 +110,36 @@ const assertOriginalTokenTraversal = (result: SyntaxFile.SyntaxFile): void => {
 }
 
 it('preserves signed exponent literals and malformed exponent recovery losslessly', () => {
-  for (const source of [
+  const wellFormed = parseText(
+    'memory://float-parser.silk',
     'fn value() -> f64 { return -1.25e-3 }',
-    'fn damaged() -> f64 { return 1.25e- }',
-  ]) {
-    const result = parseText('memory://float-parser.silk', source)
-    const literal = descendants(result.root).find(
+  )
+  const literal = descendants(wellFormed.root).find(
+    (element): element is SyntaxTree.Node =>
+      SyntaxTree.isNode(element) && element.kind === 'FloatingLiteralExpression',
+  )
+  assert.isDefined(literal)
+  assert.strictEqual(
+    literal === undefined ? undefined : directTokenText(wellFormed, literal, 'DecimalFloat'),
+    '1.25e-3',
+  )
+  assert.deepEqual(reconstructedBytes(wellFormed), ascii('fn value() -> f64 { return -1.25e-3 }'))
+
+  // An exponent with no digits is one invalid token, so no float literal node forms, and the
+  // parser still reconstructs the source byte for byte.
+  const damagedText = 'fn damaged() -> f64 { return 1.25e- }'
+  const damaged = parseText('memory://float-parser-damaged.silk', damagedText)
+  assert.isUndefined(
+    descendants(damaged.root).find(
       (element): element is SyntaxTree.Node =>
         SyntaxTree.isNode(element) && element.kind === 'FloatingLiteralExpression',
-    )
-    assert.isDefined(literal)
-    assert.strictEqual(
-      literal === undefined ? undefined : directTokenText(result, literal, 'DecimalFloat'),
-      source.includes('-1.25') ? '1.25e-3' : '1.25e-',
-    )
-    assert.deepEqual(reconstructedBytes(result), ascii(source))
-  }
+    ),
+  )
+  assert.include(
+    SyntaxTree.tokens(damaged.root).map((token) => token.kind),
+    'Invalid',
+  )
+  assert.deepEqual(reconstructedBytes(damaged), ascii(damagedText))
 })
 
 const reconstructedBytes = (result: SyntaxFile.SyntaxFile): Uint8Array => {


### PR DESCRIPTION
Closes #63

A float literal with an exponent marker and no exponent digits lexed as one `DecimalFloat` token with no diagnostic, and elaboration then mapped the unconvertible spelling to an `Unavailable` fact silently — so `1e` compiled with zero diagnostics.

Fixed at the lexer, as the issue recommends, keeping the error on the token that caused it:

- `Lexer.ts` requires at least one digit after `e`/`E` and its optional sign. Otherwise the literal becomes one `Invalid` token plus a new `LEX0006`, matching the `LEX0004`/`LEX0005` recovery shape. The digit-separator and exponent diagnostics are mutually exclusive, so `1e_` still reports exactly one `LEX0005`.
- `Elaboration.ts` — the second change the issue asks for regardless: `analyzeFloating` now returns `{ fact, diagnostics }` and reports a new `SEM0095` when `fromDecimal` cannot convert, so no float fact can reach `Unavailable` in silence.
- `examples/language-pressure/lexer/main.silk` — the Silk-implemented lexer kept in parity with the canonical one, caught by the differential `LexerPressure` corpus test.

### Acceptance criteria

- [x] `1e`, `1e+`, `1e-`, `1E`, and `1.5e` each produce exactly one lexical diagnostic.
- [x] `pub fn main() -> f64 { return 1e }` fails to compile.
- [x] Well-formed exponents (`1e5`, `1e+5`, `1e-5`, `1.5e10`) are unaffected.
- [x] A test asserts that a float spelling `fromDecimal` cannot convert never reaches an `Unavailable` fact without a diagnostic. Asserted as the invariant that makes it unreachable: `Lexer.test.ts` sweeps 92 whole/fraction/exponent/separator combinations and asserts every spelling accepted as a `DecimalFloat` with no diagnostic is convertible by `fromDecimal`. The `SEM0095` guard remains as the backstop for any future divergence.

### Note for review

`Parser.test.ts` had an assertion that `1.25e-` produces a `DecimalFloat` token inside a `FloatingLiteralExpression` — that test encoded exactly the silent acceptance this issue reports as a bug. I kept its real guarantee (lossless byte round-tripping through parser recovery) and updated it to assert the new invalid-token shape.

Tests: baseline 4 failures (measured in step 0), after 7 failures, +5 new tests

Baseline and post-change failures are all host-environment timeouts, and the set is flaky between runs. Every failing test name observed after the change (`Logging`, `OsFileSystem` x2, the `LexerPressure`/`StackVmPressure` allocation-rollback tests, `IntegerScalars`, `OccurrencePerformance`) was reproduced failing on unmodified `origin/main` with the same timeout errors, or passes in isolation. The `LexerPressure` corpus test that this change does touch passes. `pnpm typecheck` is green repo-wide.