### PR TITLE
ownership: run on a once parameter is not tracked as a consuming use

### DIFF
--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -634,13 +634,14 @@ const checkExpression = (
       return
     }
     case 'Run': {
+      const site = useSite(expression.subject)
       if (
-        expression.subject._tag === 'BindingReference' &&
+        site !== undefined &&
+        expression.subject._tag !== 'Unavailable' &&
         Type.isEffect(expression.subject.type) &&
         expression.subject.type.access === 'Take'
       ) {
-        const site = useSite(expression.subject)
-        if (site !== undefined) checkUse(state, live, site, expression.span, true)
+        checkUse(state, live, site, expression.span, true)
       } else checkExpression(state, live, expression.subject, false, guard, escaping)
       return
     }

--- a/packages/compiler/test/Ownership.test.ts
+++ b/packages/compiler/test/Ownership.test.ts
@@ -253,6 +253,49 @@ pub fn main() -> i32 {
   assert.strictEqual(facts.functions.at(1)?.verdict._tag, 'Violation')
 })
 
+it('consumes a take effect parameter on its first run and rejects a repeated run', () => {
+  const facts = check(
+    'ownership://take-effect-parameter.silk',
+    `pub effect fn twice<A, !E, ?R>(self: once Effect<A ! E ? R>) -> A ! E ? R {
+  let first = run self
+  return run self
+}`,
+  )
+
+  assert.deepEqual(
+    facts.diagnostics.map((diagnostic) => diagnostic.code),
+    ['OWN0001'],
+  )
+  assert.strictEqual(facts.functions.at(0)?.verdict._tag, 'Violation')
+})
+
+it('accepts a single run of a take effect parameter', () => {
+  const facts = check(
+    'ownership://take-effect-parameter-single.silk',
+    `pub effect fn flattenLike<A, !E, !F, ?R, ?S>(
+  self: once Effect<Effect<A ! F ? S> ! E ? R>
+) -> A ! E | F ? R | S {
+  let inner = run self
+  return run inner
+}`,
+  )
+
+  assert.deepEqual(facts.diagnostics, [])
+  assert.strictEqual(facts.functions.at(0)?.verdict._tag, 'Satisfied')
+})
+
+it('allows a shared effect parameter to run repeatedly', () => {
+  const facts = check(
+    'ownership://shared-effect-parameter.silk',
+    `pub effect fn twiceShared<?R>(self: Effect<i32 ? R>) -> i32 ? R {
+  return (run self) + (run self)
+}`,
+  )
+
+  assert.deepEqual(facts.diagnostics, [])
+  assert.strictEqual(facts.functions.at(0)?.verdict._tag, 'Satisfied')
+})
+
 it('derives take-once execution from an effect-block moved capture', () => {
   const facts = check(
     'ownership://take-effect-block.silk',


### PR DESCRIPTION
Closes #64

The ownership checker's `Run` case gated its consuming-use check on the subject being a
`BindingReference`. A parameter lowers to a `ParameterReference`, so `run self` on a `once`
parameter fell through to the non-consuming `else` branch and the affine value was never
marked dead — a body could run a `once` parameter twice with no diagnostic.

`useSite` already resolves every binding form, so the fix routes the guard through it instead
of special-casing one tag, keeping the existing `Type.isEffect` + `access === 'Take'` checks.
That is the single shared guard all callers of the `Run` case route through, so no sibling
call site needs its own patch.

## Acceptance criteria

- [x] A test asserts that a body running a `once` **parameter** twice is rejected with the same diagnostic as running a `once` **local binding** twice — `consumes a take effect parameter on its first run and rejects a repeated run` expects `OWN0001`, matching the existing local-binding test.
- [x] A test asserts that `Effect.flatten`'s single `run self` still compiles unchanged — `accepts a single run of a take effect parameter` mirrors `flatten`'s exact shape and expects no diagnostics.
- [x] Running a shared or `mut` Effect parameter is unaffected — `allows a shared effect parameter to run repeatedly` runs a non-`once` Effect parameter twice and expects no diagnostics.
- [x] No change to the pre-existing host-triple golden failures — failure set compared against a clean `origin/main` baseline measured in a separate worktree.

Tests: baseline 28 failures (measured in step 0), after 10 failures, +3 new tests

## Notes

The regression test was confirmed red before the fix (`expected [] to deeply equal [ 'OWN0001' ]`)
and green after.

All failures on this branch are a strict subset of the `origin/main` baseline (measured in a clean
worktree on the same machine) — every one is a process-spawning determinism or native-toolchain
test timing out on this host, none touch the ownership checker. The baseline's larger count comes
from determinism tests that need a prebuilt `dist/`. Test totals were 1079 on baseline and 1082
here: exactly the 3 tests added. `pnpm typecheck` passes (18/18, 0 errors).

Out of scope: a match-pattern binding of an Effect (`PatternBindingReference`) never registers as
an ownership binding in the first place, so `run` on one is still untracked. That gap is upstream
of the `Run` case and separate from this issue.
