### PR TITLE
instances: specialize calls that pass callable values

### DIFF
--- a/openspec/specs/bootstrap-callable-values/spec.md
+++ b/openspec/specs/bootstrap-callable-values/spec.md
@@ -117,6 +117,32 @@ identities merely because their public callable signatures match.
 - **WHEN** a generic function promises to call its callback repeatedly but receives a `once fn`
 - **THEN** its callable contract rejects the argument before lowering
 
+#### Scenario: Call through a function-typed parameter of an ordinary function
+
+- **WHEN** a non-effect `fn` declares a `once fn(i32) -> i32` parameter and calls it, and `main`
+  passes a named function
+- **THEN** the call lowers and the evaluator, LLVM, and Wasm agree on its result
+
+#### Scenario: Call through a function-typed parameter of a generic function
+
+- **WHEN** `fn apply<A, B>(transform: once fn(A) -> B, value: A) -> B` calls `transform`
+- **THEN** the callable's hidden identity accompanies the explicit type arguments in the target's
+  instance key, and the call lowers for named functions and leading-argument sections alike
+
+### Requirement: Callable arguments monomorphize their target
+
+A call passing a callable value SHALL specialize its target on that callable's hidden concrete
+identity, exactly as a call passing an Effect value does. Callable and Effect values are both
+compiler-private and have no target layout, so a target reached only through its explicit type
+arguments would carry a parameter no backend can represent. Discovery SHALL therefore route such a
+call off the finite-specialization path in both ordinary and effect-involving positions.
+
+#### Scenario: Distinguish two callables behind one signature
+
+- **WHEN** one function taking a `once fn(i32) -> i32` is called with two different named functions
+- **THEN** each call reaches its own specialized instance naming its target statically, and neither
+  instance drops the callable parameter from its lowered contract
+
 ### Requirement: Floating actor operations are callable values
 
 `f32` and `f64` actor operations SHALL support ordinary named references and leading-argument sections while preserving width and operation identity.

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -433,6 +433,24 @@ const hookCalls = (cleanup: Ownership.CleanupPlan): ReadonlyArray<CallTarget> =>
   }
 }
 
+/**
+ * Reports whether a call must carry hidden identity arguments to be lowerable.
+ *
+ * Effect and callable values are both compiler-private: neither has a target layout, and both are
+ * erased by monomorphizing the target on the argument's hidden concrete identity. A call passing
+ * either therefore cannot be specialized on its explicit type arguments alone — the target would
+ * be instantiated without the identity, and lowering would drop the parameter it cannot type.
+ */
+const carriesHiddenIdentity = (
+  expression: Extract<Hir.Expression, { readonly _tag: 'Call' | 'EffectConstruct' }>,
+): boolean =>
+  Type.isEffect(expression.type) ||
+  expression.arguments.some(
+    (argument) =>
+      argument._tag !== 'Unavailable' &&
+      (Type.isEffect(argument.type) || Type.isCallable(argument.type)),
+  )
+
 const callTargets = (expression: Hir.Expression): ReadonlyArray<CallTarget> => {
   if (expression._tag === 'Run') return callTargets(expression.subject)
   if (expression._tag === 'EffectResult') return callTargets(expression.protected)
@@ -498,10 +516,7 @@ const callTargets = (expression: Hir.Expression): ReadonlyArray<CallTarget> => {
     return []
   const nested = expression.arguments.flatMap((argument) => callTargets(argument))
   if (expression._tag === 'ServiceEffectConstruct') return nested
-  return Type.isEffect(expression.type) ||
-    expression.arguments.some(
-      (argument) => argument._tag !== 'Unavailable' && Type.isEffect(argument.type),
-    )
+  return carriesHiddenIdentity(expression)
     ? nested
     : [
         Object.freeze({ declaration: expression.target, typeArguments: expression.typeArguments }),
@@ -979,15 +994,10 @@ const directCallInstances = (
         ]
       }
       if (expression._tag !== 'Call' && expression._tag !== 'EffectConstruct') return []
-      // Ordinary calls without Effect values remain on the original finite-specialization path.
-      // Resolving them here as well would bypass its polymorphic-recursion guard.
-      if (
-        !Type.isEffect(expression.type) &&
-        !expression.arguments.some(
-          (argument) => argument._tag !== 'Unavailable' && Type.isEffect(argument.type),
-        )
-      )
-        return []
+      // Calls carrying neither an Effect nor a callable value remain on the original
+      // finite-specialization path. Resolving them here as well would bypass its
+      // polymorphic-recursion guard.
+      if (!carriesHiddenIdentity(expression)) return []
       const target = targetKeyOfCall(expression, context)
       const targetFn = target === undefined ? undefined : targetFunction(results, expression.target)
       if (target === undefined || targetFn === undefined) return []

--- a/packages/compiler/test/IndirectCallAcceptance.test.ts
+++ b/packages/compiler/test/IndirectCallAcceptance.test.ts
@@ -1,0 +1,210 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import type * as Mir from '../src/Mir.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-indirect-call-acceptance-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+/** The example from #100, verbatim: a plain `fn` calls through a function-typed parameter. */
+const concrete = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn apply(transform: once fn(i32) -> i32, value: i32) -> i32 {
+  return transform(value)
+}
+
+pub fn main() -> i32 { return apply(double, 21) }`
+
+/** The generic shape #35 needs: the callable's parameter and result are both type parameters. */
+const generic = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn apply<A, B>(transform: once fn(A) -> B, value: A) -> B {
+  return transform(move value)
+}
+
+pub fn main() -> i32 { return apply<i32, i32>(double, 21) }`
+
+/** A partial application rather than a named function, the shape `Effect.map(i32.add(40))` uses. */
+const partial = `fn apply(transform: once fn(i32) -> i32, value: i32) -> i32 {
+  return transform(value)
+}
+
+pub fn main() -> i32 { return apply(i32.add(40), 2) }`
+
+/**
+ * A callable parameter forwarded to a further call, so the origin is a `ParameterReference`
+ * rather than a function item at the call site. Generic on both ends, so the hidden identity has
+ * to survive alongside explicit type arguments through two levels.
+ */
+const forwarded = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn inner<A, B>(transform: once fn(A) -> B, value: A) -> B { return transform(move value) }
+
+fn outer<A, B>(transform: once fn(A) -> B, value: A) -> B {
+  return inner<A, B>(move transform, move value)
+}
+
+pub fn main() -> i32 { return outer<i32, i32>(double, 21) }`
+
+/** A shared `fn` callable, which unlike `once` may be invoked more than once. */
+const shared = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn twice(transform: fn(i32) -> i32, value: i32) -> i32 { return transform(transform(value)) }
+
+pub fn main() -> i32 { return twice(double, 10) + 2 }`
+
+it.effect(
+  'calls through a function-typed parameter and agrees on all three engines',
+  () =>
+    Effect.gen(function* () {
+      for (const [name, source] of [
+        ['concrete', concrete],
+        ['generic', generic],
+        ['partial', partial],
+        ['forwarded', forwarded],
+        ['shared', shared],
+      ] as const) {
+        const snapshot = yield* Analysis.ofSourceRealized(
+          `indirect-call/${name}`,
+          ascii(source),
+          'wasm32-unknown-unknown',
+        )
+        assert.deepEqual(Analysis.diagnostics(snapshot), [], name)
+
+        const evaluated = Analysis.evaluate(snapshot)
+        assert.strictEqual(
+          evaluated._tag,
+          'Completed',
+          `${name}: ${JSON.stringify(evaluated, (_, value) =>
+            typeof value === 'bigint' ? value.toString() : value,
+          )}`,
+        )
+        if (evaluated._tag !== 'Completed') return
+        assert.strictEqual(evaluated.result.value, 42, `${name} evaluator`)
+
+        const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+        const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+        assert.strictEqual((instance.exports.silk_main as () => number)(), 42, `${name} wasm`)
+
+        const compiled = yield* Driver.compile({
+          compilation: { root: SourceFile.make(`indirect-call/${name}`, ascii(source)) },
+          toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+          profile: 'release',
+          destination: join(destinationRoot, name),
+        }).pipe(Effect.provide(SourceResolver.empty))
+        assert.strictEqual(compiled._tag, 'Compiled', name)
+        if (compiled._tag !== 'Compiled') return
+        const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+        assert.strictEqual(run.status, 42, `${name} native: ${run.stderr}`)
+      }
+    }),
+  180_000,
+)
+
+const callableTargetName = (type: Mir.Type | undefined): string | undefined =>
+  type?._tag === 'CallableValue' && type.target._tag === 'DeclarationCallableTarget'
+    ? type.target.declaration.name
+    : undefined
+
+it.effect('keeps the callable parameter in the lowered contract', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'indirect-call/contract',
+      ascii(concrete),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    const apply = Analysis.loweredMir(snapshot).functions.find((fn) => fn.id.name === 'apply')
+    assert.isDefined(apply)
+    if (apply === undefined) return
+    // The regression in #100 was a contract whose parameter count outran its typed locals: the
+    // callable slot was dropped and `value: i32` shifted into position 0.
+    assert.strictEqual(apply.parameterCount, 2)
+    assert.isAtLeast(apply.localTypes.length, apply.parameterCount)
+    assert.strictEqual(callableTargetName(apply.localTypes.at(0)), 'double')
+    assert.strictEqual(apply.localTypes.at(1)?._tag, 'i32')
+  }),
+)
+
+it.effect('specializes one instance per callable argument', () =>
+  Effect.gen(function* () {
+    const source = `fn double(value: i32) -> i32 { return value * 2 }
+fn inc(value: i32) -> i32 { return value + 1 }
+
+fn apply(transform: once fn(i32) -> i32, value: i32) -> i32 { return transform(value) }
+
+pub fn main() -> i32 { return apply(double, 20) + apply(inc, 1) }`
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'indirect-call/specialization',
+      ascii(source),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+    // Function arguments are monomorphized like type arguments: one `apply` body per callable,
+    // each naming its target statically, so no engine needs a runtime function value.
+    const applied = Analysis.loweredMir(snapshot)
+      .functions.filter((fn) => fn.id.name === 'apply')
+      .map((fn) => callableTargetName(fn.localTypes.at(0)))
+    assert.deepEqual([...applied].sort(), ['double', 'inc'])
+
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+  }),
+)
+
+it.effect('still holds a `once` callable to a single call', () =>
+  Effect.gen(function* () {
+    const source = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn twice(transform: once fn(i32) -> i32, value: i32) -> i32 {
+  return transform(transform(value))
+}
+
+pub fn main() -> i32 { return twice(double, 10) + 2 }`
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'indirect-call/affine',
+      ascii(source),
+      'wasm32-unknown-unknown',
+    )
+    // Lowering an indirect call must not weaken the affinity of the callable it goes through.
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      ['OWN0001'],
+    )
+  }),
+)
+
+it.effect('still requires an explicit move to forward a `once` callable', () =>
+  Effect.gen(function* () {
+    const source = `fn double(value: i32) -> i32 { return value * 2 }
+
+fn inner(transform: once fn(i32) -> i32, value: i32) -> i32 { return transform(value) }
+
+fn outer(transform: once fn(i32) -> i32, value: i32) -> i32 {
+  return inner(transform, value)
+}
+
+pub fn main() -> i32 { return outer(double, 21) }`
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'indirect-call/forward-move',
+      ascii(source),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      ['OWN0003'],
+    )
+  }),
+)


### PR DESCRIPTION
Closes #100

Implements the **support** branch decided on the issue (2026-08-13): a call through a function-typed parameter in an ordinary `fn` lowers and executes on all three engines.

## What was wrong

Discovery attached hidden callable identities only on the effect-involving call path. `callTargets` routed an ordinary call — no Effect result, no Effect argument — to the plain finite-specialization path, recording `apply` as `apply<>` with no `CallableIdentityArgument`, even though `targetKeyOfCall` already knew how to compute one. At lowering, `parameterCallableIdentity` found no identity in the key and **silently dropped the parameter**: `apply` came out with `parameterCount: 2` over `localTypes: [i32, i32]`, the callable slot gone and `value: i32` shifted into position 0. The caller lowered correctly, so verification reported the mismatch.

The `fn(i32) -> i32->i32` rendering in the violation was not a spliced type. The detail format is `ordinal:ACTUAL->EXPECTED`, so it read as position 0 passing `fn(i32) -> i32` where the shifted contract expected `i32`. The type was carried whole; the *parameter list* was what got truncated.

## The fix

A shared `carriesHiddenIdentity` predicate treats a callable-typed argument exactly like an Effect-typed one in both `callTargets` and `directCallInstances`, so the call leaves the finite-specialization path and the call site records the hidden identity. Effect and callable values are both compiler-private with no target layout, and both are erased by monomorphizing on the argument's hidden concrete identity — the asymmetry was the bug.

**Representation: specialization-only.** A function argument monomorphizes its target the way a type argument does. No fat pointers, no new runtime representation: each callable gets its own specialized body naming its target statically, and an environment-less callable occupies zero ABI lanes. This was chosen because it covers both acceptance shapes and is what the codebase's existing architecture already assumed — everything downstream needed no change. MIR verification already accepts environment-realization `ApplyCallable`, the evaluator already resolves the target from the stored `CallableValue` (the machinery `Effect.map(add)` uses), and both backends already resolve `operation.target ?? sourceType.target` statically.

Net diff in the compiler is 3 lines of logic plus a documented predicate.

## Acceptance criteria

- [x] The branch above is chosen and recorded on the issue — **support**, decided 2026-08-13.
- [x] The issue's example evaluates to `42` on all three engines (evaluator, LLVM, Wasm).
- [x] A test pins the behavior — `packages/compiler/test/IndirectCallAcceptance.test.ts`.
- [x] The generic version `fn apply<A, B>(transform: once fn(A) -> B, value: A) -> B` is covered too, since that is the shape #35 needs.

## Coverage

Five shapes run to `42` on the evaluator, LLVM, and Wasm:

| shape | why |
| --- | --- |
| `apply(double, 21)` | the issue's example, verbatim |
| `apply<A, B>(double, 21)` | the generic shape #35 needs |
| `apply(i32.add(40), 2)` | a leading-argument section, not a named function |
| `outer<A,B>` → `inner<A,B>` | callable forwarded through two generic levels, so the origin is a `ParameterReference` |
| `twice(double, 10)` on `fn` | a reusable callable invoked more than once |

Plus two guardrails that pass before *and* after, pinning that lowering an indirect call does not weaken affinity: calling a `once` callable twice is still `OWN0001`, and forwarding one without `move` is still `OWN0003`. Two further tests pin the mechanism directly — that the callable parameter survives in the lowered contract, and that two different callables behind one signature reach two distinct specialized instances.

## Relationship to #25

Checked before implementing, as the issue asked. **Siblings in the same failure family, but not the same root cause — this does not unblock #25.** Both `Effect` and `fn(...)` are compiler-private with no target layout, and semantic analysis never checks that a program stays inside the erasable subset, which is why both showed zero diagnostics followed by MIR-verification death. But #100 was a *discovery* gap, fixed here; #25 is a *representation* gap — `Vector<Effect<...>>` needs Effect values to have a runtime storable layout because `RawBuffer` contents are runtime-indexed storage, which hidden-identity specialization fundamentally cannot erase. Full mechanics posted on [#100](https://github.com/julia-script/silk-effect/issues/100#issuecomment-5274431977) and cross-referenced on [#25](https://github.com/julia-script/silk-effect/issues/25#issuecomment-5274434244).

## Tests

`Tests: baseline 4 failures, after 4 failures, +5 new tests`

Both baseline and after carry the same 4 known-ignorable local failures, unchanged by this branch:
- 3 × compiler-cli `FormatCommand`/`FormatWorkflow` (chmod behaves differently as root)
- 1 × packages/wasm `Extended.test.ts` "threads address types" — verified failing on a stashed tree, and `packages/wasm` does not depend on the compiler

`packages/compiler`: **148 files / 1159 tests, all passing** (baseline 147 / 1154). The 3 lowering tests were verified to fail on a stashed tree before the change; the 2 ownership guardrails pass on both sides by design.

No new diagnostic codes, so no documentation pages needed regeneration. `openspec/specs/bootstrap-callable-values/spec.md` gains scenarios for the ordinary-`fn` indirect call and a requirement recording that callable arguments monomorphize their target.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XsxfmpXMftfGWMkWDthe7)_