### PR TITLE
lexer: Use the reserved modifier slot for raw strings

### DIFF
--- a/examples/language-pressure/lexer/main.silk
+++ b/examples/language-pressure/lexer/main.silk
@@ -84,7 +84,8 @@ fn isLineCommentStart(source: &[u8], index: usize) -> bool {
 
 fn isLiteralStart(source: &[u8], index: usize) -> bool {
   if byteAtOrZero(source, index) == 34 { return true }
-  return hasPair(source, index, 98, 34)
+  if hasPair(source, index, 98, 34) { return true }
+  return hasPair(source, index, 114, 34)
 }
 
 fn hasTripleQuote(source: &[u8], index: usize) -> bool {
@@ -260,7 +261,8 @@ fn scanLiteral(
   modifierWidth: usize,
   delimiterWidth: usize,
   kind: u8,
-  alwaysInvalid: bool
+  alwaysInvalid: bool,
+  raw: bool
 ) -> Decision {
   let mut index = start + modifierWidth + delimiterWidth
   while index < source.length {
@@ -283,7 +285,9 @@ fn scanLiteral(
         return Decision { kind: kind, end: index + 3, invalid: false }
       }
     }
-    if byte == 92 {
+    let mut escaping = byte == 92
+    if raw { escaping = false }
+    if escaping {
       if index + 1 < source.length {
         let escaped = source[index + 1]
         if delimiterWidth == 1 {
@@ -370,14 +374,19 @@ fn nextToken(source: &[u8], start: usize) -> Decision {
   if isLiteralStart(source, start) {
     let mut kind = u8.add(7, 0)
     let mut modifierWidth = usize.add(0, 0)
+    let mut raw = false
     if byte == 98 {
       kind = u8.add(8, 0)
+      modifierWidth = usize.add(1, 0)
+    }
+    if byte == 114 {
+      raw = true
       modifierWidth = usize.add(1, 0)
     }
     let quoteStart = start + modifierWidth
     let mut delimiterWidth = usize.add(1, 0)
     if hasTripleQuote(source, quoteStart) { delimiterWidth = usize.add(3, 0) }
-    return scanLiteral(source, start, modifierWidth, delimiterWidth, kind, false)
+    return scanLiteral(source, start, modifierWidth, delimiterWidth, kind, false, raw)
   }
   if isIdentifierStart(byte) {
     let end = scanIdentifier(source, start)
@@ -390,7 +399,8 @@ fn nextToken(source: &[u8], start: usize) -> Decision {
         end - start,
         delimiterWidth,
         tokenInvalidStaticLiteral,
-        true
+        true,
+        false
       )
     }
     return Decision { kind: keywordKind(source, start, end), end: end, invalid: false }

--- a/openspec/specs/bootstrap-language-pressure-programs/spec.md
+++ b/openspec/specs/bootstrap-language-pressure-programs/spec.md
@@ -29,8 +29,8 @@ lexer-specific or token-specific operations, layouts, or branches.
 
 The Silk lexer SHALL be differentially checked against the TypeScript lexer, which remains the
 canonical implementation. The corpus SHALL cover whitespace, comments, identifiers, every current
-keyword, decimal integer and float forms, single-line and multiline text and byte literals with
-valid and malformed escapes, recognized and unknown literal modifiers, physical LF and CRLF,
+keyword, decimal integer and float forms, single-line and multiline text, byte, and raw literals
+with valid and malformed escapes, recognized and unknown literal modifiers, physical LF and CRLF,
 terminated and unterminated delimiters, every current single and compound punctuation token,
 end-of-file, and unsupported byte runs.
 

--- a/openspec/specs/bootstrap-lexer/spec.md
+++ b/openspec/specs/bootstrap-lexer/spec.md
@@ -222,18 +222,27 @@ same longest complete-identifier rule as every other keyword.
 
 ### Requirement: String literal introductions are closed and extensible
 
-The lexer SHALL recognize unmodified and `b`-modified string literal introductions with either one
-quote or three quotes as one deterministic literal token. The modifier SHALL be adjacent to the
-opening delimiter, delimiter recognition SHALL prefer three quotes over one quote, and the token
-kind SHALL retain whether the literal denotes text or bytes without requiring a distinct kind for
-every delimiter width. An identifier-like spelling immediately adjacent to a quote delimiter that
-is not in the closed modifier vocabulary SHALL be reserved as an invalid literal introduction and
-SHALL produce a lexical diagnostic rather than tokenize as an identifier followed by a literal.
+The lexer SHALL recognize unmodified, `b`-modified, and `r`-modified string literal introductions
+with either one quote or three quotes as one deterministic literal token. The modifier SHALL be
+adjacent to the opening delimiter, delimiter recognition SHALL prefer three quotes over one quote,
+and the token kind SHALL retain whether the literal denotes text or bytes without requiring a
+distinct kind for every delimiter width. The body-decoding policy SHALL be selected by the modifier
+independently of the delimiter width: the unmodified and `b`-modified forms SHALL be escaped, and
+the `r`-modified form SHALL be raw. A raw literal SHALL denote text and SHALL carry the text token
+kind. An identifier-like spelling immediately adjacent to a quote delimiter that is not in the
+closed modifier vocabulary SHALL be reserved as an invalid literal introduction and SHALL produce a
+lexical diagnostic rather than tokenize as an identifier followed by a literal. A modifier spelling
+SHALL remain an ordinary identifier wherever it is not adjacent to a quote delimiter.
 
 #### Scenario: Recognize every committed literal introduction
 
-- **WHEN** source contains `"text"`, `b"bytes"`, `"""text"""`, and `b"""bytes"""`
-- **THEN** the lexer emits four literal tokens retaining their text-or-byte category, delimiter width, exact source span, and source slice
+- **WHEN** source contains `"text"`, `b"bytes"`, `r"text"`, `"""text"""`, `b"""bytes"""`, and `r"""text"""`
+- **THEN** the lexer emits six literal tokens retaining their text-or-byte category, delimiter width, exact source span, and source slice
+
+#### Scenario: Keep a modifier spelling usable as an identifier
+
+- **WHEN** source contains `r` and `b` where no quote delimiter follows either spelling
+- **THEN** each spelling remains one ordinary identifier token and produces no lexical diagnostic
 
 #### Scenario: Prefer the multiline delimiter
 
@@ -250,10 +259,11 @@ SHALL produce a lexical diagnostic rather than tokenize as an identifier followe
 An escaped single-line literal SHALL close at the first unescaped quote and SHALL otherwise stop
 immediately before a physical CR or LF. An escaped multiline literal SHALL close at the first
 unescaped run of three quotes and MAY contain physical line endings; if no closing delimiter
-exists, it SHALL consume through end-of-file. Each unterminated literal SHALL produce exactly one
-lexical diagnostic anchored to its introduction. Recovery MUST NOT infer a closing boundary from
-indentation, keywords, declarations, braces, comments, or other code-like content inside a
-multiline literal.
+exists, it SHALL consume through end-of-file. A raw literal SHALL treat a backslash as ordinary
+content and SHALL therefore close at the first run of its delimiter, under the same single-line and
+multiline rules. Each unterminated literal SHALL produce exactly one lexical diagnostic anchored to
+its introduction. Recovery MUST NOT infer a closing boundary from indentation, keywords,
+declarations, braces, comments, or other code-like content inside a multiline literal.
 
 #### Scenario: Recover an unterminated single-line literal
 
@@ -269,6 +279,11 @@ multiline literal.
 
 - **WHEN** a multiline literal body contains `\"\"\"` followed later by an unescaped `"""`
 - **THEN** the escaped quotes remain literal content and the later unescaped triple quote closes the token
+
+#### Scenario: Close a raw literal at its first delimiter run
+
+- **WHEN** source contains `r"path\"` followed by further source on the same line
+- **THEN** the raw literal closes at the quote after the backslash rather than continuing past it, and the following source lexes independently
 
 ### Requirement: Integer literals select a base from their prefix
 

--- a/openspec/specs/bootstrap-static-text/spec.md
+++ b/openspec/specs/bootstrap-static-text/spec.md
@@ -58,8 +58,14 @@ Single-line and multiline forms of the same text-or-byte category SHALL accept t
 vocabulary and reject the same malformed escapes. A backslash followed by a physical line ending
 SHALL be invalid and MUST NOT remove that line ending or any following whitespace. One or two
 unescaped consecutive quotes SHALL be content in a triple-delimited literal; the first unescaped
-run of three quotes SHALL be its closing delimiter. Raw escape behavior SHALL require a separately
-recognized future modifier and MUST NOT be inferred from delimiter width.
+run of three quotes SHALL be its closing delimiter. Raw escape behavior SHALL require the
+separately recognized `r` modifier and MUST NOT be inferred from delimiter width.
+
+A raw text literal using either one-quote or three-quote delimiters SHALL decode every content
+byte, including a backslash, as itself, SHALL accept no escape sequence, and SHALL reject no
+sequence as a malformed escape. It SHALL otherwise decode as an escaped text literal does: it SHALL
+yield immutable program-lifetime UTF-8, SHALL be rejected when its content is not valid UTF-8, and
+SHALL represent each physical CRLF pair in multiline content by one LF.
 
 #### Scenario: Decode the same escape in both widths
 
@@ -75,6 +81,11 @@ recognized future modifier and MUST NOT be inferred from delimiter width.
 
 - **WHEN** a triple-delimited literal body spells three escaped quotes as `\"\"\"`
 - **THEN** the decoded value contains three quote characters without closing at that escaped sequence
+
+#### Scenario: Decode a raw body without interpreting escapes
+
+- **WHEN** source contains `r"\n"` and `"\n"`
+- **THEN** the raw literal decodes to the two bytes backslash and `n` while the escaped literal decodes to the one byte LF
 
 ### Requirement: Static storage is target-neutral compiler data
 

--- a/packages/compiler/src/Lexer.ts
+++ b/packages/compiler/src/Lexer.ts
@@ -339,6 +339,7 @@ export const lex = (source: SourceFile.SourceFile): LexicalResult => {
         bytes,
         start + modifierWidth + delimiterWidth,
         delimiterWidth,
+        form?.escapePolicy ?? 'Escaped',
       )
       index = boundary.end
       const span = pushToken(

--- a/packages/compiler/src/LiteralForm.ts
+++ b/packages/compiler/src/LiteralForm.ts
@@ -7,12 +7,12 @@ export type Category = 'Text' | 'Bytes'
 export type DelimiterWidth = 1 | 3
 
 /** The body-decoding policy selected independently from delimiter width. */
-export type EscapePolicy = 'Escaped'
+export type EscapePolicy = 'Escaped' | 'Raw'
 
 /** Immutable source-form metadata shared by the compiler and editor tooling. */
 export interface LiteralForm {
   readonly category: Category
-  readonly modifier: '' | 'b'
+  readonly modifier: '' | 'b' | 'r'
   readonly delimiterWidth: DelimiterWidth
   readonly escapePolicy: EscapePolicy
   readonly tokenKind: 'TextLiteral' | 'ByteStringLiteral'
@@ -22,19 +22,21 @@ const make = (
   category: Category,
   modifier: LiteralForm['modifier'],
   delimiterWidth: DelimiterWidth,
+  escapePolicy: EscapePolicy,
   tokenKind: LiteralForm['tokenKind'],
-): LiteralForm =>
-  Object.freeze({ category, modifier, delimiterWidth, escapePolicy: 'Escaped', tokenKind })
+): LiteralForm => Object.freeze({ category, modifier, delimiterWidth, escapePolicy, tokenKind })
 
 /**
  * Every committed form, ordered by longest introduction first. Consumers that generate matching
  * rules can retain this order without reconstructing the language's precedence contract.
  */
 export const forms: ReadonlyArray<LiteralForm> = Object.freeze([
-  make('Bytes', 'b', 3, 'ByteStringLiteral'),
-  make('Text', '', 3, 'TextLiteral'),
-  make('Bytes', 'b', 1, 'ByteStringLiteral'),
-  make('Text', '', 1, 'TextLiteral'),
+  make('Bytes', 'b', 3, 'Escaped', 'ByteStringLiteral'),
+  make('Text', 'r', 3, 'Raw', 'TextLiteral'),
+  make('Text', '', 3, 'Escaped', 'TextLiteral'),
+  make('Bytes', 'b', 1, 'Escaped', 'ByteStringLiteral'),
+  make('Text', 'r', 1, 'Raw', 'TextLiteral'),
+  make('Text', '', 1, 'Escaped', 'TextLiteral'),
 ])
 
 const quote = 0x22
@@ -98,11 +100,15 @@ export interface Boundary {
   readonly terminated: boolean
 }
 
-/** Scans exactly one escaped literal body after its opening delimiter. */
+/**
+ * Scans exactly one literal body after its opening delimiter. A raw body never consults a
+ * backslash, so `r"path\"` closes at its own quote rather than at the next one.
+ */
 export const scanBoundary = (
   bytes: ByteSequence,
   contentStart: number,
   delimiterWidth: DelimiterWidth,
+  escapePolicy: EscapePolicy = 'Escaped',
 ): Boundary => {
   let index = contentStart
   while (index < bytes.length) {
@@ -116,7 +122,7 @@ export const scanBoundary = (
       index += 1
       continue
     }
-    if (bytes[index] === 0x5c && index + 1 < bytes.length) {
+    if (escapePolicy === 'Escaped' && bytes[index] === 0x5c && index + 1 < bytes.length) {
       if (delimiterWidth === 1 && (bytes[index + 1] === 0x0a || bytes[index + 1] === 0x0d)) {
         index += 1
       } else {

--- a/packages/compiler/src/StaticText.ts
+++ b/packages/compiler/src/StaticText.ts
@@ -63,7 +63,7 @@ export const decode = (
   let index = contentStart
   while (index < end) {
     const byte = token[index]
-    if (byte !== 0x5c) {
+    if (byte !== 0x5c || form.escapePolicy === 'Raw') {
       if (form.delimiterWidth === 3 && byte === 0x0d) {
         if (token[index + 1] !== 0x0a)
           return invalid('isolated carriage return in multiline literal', index)

--- a/packages/compiler/test/Lexer.test.ts
+++ b/packages/compiler/test/Lexer.test.ts
@@ -120,6 +120,65 @@ it('recognizes all static-literal forms with exact multiline boundaries', () => 
   assert.deepEqual(result.diagnostics, [])
 })
 
+it('recognizes raw text literals in both delimiter widths without escape processing', () => {
+  const text = 'r"\\d+\\.\\d+" r"""raw\nbody\\n""" r"path\\" tail'
+  const source = SourceFile.make('memory://raw-literals.silk', ascii(text))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens
+      .filter((token) => token.kind !== 'Whitespace')
+      .map((token) => tokenView(source, token)),
+    [
+      { kind: 'TextLiteral', start: 0, end: 11, slice: 'r"\\d+\\.\\d+"' },
+      { kind: 'TextLiteral', start: 12, end: 29, slice: 'r"""raw\nbody\\n"""' },
+      // A raw body never consults a backslash, so this closes at its own quote.
+      { kind: 'TextLiteral', start: 30, end: 38, slice: 'r"path\\"' },
+      { kind: 'Identifier', start: 39, end: 43, slice: 'tail' },
+      { kind: 'EndOfFile', start: 43, end: 43, slice: '' },
+    ],
+  )
+  assert.deepEqual(result.diagnostics, [])
+})
+
+it('keeps the raw modifier spelling an identifier away from a quote delimiter', () => {
+  const source = SourceFile.make('memory://raw-identifier.silk', ascii('r rb"value" return'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens.filter((token) => token.kind !== 'Whitespace').map((token) => token.kind),
+    ['Identifier', 'InvalidStaticLiteral', 'ReturnKeyword', 'EndOfFile'],
+  )
+  assert.deepEqual(
+    result.diagnostics.map(({ code, reason }) => ({ code, reason })),
+    [{ code: 'LEX0002', reason: { _tag: 'UnknownLiteralModifier', modifier: 'rb' } }],
+  )
+})
+
+it('recovers an unterminated raw literal with exactly one diagnostic', () => {
+  const source = SourceFile.make('memory://raw-unterminated.silk', ascii('r"broken\nnext'))
+  const result = Lexer.lex(source)
+  assert.deepEqual(
+    result.tokens.map((token) => token.kind),
+    ['InvalidStaticLiteral', 'Whitespace', 'Identifier', 'EndOfFile'],
+  )
+  assert.deepEqual(
+    result.diagnostics.map((diagnostic) => diagnostic.code),
+    ['LEX0003'],
+  )
+
+  const multiline = Lexer.lex(
+    SourceFile.make('memory://raw-unterminated-multiline.silk', ascii('r"""code-like\nfn f() { }')),
+  )
+  assert.deepEqual(
+    multiline.tokens.map((token) => token.kind),
+    ['InvalidStaticLiteral', 'EndOfFile'],
+  )
+  assert.deepEqual(
+    multiline.diagnostics.map((diagnostic) => diagnostic.code),
+    ['LEX0003'],
+  )
+  assert.strictEqual(multiline.tokens[0]?.span.end, multiline.source.bytes.length)
+})
+
 it('diagnoses reserved modifiers and unterminated delimiters once with committed recovery', () => {
   const unknown = Lexer.lex(
     SourceFile.make('memory://unknown-modifiers.silk', ascii('future"value" br"""value"""')),

--- a/packages/compiler/test/LexerPressure.test.ts
+++ b/packages/compiler/test/LexerPressure.test.ts
@@ -273,6 +273,11 @@ const corpus = [
       '"text\\"tail" b"\\x41" """line 1\r\n// body\n\\"\\"\\"""" b"""bytes\n""" future"value" "unterminated\nnext',
   }),
   Object.freeze({
+    id: 'raw-literals',
+    input:
+      'r"\\d+\\.\\d+" r"""raw\\n\nbody\r\n""" r"path\\" tail r"unterminated\nrb"value" r return',
+  }),
+  Object.freeze({
     id: 'punctuation',
     input: '( ) { } [ ] : ; , = == => - + * / % ! != ? @ < <= > >= | |> & ^ ~ . .. ->',
   }),

--- a/packages/compiler/test/LiteralForm.test.ts
+++ b/packages/compiler/test/LiteralForm.test.ts
@@ -22,6 +22,13 @@ it('recognizes every committed form longest-first', () => {
       },
       {
         category: 'Text',
+        modifier: 'r',
+        delimiterWidth: 3,
+        escapePolicy: 'Raw',
+        tokenKind: 'TextLiteral',
+      },
+      {
+        category: 'Text',
         modifier: '',
         delimiterWidth: 3,
         escapePolicy: 'Escaped',
@@ -36,6 +43,13 @@ it('recognizes every committed form longest-first', () => {
       },
       {
         category: 'Text',
+        modifier: 'r',
+        delimiterWidth: 1,
+        escapePolicy: 'Raw',
+        tokenKind: 'TextLiteral',
+      },
+      {
+        category: 'Text',
         modifier: '',
         delimiterWidth: 1,
         escapePolicy: 'Escaped',
@@ -45,6 +59,19 @@ it('recognizes every committed form longest-first', () => {
   )
   assert.strictEqual(LiteralForm.recognize(bytes('"""body"""'))?.delimiterWidth, 3)
   assert.strictEqual(LiteralForm.recognize(bytes('b"""body"""'))?.delimiterWidth, 3)
+  assert.strictEqual(LiteralForm.recognize(bytes('r"""body"""'))?.delimiterWidth, 3)
+})
+
+it('scans a raw boundary without consulting a backslash', () => {
+  // `r"path\"` closes at its own quote; the escaped form would swallow it and run on.
+  assert.deepEqual(LiteralForm.scanBoundary(bytes('r"path\\" tail'), 2, 1, 'Raw'), {
+    end: 8,
+    terminated: true,
+  })
+  assert.deepEqual(LiteralForm.scanBoundary(bytes('"path\\" tail'), 1, 1, 'Escaped'), {
+    end: 12,
+    terminated: false,
+  })
 })
 
 it('reserves identifier-like unknown modifiers without accepting them as forms', () => {

--- a/packages/compiler/test/RawStringAcceptance.test.ts
+++ b/packages/compiler/test/RawStringAcceptance.test.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const encoder = new TextEncoder()
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-raw-string-acceptance-'))
+
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const assertRunsEverywhere = Effect.fnUntraced(function* (
+  sourceId: string,
+  source: string,
+  expected: number,
+) {
+  const bytes = encoder.encode(source)
+  const snapshot = yield* Analysis.ofSourceRealized(sourceId, bytes, 'wasm32-unknown-unknown')
+  assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+  const evaluated = Analysis.evaluate(snapshot)
+  assert.strictEqual(
+    evaluated._tag,
+    'Completed',
+    JSON.stringify(evaluated, (_, value) => (typeof value === 'bigint' ? value.toString() : value)),
+  )
+  if (evaluated._tag === 'Completed') {
+    assert.strictEqual(evaluated.result.value, expected)
+  }
+
+  const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+  assert.strictEqual((instance.exports.silk_main as () => number)(), expected)
+
+  const compiled = yield* Driver.compile({
+    compilation: { root: SourceFile.make(sourceId, bytes) },
+    toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+    profile: 'release',
+    destination: join(destinationRoot, sourceId.replaceAll('/', '-')),
+  }).pipe(Effect.provide(SourceResolver.empty))
+  assert.strictEqual(
+    compiled._tag,
+    'Compiled',
+    JSON.stringify(compiled, (_, value) => (typeof value === 'bigint' ? value.toString() : value)),
+  )
+  if (compiled._tag === 'Compiled') {
+    const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+    assert.strictEqual(run.status, expected, run.stderr)
+  }
+})
+
+/**
+ * `r"\n"` is a backslash and an `n`; `"\n"` is one LF. The raw form keeps the escape vocabulary
+ * out of its body entirely, so a regular expression or a Windows path needs no doubled backslash.
+ */
+const escapePolicy = `import silk.string { byteLength, utf8Bytes }
+
+pub fn main() -> i32 {
+  let raw = r"\\n"
+  let escaped = "\\n"
+  if usize.toI32(byteLength(raw)) == 2 {} else { return 1 }
+  if usize.toI32(byteLength(escaped)) == 1 {} else { return 2 }
+
+  let rawBytes = utf8Bytes(raw)
+  if rawBytes[usize.ZERO] == 92 {} else { return 3 }
+  if rawBytes[usize.add(1, 0)] == 110 {} else { return 4 }
+  if utf8Bytes(escaped)[usize.ZERO] == 10 {} else { return 5 }
+
+  let decimalPattern = r"\\d+\\.\\d+"
+  let windowsPath = r"C:\\Users\\build"
+  if usize.toI32(byteLength(decimalPattern)) == 8 {} else { return 6 }
+  if usize.toI32(byteLength(windowsPath)) == 14 {} else { return 7 }
+  return 42
+}`
+
+it.effect(
+  'decodes a raw literal body without escapes on all three engines',
+  () => assertRunsEverywhere('raw-string/escape-policy', escapePolicy, 42),
+  60_000,
+)
+
+/** The triple-delimited raw form takes the same body policy as its single-delimited form. */
+const multiline = `import silk.string { byteLength, utf8Bytes }
+
+pub fn main() -> i32 {
+  let helpText = r"""
+Usage: silk build
+  --target \\path\\to\\dir
+"""
+  let bytes = utf8Bytes(helpText)
+  if bytes[usize.ZERO] == 10 {} else { return 1 }
+  // A backslash inside the body is content, exactly as in the single-delimited form.
+  if bytes[usize.add(30, 0)] == 92 {} else { return 2 }
+  if usize.toI32(byteLength(helpText)) == 43 {} else { return 3 }
+  return 42
+}`
+
+it.effect(
+  'keeps the raw body policy across both delimiter widths on all three engines',
+  () => assertRunsEverywhere('raw-string/multiline', multiline, 42),
+  60_000,
+)
+
+it.effect('gives a raw literal the string type, so it passes where a text literal does', () =>
+  Effect.gen(function* () {
+    // `byteLength` accepts `string` only, so accepting this call is the type evidence.
+    const source = `import silk.string { byteLength }
+
+fn measure(value: string) -> usize { return byteLength(value) }
+
+pub fn main() -> i32 {
+  return usize.toI32(measure(r"\\d")) + usize.toI32(measure("d"))
+}`
+    const snapshot = yield* Analysis.ofSourceRealized('raw-string/type', encoder.encode(source))
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 3)
+  }),
+)
+
+it.effect('rejects a raw literal whose body is not valid UTF-8', () =>
+  Effect.gen(function* () {
+    const bytes = Uint8Array.from([
+      ...encoder.encode('pub fn main() -> i32 { let value = r"'),
+      0xff,
+      ...encoder.encode('" return 0 }'),
+    ])
+    const snapshot = yield* Analysis.ofSourceRealized('raw-string/invalid-utf8', bytes)
+    assert.isAbove(Analysis.diagnostics(snapshot).length, 0)
+  }),
+)

--- a/packages/language/src/TextMate.ts
+++ b/packages/language/src/TextMate.ts
@@ -86,28 +86,31 @@ const literalPatterns: ReadonlyArray<GrammarPattern> = LiteralForm.forms.map((fo
   const delimiter = '"'.repeat(form.delimiterWidth)
   const byte = form.category === 'Bytes'
   const width = form.delimiterWidth === 3 ? 'triple' : 'double'
+  const raw = form.escapePolicy === 'Raw'
   const begin = form.modifier.length === 0 ? `(${delimiter})` : `(${form.modifier})(${delimiter})`
   const delimiterCapture = form.modifier.length === 0 ? '1' : '2'
+  const guard = raw ? '' : '(?<!\\\\)(?:\\\\\\\\)*'
   return {
-    name: `string.quoted.${width}${byte ? '.byte' : ''}.silk`,
+    name: `string.quoted.${width}${byte ? '.byte' : raw ? '.raw' : ''}.silk`,
     begin,
-    end:
-      form.delimiterWidth === 3
-        ? `(?<!\\\\)(?:\\\\\\\\)*(${delimiter})`
-        : '(?<!\\\\)(?:\\\\\\\\)*(")|$',
+    end: form.delimiterWidth === 3 ? `${guard}(${delimiter})` : `${guard}(")|$`,
     beginCaptures: {
-      ...(form.modifier.length === 0 ? {} : { '1': { name: 'storage.modifier.byte.silk' } }),
+      ...(form.modifier.length === 0
+        ? {}
+        : { '1': { name: `storage.modifier.${byte ? 'byte' : 'raw'}.silk` } }),
       [delimiterCapture]: { name: 'punctuation.definition.string.begin.silk' },
     },
     endCaptures: {
       '1': { name: 'punctuation.definition.string.end.silk' },
     },
-    patterns: [
-      {
-        name: 'constant.character.escape.silk',
-        match: '\\\\(?:[nrt0"\\\\]|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})',
-      },
-    ],
+    patterns: raw
+      ? []
+      : [
+          {
+            name: 'constant.character.escape.silk',
+            match: '\\\\(?:[nrt0"\\\\]|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})',
+          },
+        ],
   }
 })
 

--- a/packages/language/test/TextMate.test.ts
+++ b/packages/language/test/TextMate.test.ts
@@ -57,11 +57,24 @@ it('generates one longest-first TextMate rule for every committed literal form',
     literals.map((pattern) => ({ name: pattern.name, begin: pattern.begin })),
     [
       { name: 'string.quoted.triple.byte.silk', begin: '(b)(""")' },
+      { name: 'string.quoted.triple.raw.silk', begin: '(r)(""")' },
       { name: 'string.quoted.triple.silk', begin: '(""")' },
       { name: 'string.quoted.double.byte.silk', begin: '(b)(")' },
+      { name: 'string.quoted.double.raw.silk', begin: '(r)(")' },
       { name: 'string.quoted.double.silk', begin: '(")' },
     ],
   )
+})
+
+it('gives a raw literal rule no escape patterns and no backslash boundary guard', () => {
+  const raw = TextMate.grammar.patterns.filter(
+    (pattern) => pattern.name?.startsWith('string.quoted.') && pattern.name.includes('.raw.'),
+  )
+  assert.lengthOf(raw, 2)
+  for (const pattern of raw) {
+    assert.deepStrictEqual(pattern.patterns, [])
+    assert.notInclude(pattern.end ?? '', '\\\\')
+  }
 })
 
 it('the VS Code extension ships exactly this grammar and configuration', () => {
@@ -163,5 +176,9 @@ it('assigns keyword, numeric, and comment scopes via a TextMate tokenizer', asyn
   assert.notInclude(scopesAt(multiline, '// not a comment'), 'comment.line.double-slash.silk')
   assert.include(scopesAt(multiline, 'return |>'), 'string.quoted.triple.silk')
   assert.include(scopesAt('b"""bytes\n// body\n"""', '// body'), 'string.quoted.triple.byte.silk')
+  assert.include(scopesAt('r"\\d+"', '\\d+'), 'string.quoted.double.raw.silk')
+  // A raw body has no escapes, so a backslash is content rather than an escape scope.
+  assert.notInclude(scopesAt('r"\\d+"', '\\d+'), 'constant.character.escape.silk')
+  assert.include(scopesAt('r"""raw\n// body\n"""', '// body'), 'string.quoted.triple.raw.silk')
   highlighter.dispose()
 })

--- a/packages/vscode/syntaxes/silk.tmLanguage.json
+++ b/packages/vscode/syntaxes/silk.tmLanguage.json
@@ -28,6 +28,25 @@
       ]
     },
     {
+      "name": "string.quoted.triple.raw.silk",
+      "begin": "(r)(\"\"\")",
+      "end": "(\"\"\")",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.raw.silk"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.silk"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.silk"
+        }
+      },
+      "patterns": []
+    },
+    {
       "name": "string.quoted.triple.silk",
       "begin": "(\"\"\")",
       "end": "(?<!\\\\)(?:\\\\\\\\)*(\"\"\")",
@@ -71,6 +90,25 @@
           "match": "\\\\(?:[nrt0\"\\\\]|x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\})"
         }
       ]
+    },
+    {
+      "name": "string.quoted.double.raw.silk",
+      "begin": "(r)(\")",
+      "end": "(\")|$",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.raw.silk"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.silk"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.silk"
+        }
+      },
+      "patterns": []
     },
     {
       "name": "string.quoted.double.silk",


### PR DESCRIPTION
Closes #13

Stacked on #80 (`agent/63-malformed-float-exponent`).

## Acceptance criteria

- [x] The lexer produces one text literal token for `r"\d"` instead of `LEX0002`.
- [x] A lexer test shows `r"..."` and `r"""..."""` as valid literals.
- [x] A test shows that the value of `r"\n"` is two bytes, not one.
- [x] A test shows that the value of `"\n"` stays one byte.
- [x] A lexer test shows that `future"value"` still produces `LEX0002`.
- [x] A lexer test shows that `r` alone stays an identifier token.
- [x] A lexer test shows that an unterminated `r"` produces one diagnostic.
- [x] `openspec/specs/bootstrap-lexer/spec.md` gets an amendment, because the requirement names the closed vocabulary as unmodified and `b`-modified only.

## Notes

`EscapePolicy` gains a second member rather than a new axis, as the issue's implementation note describes. `scanBoundary` now takes the policy and skips the two-byte backslash advance for a raw body, so `r"path\"` closes at its own quote. `StaticText.decode` passes a raw body through while keeping multiline CRLF normalization, which belongs to the delimiter width rather than the escape policy.

Two amendments beyond the one the issue names, both because the existing text became false:

- `bootstrap-static-text` said raw behavior "SHALL require a separately recognized future modifier" — that modifier is now `r`, and the raw decoding rule is stated.
- `bootstrap-language-pressure-programs` requires the differential corpus to cover recognized literal modifiers, which now includes `r`.

`examples/language-pressure/lexer/main.silk` is updated in lockstep with a new `raw-literals` corpus case, so `LexerPressure` checks the raw boundary rule across all three engines.

Tests: baseline 0 failures (measured in step 0), after 0 failures, +8 new tests