### PR TITLE
lsp: Add signature help for calls

### DIFF
--- a/openspec/specs/language-server-signature-help/spec.md
+++ b/openspec/specs/language-server-signature-help/spec.md
@@ -1,0 +1,80 @@
+# language-server-signature-help Specification
+
+## Purpose
+
+Defines how the language server describes the call the cursor sits inside, so the parameter being
+written is read from the editor rather than recovered by moving the cursor away and counting commas
+by hand.
+
+## Requirements
+
+### Requirement: The server advertises signature help
+
+The language server SHALL advertise signature-help support to compatible clients and SHALL declare
+`(` and `,` among its trigger characters, so an editor requests help when a call is opened and again
+as each argument is separated.
+
+#### Scenario: Client initializes signature-help support
+
+- **WHEN** a compatible client initializes a Silk language-server session
+- **THEN** the returned capabilities advertise signature-help support declaring the `(` and `,` trigger characters
+
+### Requirement: Signature help describes the called declaration
+
+A request inside a call SHALL resolve the callee through the semantic occurrence index and return
+exactly one signature. Silk resolves one name to one declaration in a flat namespace, so no overload
+set is presented. The signature label SHALL be the callee's source-level callable form, and the
+signature SHALL carry one parameter label for each declared parameter, in declaration order. Both
+SHALL come from the same presentations hover and completion detail render, so one declaration reads
+identically wherever it is shown.
+
+#### Scenario: Get the signature of a three-parameter call
+
+- **WHEN** the cursor sits inside a call to `pub fn clamp(value: i32, low: i32, high: i32) -> i32`
+- **THEN** the returned signature is labelled `pub fn clamp(value: i32, low: i32, high: i32) -> i32` and carries the parameter labels `value: i32`, `low: i32`, and `high: i32`
+
+### Requirement: The active parameter follows the cursor
+
+The active parameter SHALL be the number of complete arguments before the cursor, counted from the
+commas the selected call's own argument list owns. A comma belonging to a nested call SHALL NOT
+advance the enclosing call's selection. When calls nest, the request SHALL describe the innermost
+call whose argument list contains the cursor.
+
+#### Scenario: Move the cursor across two commas
+
+- **WHEN** the cursor moves from just after the opening parenthesis to just after the first comma and then just after the second comma of one call
+- **THEN** the reported active parameter is 0, then 1, then 2
+
+#### Scenario: Cursor inside a nested call
+
+- **WHEN** the cursor sits inside a call written as an argument of another call
+- **THEN** the returned signature describes the inner call
+
+### Requirement: Signature help carries authored documentation
+
+When the called declaration has attached `///` documentation, the signature SHALL carry that
+documentation as Markdown. A declaration without documentation SHALL yield a signature with no
+documentation rather than an empty section.
+
+#### Scenario: Call a documented function
+
+- **WHEN** the cursor sits inside a call to a function preceded by `///` prose
+- **THEN** the returned signature carries that prose as Markdown
+
+### Requirement: Signature help is limited to calls and survives damage
+
+A position that is not inside a call's argument list SHALL produce no signature help, including a
+position on the callee name itself and a position after the call's closing parenthesis. Because the
+parser keeps a recovered call form, a request SHALL still be answered in a source that does not
+compile, which is when the arguments are most likely still being written. A position whose callee
+resolves to no source-backed function declaration SHALL produce no signature help.
+
+#### Scenario: Request outside a call
+
+- **WHEN** a signature-help request selects a position outside any call's argument list
+- **THEN** the server returns no signature help
+
+#### Scenario: Request inside a call that does not compile
+
+- **WHEN** a signature-help request selects a position inside a call whose argument list is unterminated and whose module reports diagnostics
+- **THEN** the server still returns the callee's signature and the active parameter for that position

--- a/packages/compiler/src/Analysis.ts
+++ b/packages/compiler/src/Analysis.ts
@@ -279,7 +279,8 @@ export const rootAnalysis = (self: FrontendSnapshot): Elaboration.Result => {
   return result
 }
 
-const declarationForIdentity = (
+/** Resolves the declaration one declaration identity names, canonical or module-local. */
+export const declarationForIdentity = (
   self: FrontendSnapshot,
   identity: Extract<SemanticOccurrence.Identity, { readonly _tag: 'DeclarationIdentity' }>,
 ): DeclarationIndex.MemberFact | undefined => {

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -2,6 +2,7 @@ import * as Analysis from '@silk-effect/compiler/Analysis'
 import * as Diagnostic from '@silk-effect/compiler/Diagnostic'
 import * as FormattedDocument from '@silk-effect/compiler/FormattedDocument'
 import * as Formatter from '@silk-effect/compiler/Formatter'
+import * as Presentation from '@silk-effect/compiler/Presentation'
 import * as SemanticOccurrence from '@silk-effect/compiler/SemanticOccurrence'
 import * as SourceFile from '@silk-effect/compiler/SourceFile'
 import * as SourceSpan from '@silk-effect/compiler/SourceSpan'
@@ -26,6 +27,7 @@ import {
   type Diagnostic as LspDiagnostic,
   type Position,
   type Range,
+  type SignatureHelp,
   SymbolKind,
   type TextEdit,
   type WorkspaceEdit,
@@ -220,6 +222,106 @@ export const hover = (
           : `${signature}\n\n${documentation}`,
     },
     range: LineIndex.rangeOf(self.index, span),
+  }
+}
+
+/**
+ * The innermost call whose argument list encloses one byte offset, with that list.
+ *
+ * The search reads the concrete syntax tree rather than elaborated facts, because the parser keeps
+ * a recovered call form for a source that does not compile and signature help is most wanted while
+ * the arguments are still half-written. An offset exactly on the closing parenthesis is outside the
+ * call; one on an absent closing parenthesis is inside it, since the user is still typing there.
+ */
+const enclosingCall = (
+  root: SyntaxTree.Node,
+  offset: number,
+): { readonly callee: SyntaxTree.Element; readonly argumentList: SyntaxTree.Node } | undefined => {
+  let selected:
+    | { readonly callee: SyntaxTree.Element; readonly argumentList: SyntaxTree.Node }
+    | undefined
+  const visit = (node: SyntaxTree.Node): void => {
+    if (node.kind === 'CallExpression') {
+      const callee = node.children[0]
+      const argumentList = node.children.find(
+        (child): child is SyntaxTree.Node =>
+          SyntaxTree.isNode(child) && child.kind === 'ArgumentList',
+      )
+      if (callee !== undefined && argumentList !== undefined) {
+        // The opening parenthesis is the list's first byte, so `>` puts the cursor after it.
+        const closed = argumentList.children.some(
+          (child) => SyntaxTree.isToken(child) && child.kind === 'RightParenthesis',
+        )
+        const end = closed ? argumentList.span.end - 1 : argumentList.span.end
+        if (
+          offset > argumentList.span.start &&
+          offset <= end &&
+          (selected === undefined ||
+            argumentList.span.end - argumentList.span.start <=
+              selected.argumentList.span.end - selected.argumentList.span.start)
+        )
+          selected = Object.freeze({ callee, argumentList })
+      }
+    }
+    for (const child of node.children) if (SyntaxTree.isNode(child)) visit(child)
+  }
+  visit(root)
+  return selected
+}
+
+/**
+ * Describes the call the cursor sits inside, selecting the parameter the cursor is writing.
+ *
+ * The label and the parameter labels come from the same presentations hover and completion detail
+ * render, so one declaration reads identically everywhere. The active parameter counts the commas
+ * this argument list owns before the cursor: a comma nested in an inner call belongs to that call's
+ * own list, so it never advances the outer selection.
+ */
+export const signatureHelp = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+): SignatureHelp | undefined => {
+  const syntax = Analysis.syntaxOf(snapshot, self.module)
+  if (syntax === undefined) return undefined
+  const offset = LineIndex.offsetOf(self.index, position)
+  const call = enclosingCall(syntax.root, offset)
+  if (call === undefined) return undefined
+  // The callee's last byte is inside its name token, which is where its occurrence is indexed.
+  const occurrence = Analysis.semanticOccurrenceAt(
+    snapshot,
+    self.module,
+    SyntaxTree.span(call.callee).end - 1,
+  )
+  if (occurrence?.resolution._tag !== 'Available') return undefined
+  const identity = occurrence.resolution.identity
+  if (identity._tag !== 'DeclarationIdentity') return undefined
+  const declaration = Analysis.declarationForIdentity(snapshot, identity)
+  if (declaration?._tag !== 'FunctionDeclaration') return undefined
+  const raw = Analysis.documentationOfIdentity(snapshot, identity)
+  const source = raw === undefined ? undefined : Analysis.sources(snapshot).get(raw.span.sourceId)
+  const documentation =
+    raw === undefined || source === undefined
+      ? undefined
+      : Documentation.toMarkdown(Documentation.parse(source, raw))
+  const activeParameter = call.argumentList.children.filter(
+    (child) =>
+      SyntaxTree.isToken(child) && child.kind === 'Comma' && SyntaxTree.span(child).end <= offset,
+  ).length
+  return {
+    signatures: [
+      {
+        label: Presentation.functionDeclaration(declaration).text,
+        parameters: declaration.parameters.map((parameter) => ({
+          label: Presentation.parameter(parameter).text,
+        })),
+        ...(documentation === undefined || documentation.length === 0
+          ? {}
+          : { documentation: { kind: 'markdown' as const, value: documentation } }),
+      },
+    ],
+    activeSignature: 0,
+    activeParameter,
   }
 }
 

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -270,11 +270,8 @@ export const start = (): void => {
     const session = await acquire(parameters.textDocument.uri)
     if (Option.isNone(session)) return null
     return (
-      Document.signatureHelp(
-        session.value.document,
-        session.value.snapshot,
-        parameters.position,
-      ) ?? null
+      Document.signatureHelp(session.value.document, session.value.snapshot, parameters.position) ??
+      null
     )
   })
 

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -62,6 +62,7 @@ export const start = (): void => {
         referencesProvider: true,
         renameProvider: { prepareProvider: true },
         completionProvider: { triggerCharacters: ['.'] },
+        signatureHelpProvider: { triggerCharacters: ['(', ','] },
         inlayHintProvider: true,
         documentSymbolProvider: true,
         documentFormattingProvider: true,
@@ -263,6 +264,18 @@ export const start = (): void => {
     const session = await acquire(parameters.textDocument.uri)
     if (Option.isNone(session)) return { isIncomplete: false, items: [] }
     return Document.completion(session.value.document, session.value.snapshot, parameters.position)
+  })
+
+  connection.onSignatureHelp(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return null
+    return (
+      Document.signatureHelp(
+        session.value.document,
+        session.value.snapshot,
+        parameters.position,
+      ) ?? null
+    )
   })
 
   connection.onDocumentSymbol(async (parameters) => {

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -1201,3 +1201,114 @@ it.effect('offers no quick fix for a diagnostic outside the requested range', ()
     )
   }),
 )
+
+const clamp = `pub fn clamp(value: i32, low: i32, high: i32) -> i32 { return value }
+pub fn main() -> i32 { return clamp(3, 0, 10) }
+`
+
+it.effect('labels a call signature with its declaration and one label per parameter', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* open(clamp)
+    const help = Document.signatureHelp(
+      document,
+      snapshot,
+      positionAt(clamp, clamp.indexOf('clamp(3') + 'clamp('.length),
+    )
+    assert.strictEqual(help?.signatures.length, 1)
+    assert.strictEqual(
+      help?.signatures[0]?.label,
+      'pub fn clamp(value: i32, low: i32, high: i32) -> i32',
+    )
+    assert.deepEqual(
+      help?.signatures[0]?.parameters?.map((parameter) => parameter.label),
+      ['value: i32', 'low: i32', 'high: i32'],
+    )
+    assert.strictEqual(help?.activeSignature, 0)
+  }),
+)
+
+it.effect('advances the active parameter across each comma of the call', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* open(clamp)
+    const call = clamp.indexOf('clamp(3')
+    const activeAt = (offset: number) =>
+      Document.signatureHelp(document, snapshot, positionAt(clamp, offset))?.activeParameter
+    assert.strictEqual(activeAt(call + 'clamp('.length), 0)
+    assert.strictEqual(activeAt(call + 'clamp(3, '.length), 1)
+    assert.strictEqual(activeAt(call + 'clamp(3, 0, '.length), 2)
+  }),
+)
+
+it.effect('returns no signature help outside a call', () =>
+  Effect.gen(function* () {
+    const { document, snapshot } = yield* open(clamp)
+    assert.isUndefined(Document.signatureHelp(document, snapshot, positionOf(clamp, 'clamp', 0)))
+    assert.isUndefined(
+      Document.signatureHelp(
+        document,
+        snapshot,
+        positionAt(clamp, clamp.indexOf('clamp(3, 0, 10)') + 'clamp(3, 0, 10)'.length),
+      ),
+    )
+  }),
+)
+
+it.effect('answers signature help from the recovered call of a source with a parser error', () =>
+  Effect.gen(function* () {
+    const source = `pub fn clamp(value: i32, low: i32, high: i32) -> i32 { return value }
+pub fn main() -> i32 { return clamp(3,
+}
+`
+    const { document, snapshot } = yield* open(source)
+    assert.isTrue(
+      Document.diagnostics(document, snapshot, () => undefined).length > 0,
+      'the source is expected not to compile',
+    )
+    const help = Document.signatureHelp(
+      document,
+      snapshot,
+      positionAt(source, source.indexOf('clamp(3,') + 'clamp(3,'.length),
+    )
+    assert.strictEqual(
+      help?.signatures[0]?.label,
+      'pub fn clamp(value: i32, low: i32, high: i32) -> i32',
+    )
+    assert.strictEqual(help?.activeParameter, 1)
+  }),
+)
+
+it.effect('carries the documentation of the called declaration as Markdown', () =>
+  Effect.gen(function* () {
+    const source = `/// Clamps a value into a range.
+pub fn clamp(value: i32, low: i32, high: i32) -> i32 { return value }
+pub fn main() -> i32 { return clamp(3, 0, 10) }
+`
+    const { document, snapshot } = yield* open(source)
+    const help = Document.signatureHelp(
+      document,
+      snapshot,
+      positionAt(source, source.indexOf('clamp(3') + 'clamp('.length),
+    )
+    assert.deepEqual(help?.signatures[0]?.documentation, {
+      kind: 'markdown',
+      value: 'Clamps a value into a range.',
+    })
+  }),
+)
+
+it.effect('selects the inner call when two calls nest', () =>
+  Effect.gen(function* () {
+    const source = `pub fn clamp(value: i32, low: i32, high: i32) -> i32 { return value }
+pub fn double(value: i32) -> i32 { return value }
+pub fn main() -> i32 { return clamp(double(1), 0, 10) }
+`
+    const { document, snapshot } = yield* open(source)
+    const help = Document.signatureHelp(
+      document,
+      snapshot,
+      positionAt(source, source.indexOf('double(1') + 'double('.length),
+    )
+    assert.strictEqual(help?.signatures[0]?.label, 'pub fn double(value: i32) -> i32')
+    assert.strictEqual(help?.activeParameter, 0)
+  }),
+)

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -139,6 +139,9 @@ it('serves diagnostics, hover, and formatting over real stdio', { timeout: 30_00
     assert.deepEqual(initialized.capabilities.codeActionProvider, {
       codeActionKinds: ['quickfix'],
     })
+    assert.deepEqual(initialized.capabilities.signatureHelpProvider, {
+      triggerCharacters: ['(', ','],
+    })
     client.send({ method: 'initialized', params: {} })
 
     const brokenUri = 'file:///silk-lsp-e2e/broken.silk'


### PR DESCRIPTION
Closes #47

Stacked on #78 (`agent/48-diagnostic-code-actions`).

## Acceptance criteria

- [x] A test asserts the initialize response advertises `signatureHelpProvider` with both trigger characters.
- [x] A test gets the signature of a call with three parameters and asserts the label text.
- [x] A test moves the cursor across two commas and asserts `activeParameter` counts 0, then 1, then 2.
- [x] A test asserts a request outside a call returns no result.
- [x] A test gets signature help in a source with a parser error.
- [x] A new `language-server-signature-help` spec records the requirements.

## Deliberate extra behavior beyond the issue's requirements

**Innermost-call selection for nested calls.** When calls nest, the cursor selects the inner call, and commas are counted only from the selected argument list. Without this the outer signature mis-advances on an inner call's commas, so requirement 5 would be wrong for `clamp(double(1), 0, 10)`. Covered by one test and one spec scenario.

## Notes

The enclosing call is found in the concrete syntax tree rather than in elaborated facts, which is what lets requirement 8 hold: the parser keeps a recovered call form, so help still answers while the arguments are half-written. Verified against both an unterminated call (`MissingToken` right-paren) and a call with an empty trailing argument. Callee resolution still goes through the semantic occurrence index per requirement 2.

`Analysis.declarationForIdentity` already existed privately and handles both canonical and module-local declaration ids; it is now exported rather than restating that lookup in the server.

Tests: baseline 0 failures (measured in step 0), after 0 failures, +6 new tests

The full compiler suite reported 3 `Driver.test.ts` timeouts under CPU contention; that file passes in 5.9s when run alone and is on the known-flaky list.
