### PR TITLE
ownership: a generic effect body leaks any owner held across a fallible run

### DIFF
--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -835,6 +835,11 @@ const deferredBlocks = (
 /**
  * Run sites in this expression that can propagate a typed failure, stopping at effect blocks:
  * a deferred body's runs propagate out of its own compiled function, not out of this one.
+ *
+ * A run is fallible when its effect type carries failures OR an open failure row: inside a
+ * generic body the caller's failures arrive as a row *parameter*, so `failures` is empty while
+ * `failureParameters` is not, and specialization can substitute a row that really does fail.
+ * Reading `failures` alone leaves every owner live at such a run without a release.
  */
 const fallibleRunSites = (
   expression: Hir.Expression,
@@ -847,8 +852,24 @@ const fallibleRunSites = (
     typeof subjectType === 'object' &&
     subjectType !== null &&
     (subjectType as { readonly _tag?: string })._tag === 'EffectType' &&
-    (subjectType as Type.Effect).failures.length > 0
+    ((subjectType as Type.Effect).failures.length > 0 ||
+      (subjectType as Type.Effect).failureParameters.length > 0)
   return fallible ? [expression, ...nested] : nested
+}
+
+/**
+ * Owner sites this expression consumes by move, keyed like the liveness set.
+ *
+ * A propagation exit is published before the statement is walked, so the live set still holds
+ * every owner the run's own operands move away — `run f(move owned)` would otherwise release
+ * `owned` here as well as in the callee that now owns it. Excluding the operands keeps the
+ * exit to the owners that genuinely survive the run and are stranded by the failure.
+ */
+const consumedSites = (expression: Hir.Expression): ReadonlyArray<string> => {
+  const nested = Hir.expressionChildren(expression).flatMap(consumedSites)
+  if (expression._tag !== 'Move') return nested
+  const site = useSite(expression.subject)
+  return site === undefined ? nested : [siteKey(site), ...nested]
 }
 
 interface LoanAnalysis {
@@ -1975,11 +1996,12 @@ const checkFunction = (
       // still live at that point must release on the way out. The exit is keyed by the run
       // expression's span so lowering can attach the releases to the run operation.
       for (const run of statementRootExpressions(statement).flatMap(fallibleRunSites)) {
+        const consumed = new Set(consumedSites(run.subject))
         exits.push(
           Object.freeze({
             kind: 'Propagation' as const,
             span: run.span,
-            sites: frameSitesInnerFirst(frames, live),
+            sites: frameSitesInnerFirst(frames, live).filter((site) => !consumed.has(site)),
           }),
         )
       }

--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -1212,9 +1212,29 @@ const emitOperation = (
             walk(plan_.element, byteOffset + index * representation.stride),
           ).flat()
         }
-        case 'UnionCleanup':
+        case 'UnionCleanup': {
           if (plan_.cases.every((entry) => !planHasHook(entry.cleanup))) return []
-          throw new RangeError('Wasm cleanup does not yet lower hook-bearing union cases')
+          const entry = LayoutPlan.entry(memory.plan, plan_.type)
+          const representation = entry?.representation
+          if (representation?._tag !== 'Union') return []
+          // Only the live case owns the payload, so each hook-bearing case runs guarded on the
+          // union's own tag. The tag sits at the union's base and the payload at its offset.
+          return plan_.cases.flatMap((caseEntry) =>
+            planHasHook(caseEntry.cleanup)
+              ? [
+                  ...frameAddress(planned.offset + byteOffset),
+                  Instr.memoryAccess('i32.load', memory.memory),
+                  Instr.i32Const(caseEntry.ordinal),
+                  Instr.op('i32.eq'),
+                  Instr.ifElse(
+                    Instr.emptyBlockType,
+                    walk(caseEntry.cleanup, byteOffset + representation.payloadOffset),
+                    [],
+                  ),
+                ]
+              : [],
+          )
+        }
         default:
           return []
       }
@@ -1312,9 +1332,29 @@ const emitOperation = (
             walk(plan_.element, byteOffset + index * representation.stride),
           ).flat()
         }
-        case 'UnionCleanup':
+        case 'UnionCleanup': {
           if (plan_.cases.every((entry) => !planHasHook(entry.cleanup))) return []
-          throw new RangeError('Wasm slot cleanup does not yet lower hook-bearing union cases')
+          const entry = LayoutPlan.entry(memory.plan, plan_.type)
+          const representation = entry?.representation
+          if (representation?._tag !== 'Union') return []
+          // Only the live case owns the payload, so each hook-bearing case runs guarded on the
+          // union's own tag. The tag sits at the union's base and the payload at its offset.
+          return plan_.cases.flatMap((caseEntry) =>
+            planHasHook(caseEntry.cleanup)
+              ? [
+                  ...addressAt(byteOffset),
+                  Instr.memoryAccess('i32.load', memory.memory),
+                  Instr.i32Const(caseEntry.ordinal),
+                  Instr.op('i32.eq'),
+                  Instr.ifElse(
+                    Instr.emptyBlockType,
+                    walk(caseEntry.cleanup, byteOffset + representation.payloadOffset),
+                    [],
+                  ),
+                ]
+              : [],
+          )
+        }
         default:
           return []
       }

--- a/packages/compiler/test/GenericRunAcquiredReleaseAcceptance.test.ts
+++ b/packages/compiler/test/GenericRunAcquiredReleaseAcceptance.test.ts
@@ -1,0 +1,151 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+/**
+ * The provider owns one heap block, so its acquisition and its release are both visible in the
+ * evaluator's allocation trace: an owner stranded by a propagating failure shows up as an acquire
+ * with no matching release, and one released twice traps instead of completing.
+ */
+const provider = `struct Clock { storage: Allocation }
+
+effect fn openClock() -> Clock ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let layout = Layout.of<[i32; 2]>()
+  let recipe = Allocator.allocate(move layout) |> Effect.provideMut(&mut allocator)
+  let allocation = run recipe
+  return Clock { storage: move allocation }
+}`
+
+/**
+ * A generic effect body that *acquires* an owner and then holds it across a run whose failure
+ * channel is a row parameter — the shape `provideWith` had before #67 restructured it around a
+ * reified `Result`.
+ *
+ * This is the leak issue #68 describes. `fallibleRunSites` read only the run's own `failures`
+ * list, which is empty inside a generic body while `failureParameters` is not, so the run counted
+ * as infallible, no propagation exit was published for it, and `held` was stranded whenever the
+ * specialized row let `self` fail.
+ *
+ * The companion `GenericRunReleaseAcceptance` covers the neighbouring shape where the owner is
+ * *passed in* rather than acquired; that one never leaked, and pins that the caller does not also
+ * release an owner it moved into the callee.
+ */
+const generic = `${provider}
+
+effect fn acquiring<A, !E>(self: once Effect<A ! E>) -> A ! E | OutOfMemory {
+  let held = run openClock()
+  let value = run move self
+  drop move held
+  return move value
+}`
+
+/** The specialized row really can fail, and the failing execution still releases the owner. */
+const failingRun = `${generic}
+
+effect fn failing() -> i32 ! OutOfMemory { fail OutOfMemory {} }
+
+effect fn work() -> i32 ! OutOfMemory { return run acquiring(failing()) }
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(work(), recover) }`
+
+/** The same body on the succeeding path, where the release was never in doubt. */
+const succeedingRun = `${generic}
+
+effect fn fine() -> i32 ! OutOfMemory { return 7 }
+
+effect fn work() -> i32 ! OutOfMemory { return run acquiring(fine()) }
+
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+
+pub fn main() -> i32 { return run Effect.catch(work(), recover) }`
+
+/**
+ * Three failing attempts under `Effect.retry`: every attempt acquires its own provider inside the
+ * generic body and must release it before the next one acquires, so a per-execution leak shows up
+ * as a growing imbalance rather than a single missing release.
+ */
+const retriedRun = `${generic}
+
+effect fn failing() -> i32 ! OutOfMemory { fail OutOfMemory {} }
+
+effect fn work() -> i32 ! OutOfMemory {
+  let attempt = acquiring(failing())
+  let retried = attempt |> Effect.retry(2)
+  return run retried
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 42 }
+
+pub fn main() -> i32 { return run Effect.catch(work(), recover) }`
+
+const allocationEvents = (
+  run: ReturnType<typeof Analysis.evaluate>,
+): ReadonlyArray<'AllocationAcquire' | 'AllocationRelease'> =>
+  run._tag === 'Completed'
+    ? run.trace.flatMap((event) =>
+        event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease'
+          ? [event._tag]
+          : [],
+      )
+    : []
+
+const accept = (
+  name: string,
+  source: string,
+  expected: number,
+  expectedEvents: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      `generic-run-acquired/${name}`,
+      ascii(source),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [], name)
+
+    const evaluated = Analysis.evaluate(snapshot)
+    // A second release of the same owner blocks with a trap rather than completing, so this
+    // assertion is what fails first if run-fallibility starts publishing redundant cleanup.
+    assert.strictEqual(evaluated._tag, 'Completed', name)
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, expected, name)
+
+    // The interleaving is the stronger statement: each execution had finished with its own
+    // provider before the next acquired, rather than the releases merely trailing the acquires.
+    const events = allocationEvents(evaluated)
+    assert.deepEqual(events, expectedEvents, `${name} acquire/release trace`)
+    assert.strictEqual(
+      events.filter((event) => event === 'AllocationAcquire').length,
+      events.filter((event) => event === 'AllocationRelease').length,
+      `${name} acquires equal releases`,
+    )
+
+    const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+    assert.strictEqual((instance.exports.silk_main as () => number)(), expected, `${name} wasm`)
+  })
+
+it.effect('releases an owner acquired inside a generic body across a failing run', () =>
+  accept('failing', failingRun, 7, ['AllocationAcquire', 'AllocationRelease']),
+)
+
+it.effect('releases an owner acquired inside a generic body across a succeeding run', () =>
+  accept('succeeding', succeedingRun, 7, ['AllocationAcquire', 'AllocationRelease']),
+)
+
+it.effect('gives every retried attempt of a generic body its own released owner', () =>
+  accept('retried', retriedRun, 42, [
+    'AllocationAcquire',
+    'AllocationRelease',
+    'AllocationAcquire',
+    'AllocationRelease',
+    'AllocationAcquire',
+    'AllocationRelease',
+  ]),
+)


### PR DESCRIPTION
Closes #68

## What was wrong

The issue's diagnosis is confirmed, and it is half of the fix.

`fallibleRunSites` (`Ownership.ts`) classified a run as able to propagate only when its effect type had `failures.length > 0`. Inside a generic combinator the caller's failures arrive as a row *parameter* — `failures` is empty while `failureParameters` is not — so the run counted as infallible, no `Propagation` exit was published, and any owner live at that run was stranded once specialization substituted a row that really fails.

Measured on `main` with a generic body that acquires a provider and holds it across a run whose failure channel is a row parameter:

| scenario | trace |
| --- | --- |
| one failing execution | `Acquire` |
| retry, three failing attempts | `Acquire, Acquire, Acquire` |

which reproduces the issue's table exactly.

## Why the obvious fix double-released, and what the real predicate is

Counting an open failure row as fallible is necessary but **not sufficient** — on its own it traps, exactly as the earlier investigation measured on `GenericRunReleaseAcceptance`'s `holding`.

The reason is a second, independent defect that the first one was masking. The propagation exit is published *before* the statement is walked, so the live set still holds every owner the run's own operands move away. For `run f(move owned)`, ownership therefore published a release of `owned` in the **caller**, even though `owned` had just been moved into the callee.

That caller release was always wrong. It was merely invisible while the callee published no release of its own. Fix the callee, and the pre-existing caller release becomes a double free.

So the actual predicate the issue asked for — what distinguishes `provideWith` (leaks) from `holding` (does not) — is not a property of the run's failure row at all. It is whether the owner is *acquired inside* the body (genuinely stranded, needs the release) or *moved in through the run's own operands* (already owned by the callee, must not be released again). Excluding the run's consumed operands from its propagation exit handles both, at the one predicate every caller routes through.

`holding` is untouched by this PR's behaviour and its test stays green; the release it always had now comes from the callee rather than the caller.

## Wasm backend

Making ownership correct reaches the path that previously threw at `WasmBackend.ts:1217` ("Wasm cleanup does not yet lower hook-bearing union cases"). Both cleanup walkers now lower `UnionCleanup`: each hook-bearing case runs guarded on the union's own tag (`i32.load` at the union base, compare to the case ordinal, run that case's cleanup under `ifElse` at the payload offset), matching the LLVM backend's semantics. It is exercised by the new tests rather than landing untested.

## Acceptance criteria

- [x] A generic effect body holding an owner across a run that fails with a specialized non-empty failure row releases that owner.
- [x] An allocation-trace test asserts acquire count equals release count for the generic case, mirroring the `provideWith` tests added in PR #67.
- [x] The Wasm backend lowers cleanup for hook-bearing union cases, or the ownership change is gated until it does.
- [x] `LexerPressure`, `StackVmPressure`, `MultiAffineReturn`, `SynchronousEffectCost`, and the determinism suites stay green.
- [ ] PR #67's `provideWith` restructuring can be simplified back toward the straightforward shape once this lands (optional follow-up, not required — left alone here).

## Tests

`GenericRunAcquiredReleaseAcceptance.test.ts` covers the shape that actually leaks — an owner *acquired inside* the generic body — on the failing path, the succeeding path, and across three retried attempts, asserting the interleaved acquire/release trace and that the counts balance, on both the evaluator and Wasm.

Verified red before green: with the source fix reverted, the failing case traces `[Acquire]` and the retried case `[Acquire, Acquire, Acquire]`.

Tests: baseline 0 failures (1079 passing, measured in step 0), after 0 failures (1082 passing), +3 new tests. Full `pnpm check` green.
