### PR TITLE
fix(wasm): reload only the frame roots a call can write through

### DIFF
--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -107,6 +107,14 @@ interface FrameRoot {
 
 interface FramePlan {
   readonly roots: ReadonlyMap<number, FrameRoot>
+  /**
+   * The roots whose address leaves the frame — borrow formations and borrow-shaped captures.
+   * A callee reaches exactly these through the pointer it was handed, so exactly these have to
+   * reload after a call. The remaining roots are addressed only by the cleanup sequence that
+   * materializes and reloads them itself, and reloading one after a call would overwrite a live
+   * value with frame bytes nothing ever wrote.
+   */
+  readonly escaping: ReadonlySet<number>
   readonly sliceRoots: ReadonlyMap<number, number>
   readonly size: number
   readonly alignment: number
@@ -117,7 +125,7 @@ const framePlan = (fn: Mir.MirFunction, plan: LayoutPlan.Plan): FramePlan => {
     (operation): operation is Extract<Mir.Operation, { readonly _tag: 'BeginLoan' }> =>
       operation._tag === 'BeginLoan',
   )
-  const rootOrdinals = new Set([
+  const escaping = new Set([
     ...formations.flatMap((operation) =>
       operation.sourceType._tag === 'Slice' ||
       fn.localTypes.at(operation.root.ordinal)?._tag === 'Reference'
@@ -136,6 +144,9 @@ const framePlan = (fn: Mir.MirFunction, plan: LayoutPlan.Plan): FramePlan => {
           )
         : [],
     ),
+  ])
+  const rootOrdinals = new Set([
+    ...escaping,
     // A hook-bearing drop passes `&mut self` into its hook, so the owner needs frame storage.
     ...Mir.operations(fn).flatMap((operation) => {
       const dropped =
@@ -184,6 +195,7 @@ const framePlan = (fn: Mir.MirFunction, plan: LayoutPlan.Plan): FramePlan => {
   }
   return Object.freeze({
     roots,
+    escaping,
     sliceRoots: new Map(
       formations.map((operation) => [operation.destination.ordinal, operation.root.ordinal]),
     ),
@@ -1165,6 +1177,12 @@ const emitOperation = (
       ]
     })
   }
+  /**
+   * Reloads the roots a call could have written through the pointer it was handed. Roots that
+   * never gave their address away keep their authoritative value in slots, so they stay put.
+   */
+  const reloadEscapingRoots = (): ReadonlyArray<Instr.Instr> =>
+    [...(memory?.frame.escaping ?? [])].sort((left, right) => left - right).flatMap(reloadRoot)
   /**
    * Runs every Drop hook one cleanup plan invokes: the owner materializes to its frame root,
    * each hook receives the address of its (possibly nested) value, and the owner's slots
@@ -2590,9 +2608,7 @@ const emitOperation = (
         ),
         Instr.call(resolve(operation.runner, operation.runnerTypeArguments)),
         ...[...outcomeSlots].reverse().map((slot) => Instr.localSet(slot)),
-        ...[...(memory?.frame.roots.keys() ?? [])]
-          .sort((left, right) => left - right)
-          .flatMap(reloadRoot),
+        ...reloadEscapingRoots(),
       ]
       const success = copy(outcomeSlots.slice(1, 1 + destinationSlots.length), destinationSlots)
       if (operation.propagationType === undefined) return [...invoke, ...success]
@@ -2645,9 +2661,7 @@ const emitOperation = (
         ),
         Instr.call(resolve(operation.runner, operation.runnerTypeArguments)),
         ...[...outcomeSlots].reverse().map((slot) => Instr.localSet(slot)),
-        ...[...(memory?.frame.roots.keys() ?? [])]
-          .sort((left, right) => left - right)
-          .flatMap(reloadRoot),
+        ...reloadEscapingRoots(),
       ]
       const writePayload = (
         source: ReadonlyArray<number>,

--- a/packages/compiler/test/VectorAcceptance.test.ts
+++ b/packages/compiler/test/VectorAcceptance.test.ts
@@ -916,11 +916,12 @@ impl Drop for Entry {
   }
 }
 
-// Consumes an owned element without reading its fields, so the check stays on ownership
-// accounting rather than field values.
-fn release(entry: Entry) -> () {
+// Reads the scalar field off the owned element before consuming it, so the exit value every
+// engine checks depends on what the vector actually stored.
+fn release(entry: Entry) -> i32 {
+  let read = entry.value
   drop entry
-  return ()
+  return read
 }
 
 effect fn seed(values: &mut Vector<Entry>, value: i32) -> () ! OutOfMemory ? &mut Allocator {
@@ -939,12 +940,15 @@ effect fn build() -> i32 ! OutOfMemory {
   let taken = pop<Entry>(&mut values)
   let popped = match move taken {
     Some<Entry> { value } => release(move value)
-    None missing => ()
+    None missing => 0
   }
-  if length<Entry>(&values) == 3 {} else { return 1 }
+  // The popped element is the last one appended, and the removed one is the first.
+  if popped == 9 {} else { return 1 }
+  if length<Entry>(&values) == 3 {} else { return 2 }
   let pulled = remove<Entry>(&mut values, 0)
   let removed = release(move pulled)
-  if length<Entry>(&values) == 2 {} else { return 2 }
+  if removed == 3 {} else { return 3 }
+  if length<Entry>(&values) == 2 {} else { return 4 }
   return 42
 }
 
@@ -1023,5 +1027,155 @@ it.effect(
       assert.strictEqual(acquires.length, 1)
       assert.strictEqual(releases.length, 1)
     }),
+  60_000,
+)
+
+// An owner that is live across an effect call and carries a Drop hook needs frame storage for
+// that hook, but its address never leaves the frame — the value itself stays in registers. The
+// Wasm backend used to reload every frame root after an effect call, which overwrote such an
+// owner with frame bytes nothing had written yet, so the element the append went on to store
+// was all-zero. Only the appends that grow reach an effect call while holding the element, which
+// is why index 0 and the index that triggers the next growth were the ones that read back zero.
+const moveOnlyElementZero = `import silk.vector { Vector, make, append, asSlice }
+
+struct Entry {
+  value: i32
+  marker: Vector<i32>
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut values = make<Entry>()
+  let entry = Entry { value: 42, marker: make<i32>() }
+  let pending = append<Entry>(&mut values, move entry) |> Effect.provideMut(&mut allocator)
+  let appended = run pending
+  let readable = asSlice<Entry>(&values)
+  return readable[0].value
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'reads back element zero of a move-only element on all three engines',
+  () => acceptOnAllEngines('move-only-element-zero', moveOnlyElementZero),
+  60_000,
+)
+
+const moveOnlyAppendSequence = `import silk.vector { Vector, make, append, asSlice, length }
+
+struct Entry {
+  value: i32
+  marker: Vector<i32>
+}
+
+effect fn seed(values: &mut Vector<Entry>, value: i32) -> () ! OutOfMemory ? &mut Allocator {
+  let entry = Entry { value: value, marker: make<i32>() }
+  let appended = run append<Entry>(move values, move entry)
+  return ()
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut values = make<Entry>()
+  let s0 = run (seed(&mut values, 1) |> Effect.provideMut(&mut allocator))
+  let s1 = run (seed(&mut values, 2) |> Effect.provideMut(&mut allocator))
+  let s2 = run (seed(&mut values, 3) |> Effect.provideMut(&mut allocator))
+  if length<Entry>(&values) == 3 {} else { return 1 }
+  let readable = asSlice<Entry>(&values)
+  if readable[0].value == 1 {} else { return 2 }
+  if readable[1].value == 2 {} else { return 3 }
+  if readable[2].value == 3 {} else { return 4 }
+  return 42
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'reads back every element of a move-only append sequence on all three engines',
+  () => acceptOnAllEngines('move-only-append-sequence', moveOnlyAppendSequence),
+  60_000,
+)
+
+// Five appends cross both growths (0 -> 4 -> 8), so two of them hold the element across the
+// allocating effect call rather than one.
+const moveOnlyGrowthSequence = `import silk.vector { Vector, make, append, asSlice, length, capacity }
+
+struct Entry {
+  value: i32
+  marker: Vector<i32>
+}
+
+effect fn seed(values: &mut Vector<Entry>, value: i32) -> () ! OutOfMemory ? &mut Allocator {
+  let entry = Entry { value: value, marker: make<i32>() }
+  let appended = run append<Entry>(move values, move entry)
+  return ()
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut values = make<Entry>()
+  let s0 = run (seed(&mut values, 1) |> Effect.provideMut(&mut allocator))
+  let s1 = run (seed(&mut values, 2) |> Effect.provideMut(&mut allocator))
+  let s2 = run (seed(&mut values, 3) |> Effect.provideMut(&mut allocator))
+  let s3 = run (seed(&mut values, 4) |> Effect.provideMut(&mut allocator))
+  let s4 = run (seed(&mut values, 5) |> Effect.provideMut(&mut allocator))
+  if length<Entry>(&values) == 5 {} else { return 1 }
+  if capacity<Entry>(&values) == 8 {} else { return 2 }
+  let readable = asSlice<Entry>(&values)
+  if readable[0].value == 1 {} else { return 3 }
+  if readable[1].value == 2 {} else { return 4 }
+  if readable[2].value == 3 {} else { return 5 }
+  if readable[3].value == 4 {} else { return 6 }
+  if readable[4].value == 5 {} else { return 7 }
+  return 42
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 8 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'reads back every element across both growths of a move-only vector on all three engines',
+  () => acceptOnAllEngines('move-only-growth-sequence', moveOnlyGrowthSequence),
+  60_000,
+)
+
+// Any move-only field reaches the same path, so the element type is pinned with Bytes rather
+// than a nested Vector.
+const moveOnlyBytesField = `import silk.vector { Vector, make, append, asSlice, length }
+import silk.bytes { Bytes, make as bytesMake }
+
+struct Entry {
+  marker: Bytes
+  value: i32
+}
+
+effect fn seed(values: &mut Vector<Entry>, value: i32) -> () ! OutOfMemory ? &mut Allocator {
+  let entry = Entry { marker: bytesMake(), value: value }
+  let appended = run append<Entry>(move values, move entry)
+  return ()
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut values = make<Entry>()
+  let s0 = run (seed(&mut values, 20) |> Effect.provideMut(&mut allocator))
+  let s1 = run (seed(&mut values, 22) |> Effect.provideMut(&mut allocator))
+  if length<Entry>(&values) == 2 {} else { return 1 }
+  let readable = asSlice<Entry>(&values)
+  return readable[0].value + readable[1].value
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'reads back element zero when the move-only field is Bytes on all three engines',
+  () => acceptOnAllEngines('move-only-bytes-field', moveOnlyBytesField),
   60_000,
 )


### PR DESCRIPTION
Closes #86

## What was wrong

The Wasm backend gives a local frame storage when its address is needed. Three things ask for that: a borrow formation (`BeginLoan`), a borrow-shaped capture into an effect or callable environment, and — the relevant one here — an owner that is live across an effect call and carries a `Drop` hook, because the hook has to receive `&mut self` if the call fails.

The first two hand the address to a callee, so after the call the root has to reload from frame memory: the callee may have written through that pointer. The third does not. Its address is used only inside the cleanup sequence, which materializes the root and reloads it around itself; between calls the authoritative value stays in the local's slots.

The backend reloaded **every** frame root after an effect call, hook-only roots included. For those, frame memory had never been written, so the reload overwrote a live value with zeros.

## Why it showed up as "element 0"

In `Vector.append`, the appended element is exactly such an owner: it carries a hook when `T` is move-only, and it is live across the `run` that allocates in the growth branch. So it was zeroed on every append that grows, and the subsequent `Slot.write` faithfully stored the zeroed struct — which matches the issue's note that the store width was correct.

That is also why the failure looked index-shaped. Appending 1‥5 read back `0, 2, 3, 4, 0`: index 0 (growth 0→4) and index 4 (growth 4→8) are the two appends that reach an effect call while holding the element. A `reserve` before the append, which keeps the growth branch out of the append itself, read back correctly even before this change. A `Copy` element type has no hook, so no frame root at all — which is why an equally sized `Copy` struct passed.

## The change

`framePlan` now tracks which roots give their address away (`escaping`) separately from the full root set. The post-call reload at `RunEffectValue` / `RunStaticEffect` and at `ReifyEffect` iterates `escaping` instead of every root. Nothing about frame sizing, materialization, or the cleanup path changes; `stdlib/silk/vector.silk` is untouched.

## Acceptance criteria

- [x] A three-engine acceptance test appends a move-only struct and asserts index 0 reads back its scalar field, verified failing on Wasm before the fix.
- [x] A test covers the multi-append case (append 1, 2, 3 → reads 1, 2, 3) and the growth case (five appends across 0→4→8).
- [x] A test covers a non-`Vector` move-only field (`Bytes`) to pin that the fix is not `Vector`-specific.
- [x] The value assertions weakened in PR #84's move-only tests are tightened back to asserting field values.

On the last one: `moveOnlyRoundTrip`'s `release` helper dropped its element without reading it. It now returns `entry.value`, and `build` asserts the popped element is `9` and the removed one is `3`, so the exit value every engine checks depends on what the vector actually stored. That tightening fails on Wasm before the fix, so it is now load-bearing rather than decorative.

## Verification

All four new tests plus the tightened one fail before the fix and pass after:

```
before: Tests  5 failed | 15 passed (20)
after:  Tests  20 passed (20)
```

Two failures are present on clean `main` as well and are unrelated to this change — both were confirmed by re-running them with this branch's changes stashed:

- `packages/wasm test/Extended.test.ts > threads address types through memory instructions` (memory64 validation; `packages/wasm` is untouched here)
- `packages/compiler test/DocumentationExamples.test.ts > documents every standard library module and every diagnostic code` (`LEX0006` missing from `diagnostics.md`)

`biome check .` (532 files), `turbo run build`, compiler `typecheck`, docs `typecheck` (0 errors) and `pnpm test:scripts` (8/8) all pass. `lsp`, `llvm`, and `language` are fully green. The three `compiler-cli` `FormatCommand`/`FormatWorkflow` failures are the known root-user artifact — they stage failures with `chmod`, which root ignores — and pass in CI.

Tests: baseline 2 failures, after 2 failures, +4 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgSeM3BtzBsxE9cZKHNtK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgSeM3BtzBsxE9cZKHNtK9)_