### PR TITLE
ci(compiler): fail the build on generated documentation drift

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -262,7 +262,7 @@
     "lexer:bench": "pnpm build && node scripts/lexer-benchmark.mjs",
     "stdlib:check": "node scripts/generate-stdlib.mjs --check",
     "stdlib:generate": "node scripts/generate-stdlib.mjs",
-    "test": "pnpm stdlib:check && pnpm test:parallel && pnpm test:native-acceptance",
+    "test": "pnpm stdlib:check && pnpm documentation:check && pnpm test:parallel && pnpm test:native-acceptance",
     "test:native-acceptance": "vitest run test/DriverNativeAcceptance.test.ts --passWithNoTests --maxWorkers=1",
     "test:parallel": "vitest run --passWithNoTests --exclude test/DriverNativeAcceptance.test.ts",
     "typecheck": "pnpm stdlib:check && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json",

--- a/packages/language/docs/README.md
+++ b/packages/language/docs/README.md
@@ -9,6 +9,10 @@
   source doc comments.
 - **[Diagnostic index](./diagnostics.md)** — every compiler error code and what it means.
 
+The last two pages are generated. Regenerate them with `pnpm --filter @silk-effect/compiler
+documentation:generate`; `pnpm --filter @silk-effect/compiler test` fails while either page is
+stale, so a new stdlib module or diagnostic code cannot land without its page.
+
 ## This package
 
 `@silk-effect/language` provides editor support for Silk: a CodeMirror 6 extension whose

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -13,14 +13,14 @@ $ pnpm --filter @silk-effect/compiler documentation:generate
 
 | Prefix | Phase | Codes |
 | --- | --- | --- |
-| `LEX` | Lexical | 5 |
+| `LEX` | Lexical | 6 |
 | `PAR` | Parser | 4 |
 | `MOD` | Module | 4 |
-| `SEM` | Semantic | 93 |
+| `SEM` | Semantic | 94 |
 | `OWN` | Ownership | 12 |
 | `LAY` | Layout | 1 |
 
-There are 119 codes in total.
+There are 121 codes in total.
 
 ## Lexical (`LEX`)
 
@@ -31,6 +31,7 @@ There are 119 codes in total.
 | `LEX0003` | Stable code for a literal whose matching closing delimiter is absent. | `Unterminated <delimiterWidth3multiline>static literal` |
 | `LEX0004` | Stable code for an integer-literal base prefix that no digit follows. | `Base-<radix> integer literal without digits` |
 | `LEX0005` | Stable code for a number-literal digit separator outside a position between two digits. | `Digit separator must sit between two digits` |
+| `LEX0006` | Stable code for a float-literal exponent marker that no exponent digit follows. | `Float literal exponent must have at least one digit` |
 
 ## Parser (`PAR`)
 
@@ -147,6 +148,7 @@ There are 119 codes in total.
 | `SEM0092` |  | `The returned slice does not originate from the function's single borrowed parameter` |
 | `SEM0093` | Stable code for one reachable intrinsic unavailable on the requested execution target. | `<operation> is unavailable for <target>` |
 | `SEM0094` | Stable code for wrapping the already-borrowed string view in another reference or slice. |  |
+| `SEM0095` | Stable code for a float literal spelling no floating-point value can represent. | `Invalid float literal: <spelling>` |
 
 ## Ownership (`OWN`)
 

--- a/packages/language/docs/stdlib.md
+++ b/packages/language/docs/stdlib.md
@@ -45,7 +45,7 @@ The library has 28 modules.
 | [`silk/u64`](#silk-u64) | `u64` | 52 |
 | [`silk/u8`](#silk-u8) | `u8` | 52 |
 | [`silk/usize`](#silk-usize) | `usize` | 54 |
-| [`silk/vector`](#silk-vector) | `Vector` | 28 |
+| [`silk/vector`](#silk-vector) | `Vector` | 45 |
 
 ## silk/bool
 
@@ -6418,6 +6418,54 @@ Inserts one owned value at an index, shifting later elements without requiring T
 ```silk
 pub fn get<T>(self: &silk/vector.Vector<T>, index: usize) -> T
 ```
+
+### `pop`
+
+```silk
+pub fn pop<T>(self: &mut silk/vector.Vector<T>) -> Option<T>
+```
+
+Removes the last element and returns it. Returns an absent value for an empty vector.
+
+### `remove`
+
+```silk
+pub fn remove<T>(self: &mut silk/vector.Vector<T>, index: usize) -> T
+```
+
+Removes the element at one index, shifting the later elements down. Traps out of range.
+
+### `clear`
+
+```silk
+pub fn clear<T>(self: &mut silk/vector.Vector<T>) -> ()
+```
+
+Drops every initialized element and sets the length to zero, keeping the capacity.
+
+### `truncate`
+
+```silk
+pub fn truncate<T>(self: &mut silk/vector.Vector<T>, length: usize) -> ()
+```
+
+Drops every element past one length, keeping the capacity. Shorter lengths are left alone.
+
+### `set`
+
+```silk
+pub fn set<T>(self: &mut silk/vector.Vector<T>, index: usize, value: T) -> ()
+```
+
+Overwrites the element at one index, dropping the old element first. Traps out of range.
+
+### `reserve`
+
+```silk
+pub effect fn reserve<T>(self: &mut silk/vector.Vector<T>, additional: usize) -> () ! OutOfMemory ? &mut Allocator
+```
+
+Grows the capacity to hold at least one additional count of elements.
 
 
 ## See also

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,15 @@
     "test": {
       "dependsOn": ["build"],
       "outputs": []
+    },
+    "@silk-effect/compiler#test": {
+      "dependsOn": ["build", "@silk-effect/documentation#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/language/docs/diagnostics.md",
+        "$TURBO_ROOT$/packages/language/docs/stdlib.md"
+      ],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
Closes #81

## What changed

`documentation:check` existed but nothing ran it. Wired it into the compiler's `test` script, immediately after the `stdlib:check` it mirrors:

```
"test": "pnpm stdlib:check && pnpm documentation:check && pnpm test:parallel && pnpm test:native-acceptance"
```

That places it inside `validate` for free — the job's `pnpm check` already runs `turbo run typecheck test` — rather than adding a separate CI step or job.

Two supporting changes:

- **`turbo.json` — `@silk-effect/compiler#test` gains `@silk-effect/documentation#build`.** The generator reads `packages/documentation/dist/Project.js` (the same model `silk doc` emits) alongside the compiler's own `dist/`. `@silk-effect/documentation` depends on `@silk-effect/compiler`, so the generic `test → build` edge does not order that build ahead of the compiler's tests; under `pnpm check` the preceding `turbo run build` happens to hide this, but a bare `pnpm test` would race. Declaring the edge makes it deterministic. The graph stays acyclic (`compiler#build → documentation#build → compiler#test`), verified with `turbo run test --dry`.
- **The generated pages join that task's `inputs`.** They live in `packages/language/`, so without this a hand edit to `stdlib.md` or `diagnostics.md` leaves the compiler's test hash unchanged and the drift hides behind a cache hit. Confirmed the hash moves when a page changes.

### The drift had already happened

`documentation:check` failed on a clean `main`. Both pages were stale since #77 landed:

- `diagnostics.md` — missing `LEX0006` (`Float literal exponent must have at least one digit`, #63) and `SEM0095` (`Invalid float literal`); the total was 119, actually 121.
- `stdlib.md` — `silk/vector` documented 28 declarations, actually 45; `pop`, `remove`, `clear`, `truncate`, `set` and `reserve` were absent.

Both pages are regenerated in this PR, so the check passes from the first commit.

Also noted in `packages/language/docs/README.md` that the two pages are generated and that the compiler's tests enforce it.

## Acceptance criteria

- [x] Adding a diagnostic code or a stdlib module without regenerating fails `pnpm --filter @silk-effect/compiler test` (or `validate`) — verified by adding a throwaway `LEX0007` constant to `Diagnostic.ts` and confirming the check failed, then reverting.
- [x] The failure output names the exact command that regenerates the pages — the generator already prints `<page> is stale. Run pnpm --filter @silk-effect/compiler documentation:generate`, and it now reaches the CI log. Because the check sits third in the `&&` chain, it fails before the ~7-minute test suites, so the message is near the top of the log rather than buried.
- [x] A clean checkout with no changes passes — `pnpm --filter @silk-effect/compiler documentation:check` exits 0 on this branch.

## Verification

- `pnpm -r build` — clean.
- `pnpm --filter @silk-effect/compiler test:parallel` — 142 files, 1125 tests, all passing.
- `npx biome check .` — 249 files, clean.
- `turbo run test --dry` — no cycle; `@silk-effect/compiler#test` depends on `@silk-effect/compiler#build` and `@silk-effect/documentation#build`.
- Drift exercised in both directions: a hand edit to `stdlib.md` and a new diagnostic constant each failed the check with the regeneration command named; both reverted.

No changeset — this changes tooling and generated documentation, not published package behavior, matching #77, which added the generator and the pages without one.

Tests: baseline 0 failures, after 0 failures, +0 new tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSkb55uPtn1UiZicCcDXvr)_