### PR TITLE
lsp: Add semantic tokens, folding ranges, and call hierarchy

### DIFF
--- a/openspec/specs/language-server-structure/spec.md
+++ b/openspec/specs/language-server-structure/spec.md
@@ -1,0 +1,120 @@
+# language-server-structure Specification
+
+## Purpose
+
+Defines how the language server describes the shape of a Silk source: the meaning of each token, the
+regions an editor may collapse, and the call relationships between functions. All three read
+artifacts the compiler already produces — the lexer's token kinds, the lossless concrete syntax
+tree, and the semantic occurrence index — so an editor reads the same facts the compiler decided
+rather than re-deriving them from a regular expression.
+
+## Requirements
+
+### Requirement: The server advertises structural capabilities
+
+The language server SHALL advertise semantic-tokens support carrying its legend, folding-range
+support, and call-hierarchy support to compatible clients. The semantic-tokens capability SHALL
+declare full-document requests. Delta and range requests are not advertised, so a client always
+requests the whole document.
+
+#### Scenario: Client initializes structural support
+
+- **WHEN** a compatible client initializes a Silk language-server session
+- **THEN** the returned capabilities advertise a semantic-tokens provider carrying the server's legend and declaring full-document support, a folding-range provider, and a call-hierarchy provider
+
+### Requirement: The semantic token legend is built from the compiler's token kinds
+
+The semantic token legend SHALL name only standard protocol token types, and every type it names
+SHALL be reachable from a compiler token kind or a semantic occurrence. The keyword, comment,
+string, number, and operator types SHALL be decided by the lexer's own token kinds — the same kinds
+the TextMate grammar in `@silk-effect/language` colors — so a keyword added to the compiler reaches
+both the grammar and the legend from one definition.
+
+#### Scenario: Compare the legend with the grammar's keywords
+
+- **WHEN** a document spelling every keyword the TextMate grammar colors is tokenized
+- **THEN** each keyword carries a semantic token of the legend's keyword type
+
+### Requirement: Semantic tokens type an identifier by what it resolves to
+
+A full-document semantic tokens request SHALL return one token per classified lexer token, in source
+order, using the protocol's delta encoding. An identifier's token type SHALL be decided by the
+semantic occurrence covering it rather than by its spelling, so a type name and a variable name
+receive different token types where the TextMate grammar's regular expressions must color them
+alike. An identifier with no covering occurrence SHALL contribute no token rather than a guessed
+one. A token spanning more than one line SHALL be omitted, because the protocol's encoding cannot
+express one.
+
+#### Scenario: Color a type name and a variable name
+
+- **WHEN** a semantic tokens request covers a document declaring a struct type and binding a local variable
+- **THEN** the type name carries the `type` token type and the variable name carries the `variable` token type
+
+### Requirement: Folding ranges cover braced regions and comment runs
+
+A folding-range request SHALL return one range for each block, each declaration body, and each run
+of adjacent comment lines. A braced region SHALL fold from the line holding its opening brace to the
+line holding its closing brace, so the line an editor leaves visible keeps the brace that opened the
+region. A region whose braces sit on one line SHALL yield no range. Because Silk has no delimited
+block comment, a run of adjacent `//`, `///`, or `//!` lines SHALL fold as one range carrying the
+`comment` kind. A range whose folding is controlled by a comment marker such as `// region` is out
+of scope.
+
+#### Scenario: Fold a function body
+
+- **WHEN** a folding-range request covers a function whose body opens on its declaration line and closes three lines later
+- **THEN** one range folds from the declaration line to the closing brace's line
+
+#### Scenario: Fold a run of comment lines
+
+- **WHEN** a folding-range request covers three adjacent comment lines followed by a declaration
+- **THEN** one range of the `comment` kind covers the three comment lines
+
+### Requirement: Call hierarchy is prepared from the selected declaration
+
+A prepare-call-hierarchy request SHALL resolve the position through the semantic occurrence index
+and SHALL return the source-backed function declaration it names, so a call site, a use as a value,
+and the declaration's own name all prepare the same declaration. A position naming no source-backed
+function declaration SHALL prepare no item. The prepared item SHALL carry the declaration's name,
+its source-level callable form as detail, the range of the whole declaration, and the name token as
+its selection range.
+
+#### Scenario: Prepare from a declaration name
+
+- **WHEN** a prepare-call-hierarchy request selects the name of `pub fn helper(value: i32) -> i32`
+- **THEN** one item named `helper` is returned carrying `pub fn helper(value: i32) -> i32` as its detail
+
+### Requirement: Incoming calls name every calling function
+
+An incoming-calls request SHALL return every function whose body encloses a use of the selected
+declaration, across every module of the analyzed project. Two calls written in one function SHALL
+collapse into one entry carrying both call ranges. A use written outside any function body, such as
+an import clause or the declaration's own name, SHALL contribute no caller.
+
+#### Scenario: Two callers in two modules
+
+- **WHEN** an incoming-calls request selects a function called once from each of two other modules
+- **THEN** both calling functions are returned, each carrying the range of its own call
+
+### Requirement: Outgoing calls name every called function
+
+An outgoing-calls request SHALL return every function declaration the selected function's body
+names, in the order the calls are written. A callee reached through a qualified name SHALL be found
+exactly as a bare one is, and repeated calls to one callee SHALL collapse into a single entry
+carrying every call's range.
+
+#### Scenario: Call two functions, one of them twice
+
+- **WHEN** an outgoing-calls request selects a function calling `helper` twice and `double` once
+- **THEN** `helper` is returned carrying two ranges and `double` carrying one
+
+### Requirement: Structural responses use the negotiated position encoding
+
+Every semantic token position, folding range line, and call hierarchy range SHALL be expressed in
+the position encoding negotiated at initialization, so a source containing characters outside the
+Basic Multilingual Plane places every structural answer exactly where the editor expects it.
+
+#### Scenario: Answer a structural request in a document holding astral characters
+
+- **WHEN** a document holds a character outside the Basic Multilingual Plane before a declaration
+- **THEN** the semantic tokens, folding ranges, and call hierarchy ranges of that declaration carry columns counted in the negotiated encoding

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@silk-effect/language": "workspace:*",
     "@types/node": "^24.10.1"
   }
 }

--- a/packages/lsp/src/Document.ts
+++ b/packages/lsp/src/Document.ts
@@ -1,4 +1,5 @@
 import * as Analysis from '@silk-effect/compiler/Analysis'
+import type * as DeclarationIndex from '@silk-effect/compiler/DeclarationIndex'
 import * as Diagnostic from '@silk-effect/compiler/Diagnostic'
 import * as FormattedDocument from '@silk-effect/compiler/FormattedDocument'
 import * as Formatter from '@silk-effect/compiler/Formatter'
@@ -7,11 +8,15 @@ import * as SemanticOccurrence from '@silk-effect/compiler/SemanticOccurrence'
 import * as SourceFile from '@silk-effect/compiler/SourceFile'
 import * as SourceSpan from '@silk-effect/compiler/SourceSpan'
 import * as SyntaxTree from '@silk-effect/compiler/SyntaxTree'
+import type * as Token from '@silk-effect/compiler/Token'
 import * as Documentation from '@silk-effect/documentation/Document'
 import * as Effect from 'effect/Effect'
 import * as Option from 'effect/Option'
 import * as Result from 'effect/Result'
 import {
+  type CallHierarchyIncomingCall,
+  type CallHierarchyItem,
+  type CallHierarchyOutgoingCall,
   type CodeAction,
   CodeActionKind,
   type CompletionItem,
@@ -19,6 +24,8 @@ import {
   type CompletionList,
   DiagnosticSeverity,
   type DocumentSymbol,
+  type FoldingRange,
+  FoldingRangeKind,
   type Hover,
   type InlayHint,
   InlayHintKind,
@@ -27,6 +34,9 @@ import {
   type Diagnostic as LspDiagnostic,
   type Position,
   type Range,
+  type SemanticTokens,
+  type SemanticTokensLegend,
+  SemanticTokenTypes,
   type SignatureHelp,
   SymbolKind,
   type TextEdit,
@@ -809,6 +819,462 @@ export const symbols = (
       },
     ]
   })
+}
+
+/**
+ * The token types the server reports, in the order the protocol's numeric encoding indexes them.
+ *
+ * Every entry is reachable from a Silk token kind or occurrence role, so the legend advertises no
+ * type the server never sends. `keyword`, `comment`, `string`, `number`, and `operator` come from
+ * the lexer's own kinds — the same kinds `@silk-effect/language`'s TextMate grammar colors — while
+ * an identifier's type is decided by the semantic occurrence covering it, which is what separates a
+ * type name from a variable name that the grammar's regular expressions must color alike.
+ */
+export const semanticTokenTypes: ReadonlyArray<string> = Object.freeze([
+  SemanticTokenTypes.keyword,
+  SemanticTokenTypes.comment,
+  SemanticTokenTypes.string,
+  SemanticTokenTypes.number,
+  SemanticTokenTypes.operator,
+  SemanticTokenTypes.type,
+  SemanticTokenTypes.typeParameter,
+  SemanticTokenTypes.function,
+  SemanticTokenTypes.method,
+  SemanticTokenTypes.parameter,
+  SemanticTokenTypes.variable,
+  SemanticTokenTypes.property,
+  SemanticTokenTypes.namespace,
+])
+
+/** The legend one client negotiates once and then decodes every token reply against. */
+export const semanticTokensLegend: SemanticTokensLegend = Object.freeze({
+  tokenTypes: [...semanticTokenTypes],
+  tokenModifiers: [],
+})
+
+const typeIndexes = new Map(semanticTokenTypes.map((name, index) => [name, index] as const))
+
+/**
+ * The token type of one lexer kind alone, before any semantic occurrence refines it.
+ *
+ * An identifier is deliberately absent: its type depends on what it names, not on how it lexed, so
+ * an identifier with no occurrence covering it contributes no token rather than a guessed one.
+ */
+const lexicalTokenType = (kind: Token.TokenKind): string | undefined => {
+  if (kind.endsWith('Keyword')) return SemanticTokenTypes.keyword
+  switch (kind) {
+    case 'LineComment':
+    case 'DocComment':
+    case 'ModuleDocComment':
+      return SemanticTokenTypes.comment
+    case 'TextLiteral':
+    case 'ByteStringLiteral':
+      return SemanticTokenTypes.string
+    case 'DecimalInteger':
+    case 'DecimalFloat':
+      return SemanticTokenTypes.number
+    case 'Equals':
+    case 'EqualEqual':
+    case 'FatArrow':
+    case 'Minus':
+    case 'Plus':
+    case 'Star':
+    case 'Slash':
+    case 'Percent':
+    case 'Bang':
+    case 'BangEqual':
+    case 'Question':
+    case 'Less':
+    case 'LessEqual':
+    case 'Greater':
+    case 'GreaterEqual':
+    case 'Pipe':
+    case 'PipeGreater':
+    case 'Ampersand':
+    case 'Caret':
+    case 'Tilde':
+    case 'Arrow':
+      return SemanticTokenTypes.operator
+    default:
+      return undefined
+  }
+}
+
+/**
+ * The token type one resolved occurrence gives the identifier it covers. The role says how the name
+ * was used and the resolved identity says what it names, so a function used as a value still reads
+ * as a function while a parameter and a local binding stay distinct.
+ */
+const occurrenceTokenType = (
+  snapshot: Analysis.FrontendSnapshot,
+  occurrence: SemanticOccurrence.SemanticOccurrence,
+): string => {
+  const identity =
+    occurrence.resolution._tag === 'Available' ? occurrence.resolution.identity : undefined
+  switch (identity?._tag) {
+    case 'TypeParameterIdentity':
+      return SemanticTokenTypes.typeParameter
+    case 'ParameterIdentity':
+      return SemanticTokenTypes.parameter
+    case 'BindingIdentity':
+    case 'PatternBindingIdentity':
+      return SemanticTokenTypes.variable
+    case 'FieldIdentity':
+      return SemanticTokenTypes.property
+    case 'ServiceOperationIdentity':
+    case 'IntrinsicOperationIdentity':
+      return SemanticTokenTypes.method
+    case 'ImportNamespaceIdentity':
+    case 'IntrinsicActorIdentity':
+      return SemanticTokenTypes.namespace
+    case 'DeclarationIdentity': {
+      const declaration = Analysis.declarationForIdentity(snapshot, identity)
+      if (declaration?._tag === 'FunctionDeclaration') return SemanticTokenTypes.function
+      if (declaration?._tag === 'ConstantDeclaration') return SemanticTokenTypes.variable
+      return SemanticTokenTypes.type
+    }
+    default:
+      break
+  }
+  // An unresolved name still has a role, which is enough to keep a type reading as a type.
+  switch (occurrence.role) {
+    case 'Type':
+      return SemanticTokenTypes.type
+    case 'Field':
+      return SemanticTokenTypes.property
+    case 'Actor':
+      return SemanticTokenTypes.namespace
+    case 'Operation':
+      return SemanticTokenTypes.method
+    default:
+      return SemanticTokenTypes.variable
+  }
+}
+
+/**
+ * Colors the whole document from the compiler's own facts rather than from a regular expression.
+ *
+ * The lexer's token kinds carry keywords, comments, literals, and operators, and the semantic
+ * occurrence index types every identifier by what it actually resolves to. Tokens are emitted in
+ * source order and delta-encoded against the previous token as the protocol requires. A token
+ * spanning more than one line is dropped rather than truncated, because the protocol's encoding
+ * cannot express one, and a multi-line token in Silk is only ever a triple-quoted literal the
+ * grammar already colors.
+ */
+export const semanticTokens = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+): SemanticTokens => {
+  const syntax = Analysis.syntaxOf(snapshot, self.module)
+  if (syntax === undefined) return { data: [] }
+  const source = Analysis.sources(snapshot).get(self.module)
+  const occurrences =
+    source === undefined
+      ? []
+      : Option.match(SourceSpan.make(source, 0, SourceFile.length(source)), {
+          onNone: () => [],
+          onSome: (whole) => [...Analysis.semanticOccurrencesInRange(snapshot, self.module, whole)],
+        })
+  // Occurrences are start-sorted, so one advancing cursor pairs each identifier with its own.
+  const byStart = new Map(occurrences.map((occurrence) => [occurrence.span.start, occurrence]))
+  const data: Array<number> = []
+  let previousLine = 0
+  let previousCharacter = 0
+  for (const token of SyntaxTree.tokens(syntax.root)) {
+    const occurrence = byStart.get(token.span.start)
+    const type =
+      occurrence !== undefined && token.kind === 'Identifier'
+        ? occurrenceTokenType(snapshot, occurrence)
+        : lexicalTokenType(token.kind)
+    if (type === undefined) continue
+    const index = typeIndexes.get(type)
+    if (index === undefined) continue
+    const start = LineIndex.positionOf(self.index, token.span.start)
+    const end = LineIndex.positionOf(self.index, token.span.end)
+    if (end.line !== start.line) continue
+    const length = end.character - start.character
+    if (length <= 0) continue
+    const deltaLine = start.line - previousLine
+    data.push(
+      deltaLine,
+      deltaLine === 0 ? start.character - previousCharacter : start.character,
+      length,
+      index,
+      0,
+    )
+    previousLine = start.line
+    previousCharacter = start.character
+  }
+  return { data }
+}
+
+/** The syntax node kinds whose body an editor may fold, each folded from its own brace pair. */
+const foldableKinds: ReadonlySet<SyntaxTree.NodeKind> = new Set([
+  'Block',
+  'StructDeclaration',
+  'ServiceDeclaration',
+  'InterfaceDeclaration',
+  'ImplDeclaration',
+  'MatchExpression',
+  'ImportMemberList',
+])
+
+/**
+ * Returns one folding range for each braced region and each run of comment lines.
+ *
+ * A region folds from the line holding its opening brace to the line holding its closing one, so
+ * the collapsed line keeps the brace that opened it, which is what an editor shows. A region whose
+ * braces sit on one line offers nothing to fold and is omitted. Comment runs fold as one range per
+ * consecutive block of comment lines: Silk has no delimited block comment, so a run of `//`, `///`,
+ * or `//!` lines is the block a reader means to collapse.
+ */
+export const foldingRanges = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+): ReadonlyArray<FoldingRange> => {
+  const syntax = Analysis.syntaxOf(snapshot, self.module)
+  if (syntax === undefined) return []
+  const ranges: Array<FoldingRange> = []
+  const visit = (node: SyntaxTree.Node): void => {
+    if (foldableKinds.has(node.kind)) {
+      const open = node.children.find(
+        (child) => SyntaxTree.isToken(child) && child.kind === 'LeftBrace',
+      )
+      const close = node.children.findLast(
+        (child) => SyntaxTree.isToken(child) && child.kind === 'RightBrace',
+      )
+      if (open !== undefined && close !== undefined) {
+        const startLine = LineIndex.lineOf(self.index, SyntaxTree.span(open).start)
+        const endLine = LineIndex.lineOf(self.index, SyntaxTree.span(close).start)
+        if (endLine > startLine) ranges.push({ startLine, endLine })
+      }
+    }
+    for (const child of node.children) if (SyntaxTree.isNode(child)) visit(child)
+  }
+  visit(syntax.root)
+  // One run of adjacent comment lines folds as a single block, in source order with the rest.
+  let runStart: number | undefined
+  let runEnd = 0
+  const flush = (): void => {
+    if (runStart !== undefined && runEnd > runStart)
+      ranges.push({ startLine: runStart, endLine: runEnd, kind: FoldingRangeKind.Comment })
+    runStart = undefined
+  }
+  for (const token of SyntaxTree.tokens(syntax.root)) {
+    if (
+      token.kind !== 'LineComment' &&
+      token.kind !== 'DocComment' &&
+      token.kind !== 'ModuleDocComment'
+    )
+      continue
+    const line = LineIndex.lineOf(self.index, token.span.start)
+    if (runStart !== undefined && line === runEnd + 1) runEnd = line
+    else {
+      flush()
+      runStart = line
+      runEnd = line
+    }
+  }
+  flush()
+  return Object.freeze(
+    ranges.sort((left, right) =>
+      left.startLine !== right.startLine
+        ? left.startLine - right.startLine
+        : left.endLine - right.endLine,
+    ),
+  )
+}
+
+/** Builds the protocol item naming one source-backed declaration of the analyzed project. */
+const callHierarchyItem = (
+  declaration: DeclarationIndex.MemberFact,
+  indexOf: (module: string) => LineIndex.LineIndex | undefined,
+  uriOf: (module: string) => string | undefined,
+): CallHierarchyItem | undefined => {
+  if (declaration.name._tag !== 'Present') return undefined
+  const module = declaration.name.token.span.sourceId
+  const uri = uriOf(module)
+  const index = indexOf(module)
+  if (uri === undefined || index === undefined) return undefined
+  return {
+    name: declaration.name.spelling,
+    kind: declaration._tag === 'FunctionDeclaration' ? SymbolKind.Function : SymbolKind.Constant,
+    ...(declaration._tag === 'FunctionDeclaration'
+      ? { detail: Presentation.functionDeclaration(declaration).text }
+      : {}),
+    uri,
+    range: LineIndex.rangeOf(index, SyntaxTree.span(declaration.syntax)),
+    selectionRange: LineIndex.rangeOf(index, declaration.name.token.span),
+    data: SemanticOccurrence.identityKey(
+      Object.freeze({
+        _tag: 'DeclarationIdentity',
+        id: declaration.canonical._tag === 'Canonical' ? declaration.canonical.id : declaration.id,
+      }),
+    ),
+  }
+}
+
+/** Every function declaration of the analyzed project, in canonical module and source order. */
+const functionDeclarations = (
+  snapshot: Analysis.FrontendSnapshot,
+): ReadonlyArray<DeclarationIndex.MemberFact> =>
+  Analysis.declarationIndex(snapshot)
+    .modules.flatMap((module) => module.members)
+    .filter((member) => member._tag === 'FunctionDeclaration')
+
+/** The declaration whose body encloses one span, which is the function a call is written inside. */
+const enclosingDeclaration = (
+  snapshot: Analysis.FrontendSnapshot,
+  module: string,
+  span: SourceSpan.SourceSpan,
+): DeclarationIndex.MemberFact | undefined =>
+  functionDeclarations(snapshot).find((declaration) => {
+    const declarationSpan = SyntaxTree.span(declaration.syntax)
+    return (
+      declarationSpan.sourceId === module &&
+      declarationSpan.start <= span.start &&
+      span.end <= declarationSpan.end
+    )
+  })
+
+/**
+ * Names the function the cursor selects, which anchors both call directions.
+ *
+ * The selection reads the semantic occurrence index, so a call site, a use as a value, and the
+ * declaration's own name all prepare the same declaration. A position naming no source-backed
+ * function prepares nothing rather than the file it sits in.
+ */
+export const prepareCallHierarchy = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  position: Position,
+  uriOf: (module: string) => string | undefined,
+): ReadonlyArray<CallHierarchyItem> => {
+  const occurrence = Analysis.semanticOccurrenceAt(
+    snapshot,
+    self.module,
+    LineIndex.offsetOf(self.index, position),
+  )
+  if (occurrence?.resolution._tag !== 'Available') return []
+  const identity = occurrence.resolution.identity
+  if (identity._tag !== 'DeclarationIdentity') return []
+  const declaration = Analysis.declarationForIdentity(snapshot, identity)
+  if (declaration?._tag !== 'FunctionDeclaration') return []
+  const item = callHierarchyItem(declaration, lineIndexes(self, snapshot), (module) =>
+    module === self.module ? self.uri : uriOf(module),
+  )
+  return item === undefined ? [] : Object.freeze([item])
+}
+
+/** Resolves the declaration one prepared item was built from, by the identity key it carries. */
+const declarationOfItem = (
+  snapshot: Analysis.FrontendSnapshot,
+  item: CallHierarchyItem,
+): DeclarationIndex.MemberFact | undefined =>
+  functionDeclarations(snapshot).find(
+    (declaration) =>
+      SemanticOccurrence.identityKey(
+        Object.freeze({
+          _tag: 'DeclarationIdentity',
+          id:
+            declaration.canonical._tag === 'Canonical' ? declaration.canonical.id : declaration.id,
+        }),
+      ) === item.data,
+  )
+
+/**
+ * Lists every function that calls the selected one, across every module of the analyzed project.
+ *
+ * Each use of the selected declaration is attributed to the declaration whose body encloses it, so
+ * two calls from one caller collapse into one entry carrying both ranges, and a use written outside
+ * any function body — an import clause, the declaration's own name — contributes no caller.
+ */
+export const incomingCalls = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  item: CallHierarchyItem,
+  uriOf: (module: string) => string | undefined,
+): ReadonlyArray<CallHierarchyIncomingCall> => {
+  const target = declarationOfItem(snapshot, item)
+  if (target === undefined) return []
+  const identity = Object.freeze({
+    _tag: 'DeclarationIdentity' as const,
+    id: target.canonical._tag === 'Canonical' ? target.canonical.id : target.id,
+  })
+  const indexOf = lineIndexes(self, snapshot)
+  const uriOfModule = (module: string): string | undefined =>
+    module === self.module ? self.uri : uriOf(module)
+  const callers = new Map<string, { item: CallHierarchyItem; ranges: Array<Range> }>()
+  for (const match of matchesOfIdentity(snapshot, identity)) {
+    if (match.occurrence.role === 'Declaration' || match.occurrence.role === 'Import') continue
+    const caller = enclosingDeclaration(snapshot, match.module, match.occurrence.span)
+    if (caller === undefined) continue
+    const index = indexOf(match.module)
+    if (index === undefined) continue
+    const key = SemanticOccurrence.identityKey(
+      Object.freeze({
+        _tag: 'DeclarationIdentity',
+        id: caller.canonical._tag === 'Canonical' ? caller.canonical.id : caller.id,
+      }),
+    )
+    const existing = callers.get(key)
+    const range = LineIndex.rangeOf(index, match.occurrence.span)
+    if (existing !== undefined) {
+      existing.ranges.push(range)
+      continue
+    }
+    const from = callHierarchyItem(caller, indexOf, uriOfModule)
+    if (from === undefined) continue
+    callers.set(key, { item: from, ranges: [range] })
+  }
+  return Object.freeze(
+    [...callers.values()].map(({ item: from, ranges }) => ({ from, fromRanges: ranges })),
+  )
+}
+
+/**
+ * Lists every function the selected one calls, in the order the calls are written.
+ *
+ * The selected declaration's own body is scanned through the same occurrence index, so a callee
+ * reached through a qualified name is found exactly as a bare one is, and repeated calls to one
+ * callee collapse into a single entry carrying every call's range.
+ */
+export const outgoingCalls = (
+  self: Document,
+  snapshot: Analysis.FrontendSnapshot,
+  item: CallHierarchyItem,
+  uriOf: (module: string) => string | undefined,
+): ReadonlyArray<CallHierarchyOutgoingCall> => {
+  const caller = declarationOfItem(snapshot, item)
+  if (caller === undefined) return []
+  const body = SyntaxTree.span(caller.syntax)
+  const module = body.sourceId
+  const indexOf = lineIndexes(self, snapshot)
+  const callerIndex = indexOf(module)
+  if (callerIndex === undefined) return []
+  const uriOfModule = (candidate: string): string | undefined =>
+    candidate === self.module ? self.uri : uriOf(candidate)
+  const callees = new Map<string, { item: CallHierarchyItem; ranges: Array<Range> }>()
+  for (const occurrence of Analysis.semanticOccurrencesInRange(snapshot, module, body)) {
+    if (occurrence.role === 'Declaration' || occurrence.resolution._tag !== 'Available') continue
+    const identity = occurrence.resolution.identity
+    if (identity._tag !== 'DeclarationIdentity') continue
+    const callee = Analysis.declarationForIdentity(snapshot, identity)
+    if (callee?._tag !== 'FunctionDeclaration') continue
+    const key = SemanticOccurrence.identityKey(identity)
+    const range = LineIndex.rangeOf(callerIndex, occurrence.span)
+    const existing = callees.get(key)
+    if (existing !== undefined) {
+      existing.ranges.push(range)
+      continue
+    }
+    const to = callHierarchyItem(callee, indexOf, uriOfModule)
+    if (to === undefined) continue
+    callees.set(key, { item: to, ranges: [range] })
+  }
+  return Object.freeze(
+    [...callees.values()].map(({ item: to, ranges }) => ({ to, fromRanges: ranges })),
+  )
 }
 
 /** Formats the whole document, yielding no edits for damaged or already canonical sources. */

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -67,6 +67,9 @@ export const start = (): void => {
         documentSymbolProvider: true,
         documentFormattingProvider: true,
         codeActionProvider: { codeActionKinds: [CodeActionKind.QuickFix] },
+        semanticTokensProvider: { legend: Document.semanticTokensLegend, full: true },
+        foldingRangeProvider: true,
+        callHierarchyProvider: true,
       },
     }
   })
@@ -292,6 +295,56 @@ export const start = (): void => {
         session.value.document,
         session.value.snapshot,
         parameters.range,
+        (module) => session.value.moduleUris.get(module),
+      ),
+    ]
+  })
+
+  connection.languages.semanticTokens.on(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return { data: [] }
+    return Document.semanticTokens(session.value.document, session.value.snapshot)
+  })
+
+  connection.onFoldingRanges(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return []
+    return [...Document.foldingRanges(session.value.document, session.value.snapshot)]
+  })
+
+  connection.languages.callHierarchy.onPrepare(async (parameters) => {
+    const session = await acquire(parameters.textDocument.uri)
+    if (Option.isNone(session)) return null
+    const items = Document.prepareCallHierarchy(
+      session.value.document,
+      session.value.snapshot,
+      parameters.position,
+      (module) => session.value.moduleUris.get(module),
+    )
+    return items.length === 0 ? null : [...items]
+  })
+
+  connection.languages.callHierarchy.onIncomingCalls(async (parameters) => {
+    const session = await acquire(parameters.item.uri)
+    if (Option.isNone(session)) return null
+    return [
+      ...Document.incomingCalls(
+        session.value.document,
+        session.value.snapshot,
+        parameters.item,
+        (module) => session.value.moduleUris.get(module),
+      ),
+    ]
+  })
+
+  connection.languages.callHierarchy.onOutgoingCalls(async (parameters) => {
+    const session = await acquire(parameters.item.uri)
+    if (Option.isNone(session)) return null
+    return [
+      ...Document.outgoingCalls(
+        session.value.document,
+        session.value.snapshot,
+        parameters.item,
         (module) => session.value.moduleUris.get(module),
       ),
     ]

--- a/packages/lsp/test/Document.test.ts
+++ b/packages/lsp/test/Document.test.ts
@@ -5,10 +5,11 @@ import * as SourceFile from '@silk-effect/compiler/SourceFile'
 import * as SourceOrigin from '@silk-effect/compiler/SourceOrigin'
 import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
 import * as Stdlib from '@silk-effect/compiler/Stdlib'
+import * as TextMate from '@silk-effect/language/TextMate'
 import * as Effect from 'effect/Effect'
 import * as Layer from 'effect/Layer'
 import * as Option from 'effect/Option'
-import { SymbolKind } from 'vscode-languageserver-types'
+import { SemanticTokenTypes, SymbolKind } from 'vscode-languageserver-types'
 import * as Document from '../src/Document.js'
 
 const encoder = new TextEncoder()
@@ -1310,5 +1311,246 @@ pub fn main() -> i32 { return clamp(double(1), 0, 10) }
     )
     assert.strictEqual(help?.signatures[0]?.label, 'pub fn double(value: i32) -> i32')
     assert.strictEqual(help?.activeParameter, 0)
+  }),
+)
+
+/** Decodes the protocol's delta encoding back into absolute, readable tokens. */
+const decodeSemanticTokens = (tokens: {
+  readonly data: ReadonlyArray<number>
+}): ReadonlyArray<{
+  readonly line: number
+  readonly character: number
+  readonly length: number
+  readonly type: string
+}> => {
+  const decoded: Array<{
+    line: number
+    character: number
+    length: number
+    type: string
+  }> = []
+  let line = 0
+  let character = 0
+  for (let index = 0; index + 4 < tokens.data.length; index += 5) {
+    const deltaLine = tokens.data[index] ?? 0
+    const deltaCharacter = tokens.data[index + 1] ?? 0
+    line += deltaLine
+    character = deltaLine === 0 ? character + deltaCharacter : deltaCharacter
+    decoded.push({
+      line,
+      character,
+      length: tokens.data[index + 2] ?? 0,
+      type: Document.semanticTokenTypes[tokens.data[index + 3] ?? 0] ?? 'unknown',
+    })
+  }
+  return decoded
+}
+
+const semanticTokenAt = (
+  decoded: ReadonlyArray<{
+    readonly line: number
+    readonly character: number
+    readonly length: number
+    readonly type: string
+  }>,
+  source: string,
+  spelling: string,
+  occurrence = 0,
+) => {
+  const { line, character } = positionOf(source, spelling, occurrence)
+  return decoded.find((token) => token.line === line && token.character === character)
+}
+
+it.effect('colors a type name and a variable name with different token types', () =>
+  Effect.gen(function* () {
+    const source = `pub struct Point { x: i32 }
+pub fn main() -> i32 {
+  let total = 1
+  return total
+}
+`
+    const { document, snapshot } = yield* open(source)
+    const decoded = decodeSemanticTokens(Document.semanticTokens(document, snapshot))
+    const type = semanticTokenAt(decoded, source, 'Point')
+    const variable = semanticTokenAt(decoded, source, 'total', 1)
+    assert.strictEqual(type?.type, 'type')
+    assert.strictEqual(variable?.type, 'variable')
+    // The lexer's own kinds carry the rest, so a keyword never depends on a resolved name.
+    assert.strictEqual(semanticTokenAt(decoded, source, 'pub')?.type, 'keyword')
+    assert.strictEqual(semanticTokenAt(decoded, source, 'main')?.type, 'function')
+  }),
+)
+
+it.effect('names every keyword the TextMate grammar colors in the semantic token legend', () =>
+  Effect.gen(function* () {
+    // The grammar and the legend both read the compiler's token kinds, so one source of keywords
+    // decides both: every kind the grammar spells must reach a legend entry the server sends.
+    const source = `${Object.values(TextMate.keywords).join(' ')}\n`
+    const { document, snapshot } = yield* open(source)
+    const decoded = decodeSemanticTokens(Document.semanticTokens(document, snapshot))
+    const colored = new Set(
+      decoded.filter((token) => token.type === 'keyword').map((token) => token.character),
+    )
+    assert.isTrue(Document.semanticTokenTypes.includes('keyword'))
+    for (const spelling of Object.values(TextMate.keywords)) {
+      assert.isTrue(
+        colored.has(positionOf(source, spelling).character),
+        `keyword ${spelling} carries no semantic token`,
+      )
+    }
+    for (const type of Document.semanticTokenTypes) {
+      assert.isTrue(
+        (Object.values(SemanticTokenTypes) as ReadonlyArray<string>).includes(type),
+        `legend entry ${type} is not a standard token type`,
+      )
+    }
+  }),
+)
+
+it.effect('folds a function body from its open brace to its close brace', () =>
+  Effect.gen(function* () {
+    const source = `pub fn main() -> i32 {
+  let total = 1
+  return total
+}
+`
+    const { document, snapshot } = yield* open(source)
+    assert.deepEqual(
+      Document.foldingRanges(document, snapshot).map(({ startLine, endLine }) => ({
+        startLine,
+        endLine,
+      })),
+      [{ startLine: 0, endLine: 3 }],
+    )
+  }),
+)
+
+it.effect('folds a run of comment lines as one block', () =>
+  Effect.gen(function* () {
+    const source = `// first
+// second
+// third
+pub fn main() -> i32 { return 1 }
+`
+    const { document, snapshot } = yield* open(source)
+    assert.deepEqual(Document.foldingRanges(document, snapshot), [
+      { startLine: 0, endLine: 2, kind: 'comment' },
+    ])
+  }),
+)
+
+const calleeModule = 'pub fn helper(value: i32) -> i32 { return value }'
+
+it.effect('lists two callers of one function across two modules', () =>
+  Effect.gen(function* () {
+    const first = 'import helper\npub fn caller() -> i32 { return helper.helper(1) }'
+    const second = 'import helper\npub fn main() -> i32 { return helper.helper(3) }'
+    const { document, snapshot } = yield* openProject(
+      [
+        { module: 'helper', text: calleeModule },
+        { module: 'caller', text: first },
+        { module: 'main', text: second },
+      ],
+      'helper',
+    )
+    const prepared = Document.prepareCallHierarchy(
+      document,
+      snapshot,
+      positionOf(calleeModule, 'helper'),
+      uriOfModule,
+    )
+    assert.strictEqual(prepared.length, 1)
+    assert.strictEqual(prepared[0]?.name, 'helper')
+    assert.strictEqual(prepared[0]?.detail, 'pub fn helper(value: i32) -> i32')
+    const item = prepared[0]
+    if (item === undefined) throw new Error('prepare produced no item')
+    assert.deepEqual(
+      Document.incomingCalls(document, snapshot, item, uriOfModule).map(({ from, fromRanges }) => ({
+        name: from.name,
+        uri: from.uri,
+        calls: fromRanges.length,
+      })),
+      [
+        { name: 'caller', uri: uriOfModule('caller'), calls: 1 },
+        { name: 'main', uri: uriOfModule('main'), calls: 1 },
+      ],
+    )
+  }),
+)
+
+it.effect('places structural answers with the negotiated position encoding', () =>
+  Effect.gen(function* () {
+    // The comment holds an astral character, which is one UTF-16 surrogate pair and four bytes:
+    // a byte-counted column would put every answer after it two columns too far right.
+    const source = `// 😀
+pub fn helper(value: i32) -> i32 { return value }
+pub fn main() -> i32 {
+  return helper(1)
+}
+`
+    const { document, snapshot } = yield* open(source)
+    const decoded = decodeSemanticTokens(Document.semanticTokens(document, snapshot))
+    assert.deepEqual(
+      decoded.filter((token) => token.line === 1 && token.type === 'function'),
+      // `helper` sits at UTF-16 column 7 of its own line, unshifted by the astral character above.
+      [{ line: 1, character: 7, length: 6, type: 'function' }],
+    )
+    assert.deepEqual(
+      Document.foldingRanges(document, snapshot).map(({ startLine, endLine }) => ({
+        startLine,
+        endLine,
+      })),
+      [
+        { startLine: 0, endLine: 0 },
+        { startLine: 1, endLine: 1 },
+        { startLine: 2, endLine: 4 },
+      ].filter(({ startLine, endLine }) => endLine > startLine),
+    )
+    const prepared = Document.prepareCallHierarchy(
+      document,
+      snapshot,
+      positionOf(source, 'main'),
+      () => undefined,
+    )
+    const item = prepared[0]
+    if (item === undefined) throw new Error('prepare produced no item')
+    assert.deepEqual(
+      Document.outgoingCalls(document, snapshot, item, () => undefined).map(
+        ({ to, fromRanges }) => ({ name: to.name, ranges: fromRanges }),
+      ),
+      [
+        {
+          name: 'helper',
+          ranges: [{ start: { line: 3, character: 9 }, end: { line: 3, character: 15 } }],
+        },
+      ],
+    )
+  }),
+)
+
+it.effect('lists the functions one function calls', () =>
+  Effect.gen(function* () {
+    const source = `pub fn helper(value: i32) -> i32 { return value }
+pub fn double(value: i32) -> i32 { return value }
+pub fn main() -> i32 { return helper(1) + double(2) + helper(3) }
+`
+    const { document, snapshot } = yield* open(source)
+    const prepared = Document.prepareCallHierarchy(
+      document,
+      snapshot,
+      positionOf(source, 'main'),
+      () => undefined,
+    )
+    const item = prepared[0]
+    if (item === undefined) throw new Error('prepare produced no item')
+    assert.deepEqual(
+      Document.outgoingCalls(document, snapshot, item, () => undefined).map(
+        ({ to, fromRanges }) => ({ name: to.name, calls: fromRanges.length }),
+      ),
+      [
+        { name: 'helper', calls: 2 },
+        { name: 'double', calls: 1 },
+      ],
+    )
   }),
 )

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { assert, it } from '@effect/vitest'
+import * as Document from '../src/Document.js'
 
 const binPath = fileURLToPath(new URL('../dist/bin.js', import.meta.url))
 
@@ -141,6 +142,12 @@ it('serves diagnostics, hover, and formatting over real stdio', { timeout: 30_00
     })
     assert.deepEqual(initialized.capabilities.signatureHelpProvider, {
       triggerCharacters: ['(', ','],
+    })
+    assert.strictEqual(initialized.capabilities.foldingRangeProvider, true)
+    assert.strictEqual(initialized.capabilities.callHierarchyProvider, true)
+    assert.deepEqual(initialized.capabilities.semanticTokensProvider, {
+      legend: { tokenTypes: [...Document.semanticTokenTypes], tokenModifiers: [] },
+      full: true,
     })
     client.send({ method: 'initialized', params: {} })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+      '@silk-effect/language':
+        specifier: workspace:*
+        version: link:../language
       '@types/node':
         specifier: ^24.10.1
         version: 24.13.3


### PR DESCRIPTION
Closes #49

Stacked on #85 (`agent/47-signature-help`), itself stacked on #78. Review only the top commit; the base branch carries the rest.

All three capabilities map an artifact the compiler already computes onto the protocol, and all three reuse `LineIndex` for positions, so each answer lands in the negotiated `utf-16` encoding.

- **Semantic tokens** type an identifier from the semantic occurrence covering it rather than from its spelling — which is what separates a type name from a variable name that the TextMate grammar's regular expressions must color alike. Keywords, comments, literals, and operators are decided by the lexer's own token kinds, the same source `packages/language/src/TextMate.ts` reads.
- **Folding ranges** fold each braced region from its opening brace's line to its closing brace's line, plus one range per run of adjacent comment lines. Silk has no delimited block comment, so a run of `//`, `///`, or `//!` lines is the block a reader means to collapse.
- **Call hierarchy** resolves the selection through the occurrence index (via `Analysis.declarationForIdentity`, exported by #85) and attributes each use to the declaration whose body encloses it, so incoming calls span every module of the analyzed project and repeated calls collapse into one entry carrying every range.

## Acceptance criteria

- [x] A test asserts the initialize response advertises all three providers.
- [x] A test compares the semantic token legend with the token kinds in `packages/language/src/TextMate.ts`. Added `@silk-effect/language` as a **devDependency** of `@silk-effect/lsp` so the test reads the grammar's real keyword table; it stays out of the runtime dependencies.
- [x] A test asserts a semantic token request colors a type name and a variable name with different types.
- [x] A test asserts a folding range covers a function body from the open brace to the close brace.
- [x] A test asserts incoming calls of one function list two callers across two modules.
- [x] A test asserts outgoing calls of one function list the functions it calls.
- [x] A new `language-server-structure` spec records the requirements for the three capabilities.

One test beyond the criteria covers requirement 10 directly: a document holding an astral character asserts that semantic tokens, folding ranges, and call hierarchy ranges are all placed in UTF-16 columns rather than byte columns.

## Notes

- Out-of-scope items in the issue are respected: no delta or range semantic tokens (`full: true` only), and no `// region` marker folding.
- A token spanning more than one line is omitted rather than truncated, because the protocol's delta encoding cannot express one.
- `biome check` reports one pre-existing formatting nit in the `signatureHelp` handler in `packages/lsp/src/Server.ts`, which comes from the base branch (#85) and is untouched here.

Tests: baseline 0 failures (measured in step 0), after 0 failures, +7 new tests
