### PR TITLE
docs: regenerate stdlib.md and diagnostics.md to unbreak main

### DIFF
--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -13,14 +13,14 @@ $ pnpm --filter @silk-effect/compiler documentation:generate
 
 | Prefix | Phase | Codes |
 | --- | --- | --- |
-| `LEX` | Lexical | 5 |
+| `LEX` | Lexical | 6 |
 | `PAR` | Parser | 4 |
 | `MOD` | Module | 4 |
-| `SEM` | Semantic | 93 |
+| `SEM` | Semantic | 94 |
 | `OWN` | Ownership | 12 |
 | `LAY` | Layout | 1 |
 
-There are 119 codes in total.
+There are 121 codes in total.
 
 ## Lexical (`LEX`)
 
@@ -31,6 +31,7 @@ There are 119 codes in total.
 | `LEX0003` | Stable code for a literal whose matching closing delimiter is absent. | `Unterminated <delimiterWidth3multiline>static literal` |
 | `LEX0004` | Stable code for an integer-literal base prefix that no digit follows. | `Base-<radix> integer literal without digits` |
 | `LEX0005` | Stable code for a number-literal digit separator outside a position between two digits. | `Digit separator must sit between two digits` |
+| `LEX0006` | Stable code for a float-literal exponent marker that no exponent digit follows. | `Float literal exponent must have at least one digit` |
 
 ## Parser (`PAR`)
 
@@ -147,6 +148,7 @@ There are 119 codes in total.
 | `SEM0092` |  | `The returned slice does not originate from the function's single borrowed parameter` |
 | `SEM0093` | Stable code for one reachable intrinsic unavailable on the requested execution target. | `<operation> is unavailable for <target>` |
 | `SEM0094` | Stable code for wrapping the already-borrowed string view in another reference or slice. |  |
+| `SEM0095` | Stable code for a float literal spelling no floating-point value can represent. | `Invalid float literal: <spelling>` |
 
 ## Ownership (`OWN`)
 

--- a/packages/language/docs/stdlib.md
+++ b/packages/language/docs/stdlib.md
@@ -45,7 +45,7 @@ The library has 28 modules.
 | [`silk/u64`](#silk-u64) | `u64` | 52 |
 | [`silk/u8`](#silk-u8) | `u8` | 52 |
 | [`silk/usize`](#silk-usize) | `usize` | 54 |
-| [`silk/vector`](#silk-vector) | `Vector` | 28 |
+| [`silk/vector`](#silk-vector) | `Vector` | 45 |
 
 ## silk/bool
 
@@ -6418,6 +6418,54 @@ Inserts one owned value at an index, shifting later elements without requiring T
 ```silk
 pub fn get<T>(self: &silk/vector.Vector<T>, index: usize) -> T
 ```
+
+### `pop`
+
+```silk
+pub fn pop<T>(self: &mut silk/vector.Vector<T>) -> Option<T>
+```
+
+Removes the last element and returns it. Returns an absent value for an empty vector.
+
+### `remove`
+
+```silk
+pub fn remove<T>(self: &mut silk/vector.Vector<T>, index: usize) -> T
+```
+
+Removes the element at one index, shifting the later elements down. Traps out of range.
+
+### `clear`
+
+```silk
+pub fn clear<T>(self: &mut silk/vector.Vector<T>) -> ()
+```
+
+Drops every initialized element and sets the length to zero, keeping the capacity.
+
+### `truncate`
+
+```silk
+pub fn truncate<T>(self: &mut silk/vector.Vector<T>, length: usize) -> ()
+```
+
+Drops every element past one length, keeping the capacity. Shorter lengths are left alone.
+
+### `set`
+
+```silk
+pub fn set<T>(self: &mut silk/vector.Vector<T>, index: usize, value: T) -> ()
+```
+
+Overwrites the element at one index, dropping the old element first. Traps out of range.
+
+### `reserve`
+
+```silk
+pub effect fn reserve<T>(self: &mut silk/vector.Vector<T>, additional: usize) -> () ! OutOfMemory ? &mut Allocator
+```
+
+Grows the capacity to hold at least one additional count of elements.
 
 
 ## See also


### PR DESCRIPTION
`main` has been red since `8221f5a` (the #80 merge). This regenerates the two generated documentation pages to fix it.

## What broke

`DocumentationExamples.test.ts > documents every standard library module and every diagnostic code` asserts that every code declared in `Diagnostic.ts` appears in the generated diagnostic index:

```
AssertionError: LEX0006 is missing from diagnostics.md
```

**No PR was wrong on its own.** #77 (issue #52) added `diagnostics.md` and the test that guards it. #80 (issue #63) added `LEX0006` and its `SEM0095` backstop. Each was CI-green against a base that did not yet contain the other, and the two changes touch disjoint files — so there was no textual conflict for git to catch and nothing failed until both were on `main`.

`stdlib.md` was stale for the same reason, and **nothing caught that one at all**: the test only asserts a `## <module>` heading per manifest module, so the six `Vector` operations #84 (issue #37) added drifted out of the page silently. Running `documentation:check` locally reports both pages stale.

## The fix

`pnpm --filter @silk-effect/compiler documentation:generate`, committed verbatim. The diff is entirely generated content:

- `diagnostics.md` — adds `LEX0006` and `SEM0095`, updates the per-prefix counts (`LEX` 5→6, `SEM` 93→94) and the total (119→121).
- `stdlib.md` — adds the six `Vector` operations from #84.

## Verification

- `pnpm --filter @silk-effect/compiler documentation:check` — clean (was reporting both pages stale).
- `packages/compiler` `DocumentationExamples.test.ts` — 22/22 passing (was 1 failing).
- `biome check` — clean.

## Follow-up

This is exactly the drift **#81** exists to prevent: the generator's `--check` mode is not wired into CI, so a stale page can only fail after a merge, never on the PR that causes it. A worker is on #81 now. Worth noting that the guard #81 adds would not have caught this one either — both PRs were green *individually* and only conflicted once combined, so the check has to run on the merge result to help here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015FhCk4QY6Fj8xWNJ4tnLam)_