### PR TITLE
cli: Add silk clean and a watch mode, and charter silk test

### DIFF
--- a/openspec/specs/silk-cli-workflows/spec.md
+++ b/openspec/specs/silk-cli-workflows/spec.md
@@ -7,7 +7,7 @@ Defines the user-visible Silk language-tool commands for project checking, build
 ## Requirements
 
 ### Requirement: Project-oriented command surface
-The root `silk` command SHALL expose `init`, `build`, `check`, `format`, `run`, and `build-exe`. `init` SHALL accept an optional path and package-name override. Project compilation commands SHALL accept a shared optional `--manifest-path`, one `--backend`, repeatable `--target`, and profile selection. Repeated command-line targets SHALL replace rather than append to manifest targets. `--release` SHALL select the release profile and SHALL conflict with an explicitly different `--profile`.
+The root `silk` command SHALL expose `init`, `build`, `check`, `clean`, `format`, `run`, and `build-exe`. `init` SHALL accept an optional path and package-name override. Project compilation commands SHALL accept a shared optional `--manifest-path`, one `--backend`, repeatable `--target`, and profile selection. Repeated command-line targets SHALL replace rather than append to manifest targets. `--release` SHALL select the release profile and SHALL conflict with an explicitly different `--profile`.
 
 #### Scenario: Display root help
 - **WHEN** a user requests `silk --help`
@@ -70,6 +70,28 @@ The root `silk` command SHALL expose `init`, `build`, `check`, `format`, `run`, 
 #### Scenario: Refuse a non-runnable backend
 - **WHEN** the selected backend cannot produce a host executable
 - **THEN** `silk run` fails before compilation with a clear backend compatibility error
+
+### Requirement: Project clean
+`silk clean` SHALL remove the artifacts the manifest output directory holds and SHALL accept the shared optional `--manifest-path`. It SHALL NOT remove a file the build did not write, and it SHALL exit zero when the output directory does not exist.
+
+#### Scenario: Remove build artifacts
+- **WHEN** a project has been built and `silk clean` is invoked
+- **THEN** the manifest output directory is removed, every project source file remains, and the command exits zero
+
+#### Scenario: Clean a project that was never built
+- **WHEN** `silk clean` is invoked and the manifest output directory does not exist
+- **THEN** the command removes nothing and exits zero
+
+### Requirement: Watch mode
+`silk build` and `silk check` SHALL accept `--watch`. Watch mode SHALL compile again after a change to any file in the source graph and SHALL report each compilation in the same format as one command run. It SHALL keep running after a compilation that reports diagnostics, and the toolchain exit codes SHALL apply only when the user stops it.
+
+#### Scenario: Recompile after a source change
+- **WHEN** `silk check --watch` is running and a file in the source graph changes
+- **THEN** the command analyzes the project again and reports the new result in the ordinary single-run format
+
+#### Scenario: Survive a reported diagnostic
+- **WHEN** a watched compilation reports a diagnostic
+- **THEN** the command prints the diagnostic, keeps watching, and does not exit with the compilation's status
 
 ### Requirement: Explicit direct-file compilation
 `silk build-exe <source>` SHALL retain direct-file controls for source root, output, target, profile, Clang path, saved temporary artifacts, and timing reports. The former `silk compile` command SHALL NOT be registered.

--- a/packages/compiler-cli/src/BuildCommand.ts
+++ b/packages/compiler-cli/src/BuildCommand.ts
@@ -15,6 +15,7 @@ export const command = Command.make(
     targets: ProjectOptions.targets,
     profile: ProjectOptions.profile,
     release: ProjectOptions.release,
+    watch: ProjectOptions.watch,
   },
   Effect.fnUntraced(function* (config) {
     const options = ProjectOptions.resolve({
@@ -28,6 +29,10 @@ export const command = Command.make(
       yield* Console.error(options.failure.message)
       return yield* CommandExit.complete(2)
     }
-    yield* CommandExit.complete(yield* Workflow.build(options.success))
+    yield* CommandExit.complete(
+      config.watch
+        ? yield* Workflow.watch(Workflow.build, options.success)
+        : yield* Workflow.build(options.success),
+    )
   }),
 ).pipe(Command.withDescription('Build the nearest Silk project.'))

--- a/packages/compiler-cli/src/CheckCommand.ts
+++ b/packages/compiler-cli/src/CheckCommand.ts
@@ -15,6 +15,7 @@ export const command = Command.make(
     targets: ProjectOptions.targets,
     profile: ProjectOptions.profile,
     release: ProjectOptions.release,
+    watch: ProjectOptions.watch,
   },
   Effect.fnUntraced(function* (config) {
     const options = ProjectOptions.resolve({
@@ -28,6 +29,10 @@ export const command = Command.make(
       yield* Console.error(options.failure.message)
       return yield* CommandExit.complete(2)
     }
-    yield* CommandExit.complete(yield* Workflow.check(options.success))
+    yield* CommandExit.complete(
+      config.watch
+        ? yield* Workflow.watch(Workflow.check, options.success)
+        : yield* Workflow.check(options.success),
+    )
   }),
 ).pipe(Command.withDescription('Analyze the nearest Silk project without producing artifacts.'))

--- a/packages/compiler-cli/src/CleanCommand.ts
+++ b/packages/compiler-cli/src/CleanCommand.ts
@@ -1,0 +1,19 @@
+import * as Effect from 'effect/Effect'
+import * as Option from 'effect/Option'
+import { Command } from 'effect/unstable/cli'
+import * as CommandExit from './CommandExit.js'
+import * as ProjectOptions from './ProjectOptions.js'
+import * as Workflow from './Workflow.js'
+
+export const command = Command.make(
+  'clean',
+  { manifestPath: ProjectOptions.manifestPath },
+  Effect.fnUntraced(function* (config) {
+    yield* CommandExit.complete(
+      yield* Workflow.clean({
+        ...(Option.isNone(config.manifestPath) ? {} : { manifestPath: config.manifestPath.value }),
+        profile: 'debug',
+      }),
+    )
+  }),
+).pipe(Command.withDescription('Remove the build artifacts of the nearest Silk project.'))

--- a/packages/compiler-cli/src/Cli.ts
+++ b/packages/compiler-cli/src/Cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'effect/unstable/cli'
 import * as BuildCommand from './BuildCommand.js'
 import * as BuildExeCommand from './BuildExeCommand.js'
 import * as CheckCommand from './CheckCommand.js'
+import * as CleanCommand from './CleanCommand.js'
 import * as DocCommand from './DocCommand.js'
 import * as FormatCommand from './FormatCommand.js'
 import * as InitCommand from './InitCommand.js'
@@ -17,6 +18,7 @@ export const command = Command.make('silk').pipe(
     InitCommand.command,
     BuildCommand.command,
     CheckCommand.command,
+    CleanCommand.command,
     DocCommand.command,
     FormatCommand.command,
     RunCommand.command,

--- a/packages/compiler-cli/src/ProjectOptions.ts
+++ b/packages/compiler-cli/src/ProjectOptions.ts
@@ -32,6 +32,10 @@ export const release = Flag.boolean('release').pipe(
   Flag.withDescription('Build with the release profile.'),
 )
 
+export const watch = Flag.boolean('watch').pipe(
+  Flag.withDescription('Run again after every change to a project source file.'),
+)
+
 export interface Input {
   readonly manifestPath?: string
   readonly backend?: string

--- a/packages/compiler-cli/src/Workflow.ts
+++ b/packages/compiler-cli/src/Workflow.ts
@@ -11,6 +11,7 @@ import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
 import * as Path from 'effect/Path'
 import * as Result from 'effect/Result'
+import * as Stream from 'effect/Stream'
 import type { ChildProcessSpawner } from 'effect/unstable/process'
 import * as BuildBatch from './BuildBatch.js'
 import type * as BuildPlan from './BuildPlan.js'
@@ -256,6 +257,58 @@ export const build = Effect.fn('Workflow.build')(function* (
   const succeeded = attempts.filter((attempt) => attempt.status === 0).length
   yield* Console.log(`Build summary: ${succeeded} succeeded, ${attempts.length - succeeded} failed`)
   return aggregateStatus(attempts.map((attempt) => attempt.status))
+})
+
+/**
+ * Runs one compilation, then repeats it after every change under the project source root. The
+ * status of each pass is reported but never returned: only stopping the watch ends the command,
+ * so a pass that reports diagnostics leaves the watch running.
+ */
+export const watch = Effect.fn('Workflow.watch')(function* (
+  run: (
+    options: ProjectSelection,
+  ) => Effect.Effect<ExitStatus, never, FileSystem.FileSystem | Path.Path>,
+  options: ProjectSelection,
+): Effect.fn.Return<ExitStatus, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem
+  const loaded = yield* Effect.result(loadProject(options))
+  if (Result.isFailure(loaded)) return yield* reportPreparationFailure(loaded.failure)
+  const sourceRoot = loaded.success.entry.sourceRoot
+  yield* run(options)
+  yield* Console.log(`Watching ${sourceRoot} for changes.`)
+  yield* fileSystem.watch(sourceRoot).pipe(
+    // ponytail: every event recompiles the whole graph; debounce if editors emit noisy bursts.
+    Stream.runForEach(
+      Effect.fnUntraced(function* () {
+        yield* run(options)
+        yield* Console.log(`Watching ${sourceRoot} for changes.`)
+      }),
+    ),
+    Effect.catchCause(() => Console.error(`Stopped watching ${sourceRoot}`)),
+  )
+  return 0
+})
+
+/**
+ * Removes the manifest output directory. Only the build writes there — `Project.load` rejects an
+ * `output-dir` that escapes the project — so no source file is reachable from this removal.
+ */
+export const clean = Effect.fn('Workflow.clean')(function* (
+  options: ProjectSelection,
+): Effect.fn.Return<ExitStatus, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem
+  const loaded = yield* Effect.result(loadProject(options))
+  if (Result.isFailure(loaded)) return yield* reportPreparationFailure(loaded.failure)
+  const outputDirectory = loaded.success.build.outputDirectory
+  const removed = yield* Effect.result(
+    fileSystem.remove(outputDirectory, { recursive: true, force: true }),
+  )
+  if (Result.isFailure(removed)) {
+    yield* Console.error(`Cannot remove build directory ${outputDirectory}`)
+    return 2
+  }
+  yield* Console.log(`Removed ${outputDirectory}`)
+  return 0
 })
 
 /** Builds exactly the host target through a runnable backend and preserves program exit status. */

--- a/packages/compiler-cli/src/Workflow.ts
+++ b/packages/compiler-cli/src/Workflow.ts
@@ -260,6 +260,32 @@ export const build = Effect.fn('Workflow.build')(function* (
 })
 
 /**
+ * Collects the source root and every directory beneath it. `FileSystem.watch` reports only a
+ * directory's own entries, so a nested module needs its own watch to be seen at all.
+ */
+const sourceDirectories = Effect.fnUntraced(function* (
+  root: string,
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const found: Array<string> = []
+  const pending: Array<string> = [root]
+  while (pending.length > 0) {
+    const directory = pending.pop()
+    if (directory === undefined) continue
+    found.push(directory)
+    const names = yield* Effect.result(fileSystem.readDirectory(directory))
+    if (Result.isFailure(names)) continue
+    for (const name of names.success) {
+      const candidate = path.resolve(directory, name)
+      const info = yield* Effect.result(fileSystem.stat(candidate))
+      if (Result.isSuccess(info) && info.success.type === 'Directory') pending.push(candidate)
+    }
+  }
+  return found
+})
+
+/**
  * Runs one compilation, then repeats it after every change under the project source root. The
  * status of each pass is reported but never returned: only stopping the watch ends the command,
  * so a pass that reports diagnostics leaves the watch running.
@@ -275,8 +301,13 @@ export const watch = Effect.fn('Workflow.watch')(function* (
   if (Result.isFailure(loaded)) return yield* reportPreparationFailure(loaded.failure)
   const sourceRoot = loaded.success.entry.sourceRoot
   yield* run(options)
+  // ponytail: directories are enumerated once; a directory created later needs a restart.
+  const directories = yield* sourceDirectories(sourceRoot)
   yield* Console.log(`Watching ${sourceRoot} for changes.`)
-  yield* fileSystem.watch(sourceRoot).pipe(
+  yield* Stream.mergeAll(
+    directories.map((directory) => fileSystem.watch(directory)),
+    { concurrency: 'unbounded' },
+  ).pipe(
     // ponytail: every event recompiles the whole graph; debounce if editors emit noisy bursts.
     Stream.runForEach(
       Effect.fnUntraced(function* () {

--- a/packages/compiler-cli/test/Cli.test.ts
+++ b/packages/compiler-cli/test/Cli.test.ts
@@ -11,7 +11,16 @@ it('exposes the project-first command surface without a compile alias', () => {
     group.commands.map((command) => command.name),
   )
 
-  assert.deepStrictEqual(names, ['init', 'build', 'check', 'doc', 'format', 'run', 'build-exe'])
+  assert.deepStrictEqual(names, [
+    'init',
+    'build',
+    'check',
+    'clean',
+    'doc',
+    'format',
+    'run',
+    'build-exe',
+  ])
   assert.strictEqual(names.includes('compile'), false)
 })
 
@@ -90,6 +99,15 @@ it.effect(
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   30_000,
 )
+
+it('lists clean with its purpose in root help', () => {
+  const clean = Cli.command.subcommands
+    .flatMap((group) => group.commands)
+    .find((command) => command.name === 'clean')
+
+  assert.notStrictEqual(clean, undefined)
+  assert.strictEqual(clean?.description, 'Remove the build artifacts of the nearest Silk project.')
+})
 
 it.effect('rejects the removed compile subcommand', () =>
   Effect.gen(function* () {

--- a/packages/compiler-cli/test/Workflow.test.ts
+++ b/packages/compiler-cli/test/Workflow.test.ts
@@ -4,6 +4,7 @@ import { assert, it } from '@effect/vitest'
 import * as Backend from '@silk-effect/compiler/Backend'
 import * as Target from '@silk-effect/compiler/Target'
 import * as Effect from 'effect/Effect'
+import * as Fiber from 'effect/Fiber'
 import * as FileSystem from 'effect/FileSystem'
 import * as Project from '../src/Project.js'
 import * as Workflow from '../src/Workflow.js'
@@ -36,6 +37,34 @@ const makeProject = Effect.fnUntraced(function* (root: string, program = source)
 const options = (workingDirectory: string): Workflow.ProjectSelection => ({
   workingDirectory,
   profile: 'debug',
+})
+
+/** Polls a watch-mode side effect, which lands on a filesystem event rather than a returned value. */
+const waitUntil = Effect.fnUntraced(function* (condition: () => boolean) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (condition()) return
+    yield* Effect.sleep('50 millis')
+  }
+  throw new Error('Timed out waiting for the watch mode to compile again')
+})
+
+/**
+ * Rewrites a source file until the watch reacts. The watcher registers after the first
+ * compilation finishes, so a single early write can land before anything is listening.
+ */
+const editUntilRecompiled = Effect.fnUntraced(function* (
+  file: string,
+  text: string,
+  recompiled: () => boolean,
+) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    yield* writeFile(file, text)
+    for (let poll = 0; poll < 20; poll += 1) {
+      if (recompiled()) return
+      yield* Effect.sleep('50 millis')
+    }
+  }
+  throw new Error('Timed out waiting for the watch mode to compile again')
 })
 
 it.effect('checks a whole project without creating build artifacts', () =>
@@ -238,6 +267,90 @@ it.effect(
       const status = yield* Workflow.run(options(root), ['--literal', 'argument'])
 
       assert.strictEqual(status, 42)
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  30_000,
+)
+
+it.effect(
+  'removes the build artifacts and keeps the source files',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      assert.strictEqual(yield* Workflow.build(options(root)), 0)
+      assert.strictEqual(yield* fileSystem.exists(`${root}/build`), true)
+
+      const status = yield* Workflow.clean(options(root))
+
+      assert.strictEqual(status, 0)
+      assert.strictEqual(yield* fileSystem.exists(`${root}/build`), false)
+      assert.strictEqual(yield* fileSystem.exists(`${root}/src/Main.silk`), true)
+      assert.strictEqual(yield* fileSystem.exists(`${root}/silk.toml`), true)
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  30_000,
+)
+
+it.effect('exits zero cleaning a project that was never built', () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem
+    const root = yield* fileSystem.makeTempDirectoryScoped()
+    yield* makeProject(root)
+    assert.strictEqual(yield* fileSystem.exists(`${root}/build`), false)
+
+    assert.strictEqual(yield* Workflow.clean(options(root)), 0)
+    assert.strictEqual(yield* fileSystem.exists(`${root}/src/Main.silk`), true)
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+)
+
+it.live(
+  'checks again after a watched source file changes',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      const passes: Array<Workflow.ExitStatus> = []
+      const record = (selection: Workflow.ProjectSelection) =>
+        Workflow.check(selection).pipe(
+          Effect.tap((status) => Effect.sync(() => passes.push(status))),
+        )
+
+      const watching = yield* Effect.forkChild(Workflow.watch(record, options(root)))
+      yield* waitUntil(() => passes.length >= 1)
+      yield* editUntilRecompiled(
+        `${root}/src/Main.silk`,
+        'pub fn main() -> i32 { return 7 }',
+        () => passes.length >= 2,
+      )
+      yield* Fiber.interrupt(watching)
+
+      assert.deepStrictEqual(passes.slice(0, 2), [0, 0])
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  30_000,
+)
+
+it.live(
+  'keeps watching after a compilation that reports a diagnostic',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root, 'pub fn main() -> Mystery { return 42 }')
+      const passes: Array<Workflow.ExitStatus> = []
+      const record = (selection: Workflow.ProjectSelection) =>
+        Workflow.check(selection).pipe(
+          Effect.tap((status) => Effect.sync(() => passes.push(status))),
+        )
+
+      const watching = yield* Effect.forkChild(Workflow.watch(record, options(root)))
+      yield* waitUntil(() => passes.length >= 1)
+      assert.strictEqual(passes[0], 1)
+
+      yield* editUntilRecompiled(`${root}/src/Main.silk`, source, () => passes.length >= 2)
+
+      assert.strictEqual(passes[1], 0)
+      yield* Fiber.interrupt(watching)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   30_000,
 )

--- a/packages/compiler-cli/test/Workflow.test.ts
+++ b/packages/compiler-cli/test/Workflow.test.ts
@@ -331,6 +331,37 @@ it.live(
 )
 
 it.live(
+  'checks again after a nested module in the source graph changes',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(
+        root,
+        'import library.Answer { answer }\npub fn main() -> i32 { return answer() }',
+      )
+      yield* writeFile(`${root}/src/library/Answer.silk`, 'pub fn answer() -> i32 { return 42 }')
+      const passes: Array<Workflow.ExitStatus> = []
+      const record = (selection: Workflow.ProjectSelection) =>
+        Workflow.check(selection).pipe(
+          Effect.tap((status) => Effect.sync(() => passes.push(status))),
+        )
+
+      const watching = yield* Effect.forkChild(Workflow.watch(record, options(root)))
+      yield* waitUntil(() => passes.length >= 1)
+      yield* editUntilRecompiled(
+        `${root}/src/library/Answer.silk`,
+        'pub fn answer() -> i32 { return 7 }',
+        () => passes.length >= 2,
+      )
+      yield* Fiber.interrupt(watching)
+
+      assert.deepStrictEqual(passes.slice(0, 2), [0, 0])
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  30_000,
+)
+
+it.live(
   'keeps watching after a compilation that reports a diagnostic',
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
Closes #50

`silk clean` removes the manifest output directory, and `--watch` applies to `silk build` and `silk check`. Per the issue, `silk test` stays out of scope: it needs a test-declaration form in the language first, which a separate ticket must charter.

## Acceptance criteria

- [x] The `silk-cli-workflows` spec lists `clean` in the closed command list.
- [x] The spec gets a requirement and a scenario for the watch mode.
- [x] A test asserts `silk clean` removes the build artifacts and keeps the source files.
- [x] A test asserts `silk clean` exits with code 0 on a project that was never built.
- [x] A test asserts `silk check --watch` compiles again after a source file changes.
- [x] A test asserts the watch mode keeps running after a compilation that reports a diagnostic.
- [x] `silk --help` lists `clean` with its purpose.

## Notes

`clean` removes the manifest output directory rather than tracking individual artifacts. Only the build writes there, and `Project.load` already rejects an `output-dir` that escapes the project, so requirement 3 holds without an artifact manifest.

`FileSystem.watch` reports only a directory's own entries and its typed signature exposes no recursive option, so the watch enumerates the source root and every directory beneath it. Without that, a nested module such as `src/library/Answer.silk` produced no recompilation; an extra test covers this case. Directories are enumerated once, so a directory created after the watch starts needs a restart.

Tests: baseline 0 failures (measured in step 0), after 0 failures, +7 new tests
