### PR TITLE
design proposal: explicit heap indirection via Box (#19)

### DIFF
--- a/openspec/changes/add-box-heap-indirection/design.md
+++ b/openspec/changes/add-box-heap-indirection/design.md
@@ -1,0 +1,285 @@
+## Context
+
+Every claim below was measured against `main` at 30310de, and the mechanism was validated with a
+throwaway spike that is **not part of this change**. Where a measurement contradicts issue #19, the
+measurement is stated first and the issue's text is treated as superseded.
+
+The gate is one sentence: a struct must be able to reach itself through a value whose *layout* does
+not depend on the struct's layout, and the value behind that indirection must still be released
+exactly once at runtime.
+
+## Goals / Non-Goals
+
+Goals:
+
+- One explicit heap indirection a program asks for by name, so `SyntaxTree`, `Hir.Expression`,
+  `Type.Type`, and `Mir` become expressible.
+- Cycle detection that matches the rule `bootstrap-struct-types` already states — a cycle "of inline
+  struct fields" — rather than the stricter rule the implementation currently enforces.
+- A runtime release path with no new compiler machinery, proven by a leak test that fails today.
+
+Non-Goals: inline recursion (stays rejected), `Rc`/`Arc`/shared ownership, cyclic graphs, an arena
+allocator (#22), and any relaxation of stack-depth behaviour — a deep chain exhausts the stack, and
+that is accepted.
+
+## Measurements
+
+### The SCC check does not break cycles through intrinsic nominals
+
+`Type.nominals` (`Type.ts:694-713`) recurses into `self.arguments`:
+
+```ts
+isNominal(self) ? Object.freeze([self, ...self.arguments.flatMap(nominals)]) : ...
+```
+
+so `RawBuffer<Node>` yields `[RawBuffer, Node]`. Neighbour extraction at
+`DeclarationIndex.ts:2784-2791` maps those to `module.name` and filters by `byKey.has`; `RawBuffer`
+is dropped because it has no struct declaration, but `Node` is kept and the self-edge survives.
+A second, independent site — the `selfEdge` test at `DeclarationIndex.ts:3685-3693` — repeats the
+same `Type.nominals` call, so **both** sites must change together.
+
+Measured on `main`:
+
+| source | diagnostics |
+| --- | --- |
+| `struct Node { next: RawBuffer<Node> }` | `["SEM0020"]`, `dependency: Unavailable` |
+| `struct Node { next: Slot<Node> }` | `["SEM0020", "SEM0054"]` |
+| `struct Cell<T> { buffer: RawBuffer<T> }` + `struct Node { next: Cell<Node> }` | `["SEM0020"]` |
+| `struct Pair<T> { value: T }` + `struct Node { next: Pair<Node> }` | `["SEM0020"]` |
+| `struct Node { anchor: [Node; 0] }` | `["SEM0020"]` |
+
+The issue's requirement 5 ("accepted with no change to that check") is therefore false, and its
+premise — that `RawBuffer` and `Slot` already break cycles — is false as well.
+
+### An intrinsic nominal cannot carry a `Drop` hook
+
+`Ownership.cleanupPlan` (`Ownership.ts:1617-1726`) reaches a hook only through two gates:
+
+- `Ownership.ts:1673-1680` — `NoCleanup` unless `DeclarationIndex.byCanonical` yields a
+  `StructDeclaration`.
+- `Ownership.ts:1703-1706` — `structPlan` unless `DeclarationIndex.witness` yields a
+  `SourceConformanceWitness`, i.e. a source-level `impl Drop`.
+
+`RawBuffer` and `Slot` are entries in `Type.intrinsicNominals` (`Type.ts:287-300`) with no struct
+declaration and no `impl` anywhere in the standard library. So issue requirement 1 (intrinsic
+nominal) and requirement 4 (a source `Drop` hook) are mutually exclusive under the current
+architecture. This is the fork; it is resolved below.
+
+### The hook rules the drop path must satisfy
+
+`DeclarationIndex.ts:3429-3465` requires the hook to be named `drop`, `Ordinary`, with zero type
+parameters, exactly one parameter named `self` of type `&mut Provider`, returning `()`, with
+`failureRow.failures.length === 0` and `requirementRow.requirements.length === 0`.
+
+`Box.make` must allocate through `Allocator` and fail with `OutOfMemory`, which looks like a
+conflict — but it is not, and `Vector<T>` already shows why. Allocation lives in `append`
+(`vector.silk:97`, `! OutOfMemory ? &mut Allocator`) while the hook at `vector.silk:64-72` only
+*releases*, and releasing needs no allocator and cannot fail. `Box` inherits that split exactly.
+
+### The runtime recursion vehicle already exists and is already exercised
+
+`RawBufferCleanup` (`Ownership.ts:1636-1645`) releases the allocation and **does not descend into
+the element type**. That single fact is what makes the static plan finite through an indirection,
+and it is also why the payload must be dropped explicitly. `Vector` does exactly that, via
+`Slot.dropValue` (`slot.silk:16-19` → `Intrinsic.slotDrop`) in `releaseBuffer`
+(`vector.silk:81-93`).
+
+`Slot.dropValue<T>` is not a black box: the MIR `SlotDrop` operation carries its own
+`cleanup: CleanupPlan` for `T` (`Mir.ts:1508-1509`), lowered by Wasm at `WasmBackend.ts:1353-1377`
+and by LLVM through `dropThroughPlan` at `Backend.ts:3539-3573`, and
+`Instances.slotDropHookTargets` (`Instances.ts:542-567`) discovers the hook instances that plan
+calls. So the recursion is:
+
+```
+cleanup(Tree)          = StructCleanup { shape: UnionCleanup { Branch: HookCleanup(Box.drop<Tree>) x2 } }
+Box.drop<Tree>  body   → Slot.dropValue<Tree> → SlotDrop { cleanup: cleanup(Tree) } → call Box.drop<Tree>
+```
+
+The static plan is finite because `HookCleanup` lowers to a **call**, not an inlining, and because
+`RawBufferCleanup` terminates the descent. The unbounded part happens at runtime, inside a
+recursive function — which is precisely requirement 7's "deep chain exhausts the stack".
+
+The `seen` guard at `Ownership.ts:1671-1672` (which returns `NoCleanup` and is the mechanism the
+issue warns about) is therefore never reached on this shape. That was verified by trace, not by
+argument.
+
+### PR #92 is the enabling precedent, not the cleanup path
+
+PR #92 (`b8a22e2`) replaced `throw new RangeError('Wasm cleanup does not yet lower hook-bearing
+union cases')` with tag-guarded per-case lowering at `WasmBackend.ts:1233-1257` and `1353-1377`.
+`Box`'s storage is a vacant/occupied union, the same idiom `Vector` uses, so that lowering is what
+makes the shape safe in Wasm generally. Note precisely: for `Box<T>` itself the union's occupied
+case is hook-free in every instantiation, because `RawBufferCleanup` does not descend into `T`. #92
+is what removes the hazard for a hook-bearing member reached through the same union idiom; it is
+not a path this change extends with new code.
+
+### Polymorphic recursion is already rejected
+
+`struct Bad<T> { value: T next: Box<Bad<Box<T>>> }` would demand an infinite tower of drop
+instances. Instantiating it (via `Vector.make<Bad<i32>>()`, which forces `cleanupPlan(Bad<i32>)`
+through `Slot.dropValue`) produces `["SEM0053"]` — `Diagnostic.polymorphicRecursionCode`, raised
+from `Instances.ts:237` by the existing finite-discovery check. No new guard is needed; a test pins
+it.
+
+## Decisions
+
+### `Box<T>` is standard-library Silk source, not a compiler intrinsic
+
+This is the decision issue #19 got wrong, and the one Julia should review most closely. Both options
+were worked through; the recommendation is **B**.
+
+**Option A — compiler-intrinsic nominal (the issue's requirement 1).** `Box` joins
+`Type.intrinsicNominals` with a `Layout` branch beside `RawBuffer`. The cycle fix is then small: a
+barrier list of indirecting intrinsics that neighbour extraction refuses to descend through. But
+because an intrinsic has no struct declaration and no source `impl`, it cannot carry a `Drop` hook,
+so cleanup needs a new `BoxCleanup` plan node **plus** a compiler-synthesized per-instantiation drop
+thunk (an intrinsic cannot inline `T`'s cleanup at the plan level without re-entering the `seen`
+guard and leaking), **plus** lowering for both in `WasmBackend` and the LLVM `Backend`. That is new
+release machinery in two backends, written to be correct on first contact, guarding the exact leak
+this issue exists to prevent.
+
+**Option B — ordinary stdlib struct over `RawBuffer<T>` (recommended).**
+
+```silk
+struct Vacant {}
+struct Occupied<T> { buffer: RawBuffer<T> }
+pub struct Box<T> { storage: Vacant | Occupied<T> }
+
+impl<T> Drop for Box<T> {
+  fn drop(self: &mut Box<T>) -> () {
+    let storage = Intrinsic.replace(self.storage, Vacant {})
+    return match move storage {
+      Vacant nothing => ()
+      Occupied<T> full => releaseOccupied<T>(move full)
+    }
+  }
+}
+```
+
+`Vacant` exists for the same reason `Vector`'s `Empty<T>` does: the hook holds `&mut self` and
+`Intrinsic.replace` needs something to put back. It is a non-generic marker rather than
+`Vector`'s `anchor: [T; 0]`, because a zero-length array of `T` is still an inline reach into `T`
+(measured: `struct Node { anchor: [Node; 0] }` is `SEM0020` today, and this change deliberately
+leaves that conservative). `Box` never needs to borrow an empty slice, so it needs no anchor.
+
+Cost of B: the cycle fix must recognise that `Box`'s parameter is *not* reached inline, which cannot
+be a spelling check — `AGENTS.md` forbids recognising a library declaration by name in semantic
+analysis. It must be a general per-parameter analysis. That analysis is the whole implementation
+cost, and it buys something A does not: any user type that indirects through `RawBuffer` becomes
+recursion-capable for free, without asking the compiler's permission.
+
+Why B wins:
+
+- **It needs no new release machinery.** Measured end-to-end (below): zero new plan nodes, zero
+  backend changes, balanced releases on all three engines. A's synthesized drop thunk is exactly the
+  code most likely to reintroduce the leak.
+- **`AGENTS.md` "Minimal compiler privilege" points at it directly**: "A new compiler feature
+  exposes only the smallest target-neutral primitive needed to build its public API in ordinary Silk
+  source. Keep … safe reusable wrappers in the standard library." `RawBuffer` is that primitive and
+  it already exists; `Box` is the safe reusable wrapper.
+- **It makes the implementation match the spec it already has.** `bootstrap-struct-types` says a
+  cycle "consisting only of inline struct fields" is rejected. The implementation over-approximates
+  "inline" as "mentioned anywhere in the field's type". B's analysis is the honest reading of the
+  existing sentence, not a new rule.
+
+What B costs relative to the issue: requirement 1 as literally written ("compiler-intrinsic
+nominal") is not met. Requirement 1's *outcome* — one pointer-sized heap indirection, `MoveOnly`,
+allocating through `Allocator` — is met in full. If Julia wants the intrinsic spelling for a reason
+not captured here (a stable ABI symbol, a debugger contract, a plan to special-case `Box` in later
+optimisation), Option A is still available, and the cycle-detection work in section 1 of `tasks.md`
+shrinks rather than disappears while section 3 grows into two-backend work.
+
+### Cycle detection uses inline reach, computed as a fixed point
+
+Replace the `Type.nominals` call at the two cycle sites with an inline-reach walk. Rules:
+
+- `RawBuffer<T>` and `Slot<T>`: yield the nominal, **do not** descend into arguments. Their layouts
+  are `{$allocation, count}` and `{$address}` (`Layout.ts:644-651`) — element-independent.
+- Any other nominal `S<A₀…Aₙ>`: yield `S`, and descend into `Aᵢ` only when parameter `i` of `S` is
+  reached inline by `S`'s own fields.
+- Fixed arrays, slices, references, callables, effects, and unions: descend as `Type.nominals` does
+  today, preserving current diagnostics exactly.
+
+"Parameter `i` of `S` is inline" is a monotone fixed point: start with no parameter inline, and
+repeatedly mark parameter `i` inline when some field of `S` reaches it under the rules above.
+Growth-only, so it terminates.
+
+`Type.nominals` itself is **not** changed. The reported `dependency` list at
+`DeclarationIndex.ts:3706-3714` keeps naming every referenced nominal, so
+`bootstrap-struct-types`'s "the field retains that type dependency" stays true. Only cycle detection
+switches graphs.
+
+### The runtime cleanup mechanism, stated plainly
+
+For a value reachable only through a `Box`:
+
+1. The holder's static plan contains `HookCleanup { hook: Box.drop<T>, inner: … }` — one call, at a
+   constant offset, exactly as `WasmBackend.ts:1189-1204` requires.
+2. `Box.drop<T>` moves the storage out through `&mut self`, matches the union, and calls
+   `Slot.dropValue<T>` on the single element.
+3. `SlotDrop` carries `T`'s own cleanup plan, which contains the next `HookCleanup` call.
+4. Depth is consumed by the call stack, not by the plan. Deep chains exhaust the stack; nothing
+   leaks.
+
+If step 2 were omitted, `RawBufferCleanup` would release the block and abandon its contents. That is
+the silent leak, and it is why the tests below are part of the deliverable rather than a follow-up.
+
+## Validation
+
+A throwaway spike on `main` (30310de) implemented the fixed point at both cycle sites and wrote
+`Box` in test source. **Not shipped; recorded here as evidence the design works.**
+
+Cycle detection, after the change:
+
+| source | result |
+| --- | --- |
+| `struct Node { next: RawBuffer<Node> }` | accepted, `dependency: Available` |
+| `struct Cell<T> { buffer: RawBuffer<T> }` + `struct Node { next: Cell<Node> }` | accepted |
+| `struct Pair<T> { value: T }` + `struct Node { next: Pair<Node> }` | `SEM0020` — unchanged |
+| `struct Node { next: Node }` | `SEM0020` — unchanged |
+| `struct Node { anchor: [Node; 0] }` | `SEM0020` — unchanged |
+
+End-to-end, a 3-level tree (`Tree` → `Branch` → `Box<Tree>`, 7 nodes, 6 boxes):
+
+| engine | result |
+| --- | --- |
+| diagnostics | none |
+| evaluator | `Completed`, value 42, **6 `AllocationAcquire` / 6 `AllocationRelease`** |
+| Wasm (`silk_main`, release) | 42 |
+| native LLVM (clang, release) | exit 42 |
+
+Negative control — byte-identical source with the `impl Drop for Box` deleted:
+
+| | |
+| --- | --- |
+| diagnostics | **none** |
+| evaluator | `Completed`, value 42, **6 acquires / 2 releases** |
+| Wasm | 42 |
+
+The leak is silent, produces the right answer, and passes every check the compiler has today. Only
+the acquire/release trace catches it.
+
+Regression: the full compiler suite ran with the cycle change applied — **149 files, 1160 tests,
+all passing**.
+
+## Risks
+
+- **Two cycle sites, one rule.** `DeclarationIndex.ts:2784-2791` and `:3685-3693` must use the same
+  walk and the same fixed point. Changing one and not the other yields a graph that disagrees with
+  itself. Tasks 1.2 and 1.3 pin both.
+- **The fixed point widens what compiles.** Any user generic that indirects through `RawBuffer`
+  becomes recursion-capable, not just `Box`. That is intended and is the reason the rule is general
+  rather than a `Box` special case, but it is a real surface increase and the reviewer should agree
+  to it explicitly.
+- **A hook that forgets `Slot.dropValue` leaks silently.** Nothing in the type system prevents it.
+  The mitigation is the negative-control test (task 4.3), which must be written as a test that
+  *fails* if the hook is removed.
+- **`[T; 0]` stays an inline reach.** Conservative and unchanged, which is why `Box` uses a
+  non-generic `Vacant`. Revisiting it would let `Vector`'s `Empty<T>` shape work inside recursive
+  types too, but that is a separate change.
+
+## Open question for review
+
+One, already answered with a recommendation rather than left blocking: **intrinsic `Box` (A) or
+stdlib `Box` (B)?** The recommendation is B, on the evidence above. Nothing else in this design
+forks on it — the cycle work in section 1 is required either way, only its shape changes.

--- a/openspec/changes/add-box-heap-indirection/proposal.md
+++ b/openspec/changes/add-box-heap-indirection/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Silk has no heap indirection, so no struct can name itself. `SyntaxTree`, `Hir.Expression`,
+`Type.Type`, and `Mir` are all recursive trees, and a self-hosted compiler cannot hold one of them
+today. `pub struct Expr { left: Expr }` is rejected with `SEM0020`, and that rejection is correct:
+`bootstrap-struct-types` forbids the compiler to "silently add indirection". What is missing is a
+way for a program to ask for indirection explicitly. This is the self-hosting gate (#19).
+
+Two claims in the issue that shaped its plan were measured against `main` (30310de) and are false or
+incomplete, so this proposal replaces the mechanism rather than restating it.
+
+- **The issue claims intrinsic nominals already break the cycle.** They do not.
+  `Type.nominals` (`Type.ts:694-713`) descends into a nominal's type *arguments*, so
+  `RawBuffer<Node>` yields `[RawBuffer, Node]` and `Node` survives the `byKey.has` filter at
+  `DeclarationIndex.ts:2790`. Measured on `main`: `struct Node { next: RawBuffer<Node> }` produces
+  `SEM0020` with `dependency: Unavailable`. The cycle check needs a real change.
+- **The issue's `Box` shape cannot carry the `Drop` hook it also requires.**
+  `Ownership.cleanupPlan` returns `NoCleanup` unless `byCanonical` yields a `StructDeclaration`
+  (`Ownership.ts:1673-1680`) and reaches `HookCleanup` only through a `SourceConformanceWitness`
+  (`Ownership.ts:1703-1706`). An intrinsic nominal has no struct declaration and no source `impl`,
+  so requirement 1 and requirement 4 of the issue are not simultaneously satisfiable as written.
+
+Admitting the recursion without a working runtime cleanup path is the trap the issue itself names:
+cleanup plans are statically unrolled to constant byte offsets (`WasmBackend.ts:1189-1204`), so the
+plan releases the top level and silently leaks everything below it. That leak was reproduced: a
+3-level tree built from a `Box` with its `Drop` hook removed compiles with **zero diagnostics**,
+returns the right answer, and traces **6 acquires against 2 releases**.
+
+## What Changes
+
+- **`Box<T>` is ordinary standard-library Silk source**, not a compiler-intrinsic nominal:
+  a struct over `RawBuffer<T>` with an `impl<T> Drop for Box<T>` hook, built the way `Vector<T>`
+  already is. The compiler learns no new type and gains no new cleanup plan node, and both backends
+  are untouched. See `design.md` for the rejected intrinsic alternative and the trade.
+- **Struct cycle detection distinguishes *inline* reach from *mentioned* reach.** A field's
+  neighbours become the nominals its layout actually requires: descent stops at `RawBuffer<T>` and
+  `Slot<T>`, whose layouts are fixed and element-independent (`Layout.ts:644-651`), and descent into
+  a user generic's type argument happens only when that parameter is itself reached inline, computed
+  as a monotone fixed point over the declarations. `struct Node { next: Box<Node> }` is accepted;
+  `struct Node { next: Node }` and `struct Node { next: Pair<Node> }` still fail with `SEM0020`.
+- **`bootstrap-struct-types` is amended** so its "cycle consisting only of inline struct fields"
+  clause names explicit indirection as the sanctioned escape and defines "inline" precisely. The
+  clause forbidding the compiler to silently add indirection is kept verbatim.
+- **The leak becomes a pinned acceptance test** rather than an unwritten assumption: a 3-level tree
+  asserts acquire count equals release count on the evaluator, the Wasm backend, and the native
+  LLVM backend.
+
+`Box<T>` is `MoveOnly` for every `T` with no ownership change — `Ownership.categoryOf`
+(`Ownership.ts:258-281`) has no nominal branch, so every nominal already falls through to
+`MoveOnly`. `Box.make` allocates through `Allocator` and fails with `OutOfMemory`; the drop path
+stays requirement-free and failure-free as the hook rules demand (`DeclarationIndex.ts:3450-3459`),
+because releasing needs neither.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bootstrap-struct-types`: define the inline-reach dependency graph, name explicit indirection as
+  the sanctioned way through a cycle, and keep rejecting cycles that are inline throughout.
+- `bootstrap-target-layout`: pin that a struct reaching itself only through indirection lays out,
+  and that indirected element layout is not a layout dependency of its holder.
+- `bootstrap-ownership`: state that a value reachable only through indirection is released by its
+  holder's `Drop` hook at runtime, never by the statically unrolled plan.
+- `bootstrap-silk-stdlib`: ship `Box<T>` as canonical ordinary Silk source with no compiler
+  privilege.
+
+## Impact
+
+Affects struct dependency analysis and its two cycle-detection sites in `DeclarationIndex`, the
+standard-library manifest and its generated source table, and acceptance tests. It adds no compiler
+intrinsic, no cleanup plan node, no backend code, and no change to `Ownership.cleanupPlan`.
+
+Out of scope, unchanged: inline recursion stays rejected; no `Rc`, `Arc`, or shared ownership; no
+cyclic graphs — `Box` gives trees only; no arena allocator (#22). A deep `Box` chain exhausts the
+stack, which is accepted behaviour, and it must not leak.

--- a/openspec/changes/add-box-heap-indirection/specs/bootstrap-ownership/spec.md
+++ b/openspec/changes/add-box-heap-indirection/specs/bootstrap-ownership/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Indirected values are released at runtime by their holder's hook
+
+The target-neutral cleanup plan is statically unrolled to constant offsets, so it SHALL NOT be
+required to represent an unbounded chain of owners. A struct that owns a value only through an
+indirection SHALL release that value through its own `Drop` hook, which the plan invokes as one
+call rather than by inlining the indirected value's cleanup. Cleanup of a compiler-owned
+indirection SHALL release the storage only and MUST NOT descend into the indirected element type,
+so the plan stays finite; the hook SHALL therefore drop the element explicitly before the storage
+releases. Recursion depth SHALL be consumed by the runtime call stack, so an owner reachable
+through any number of indirections SHALL be released exactly once, and exhausting the stack on a
+deep chain SHALL NOT leak.
+
+A cleanup plan MUST NOT reach its recursion guard on a cycle that passes through an indirection: no
+owner in such a cycle may be planned as having no cleanup.
+
+#### Scenario: Release a recursive tree through its hooks
+
+- **WHEN** a multi-level tree whose nodes hold their children behind indirections leaves scope
+- **THEN** every level's storage is released, and the release count equals the acquire count
+
+#### Scenario: Invoke a hook rather than inline an indirected owner
+
+- **WHEN** a struct's cleanup plan reaches a field that owns a value through an indirection
+- **THEN** the plan records one hook call at a constant offset rather than the indirected value's own recursive cleanup
+
+#### Scenario: Keep releasing a value the storage release would abandon
+
+- **WHEN** an indirection's storage cleanup releases the block that holds an owned element
+- **THEN** the element has already been dropped by the holder's hook, so no owner below the first level is abandoned
+
+#### Scenario: Preserve identical release counts across engines
+
+- **WHEN** the same recursive owner is released under the evaluator, the Wasm backend, and the native backend
+- **THEN** all three report the same number of releases

--- a/openspec/changes/add-box-heap-indirection/specs/bootstrap-silk-stdlib/spec.md
+++ b/openspec/changes/add-box-heap-indirection/specs/bootstrap-silk-stdlib/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Box is canonical ordinary Silk source
+
+Canonical standard-library source SHALL define `Box<T>`, one owned heap indirection holding exactly
+one value of `T`, as ordinary Silk with no compiler privilege. No compiler phase SHALL know `Box` by
+name: it MUST NOT appear in the intrinsic nominal registry, gain a layout branch, gain a cleanup
+plan node, or be recognized by spelling in semantic analysis, HIR, MIR, evaluation, or a backend. It
+SHALL be built from the existing typed raw storage and slot primitives, mirroring how `Vector<T>` is
+built.
+
+`Box<T>` SHALL be move-only for every `T` through the ordinary nominal ownership rule, with no
+ownership special case. Its construction SHALL allocate through the `Allocator` service and SHALL
+fail with `OutOfMemory`. Its `Drop` hook SHALL take exclusive `self`, return unit, and declare no
+failures and no requirements, dropping the held value before its storage releases. A boxed value
+SHALL be reachable by shared borrow, exclusive borrow, and consuming move without unsafe code at the
+call site.
+
+`Box<T>` SHALL give trees only. It MUST NOT provide shared ownership, reference counting, or a way
+to construct a cyclic graph.
+
+#### Scenario: Hold a recursive type
+
+- **WHEN** a struct declares a field of `Box` applied to the struct's own type
+- **THEN** the declaration is accepted and the layout is finite, without the compiler recognizing `Box` by name
+
+#### Scenario: Report allocation exhaustion
+
+- **WHEN** the allocator cannot satisfy a box construction
+- **THEN** the caller receives the ordinary `OutOfMemory` typed failure and no partially initialized box exists
+
+#### Scenario: Release the held value with the box
+
+- **WHEN** a box holding a value that owns resources leaves scope
+- **THEN** the held value is dropped before the box's storage releases, and the release count equals the acquire count
+
+#### Scenario: Move a box without copying
+
+- **WHEN** a box is assigned or passed by value
+- **THEN** ownership transfers under the ordinary move-only rules and the source is no longer live

--- a/openspec/changes/add-box-heap-indirection/specs/bootstrap-struct-types/spec.md
+++ b/openspec/changes/add-box-heap-indirection/specs/bootstrap-struct-types/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Inline struct dependencies are finite
+
+Resolved nominal fields SHALL form a deterministic type-dependency graph. A field SHALL retain every
+nominal type it references as a reported dependency. Cycle detection SHALL use the narrower graph of
+*inline reach*: the nominals whose layout a field's layout actually requires.
+
+Inline reach SHALL be defined as follows. A field reaches a nominal inline when the nominal appears
+in the field's type outside every indirecting position. A type argument of a compiler-owned
+indirection whose layout is independent of that argument SHALL NOT be an inline position. A type
+argument of a declared generic SHALL be an inline position exactly when that generic reaches its own
+corresponding type parameter inline, computed as a monotone fixed point over the declarations and
+therefore independent of declaration and module order.
+
+Acyclic inline dependencies SHALL be available regardless of source or module order. Any direct or
+mutual cycle consisting only of inline struct fields SHALL make every participating struct's layout
+unavailable with one stable, canonically attributed diagnostic cycle. A cycle that passes through at
+least one indirecting position SHALL be available, because the participating layouts are finite. The
+compiler MUST NOT guess a size, silently add indirection, or reject an import cycle that contains no
+inline type cycle.
+
+#### Scenario: Resolve an acyclic nested struct
+
+- **WHEN** `Span` contains two `Position` fields and `Position` contains scalar fields
+- **THEN** both nominal types and their dependency edge are available independently of declaration order
+
+#### Scenario: Reject direct inline recursion
+
+- **WHEN** `Node` declares a field of type `Node`
+- **THEN** `Node` retains its nominal identity and fields but its dependency and layout state identify the direct recursive cycle as unavailable
+
+#### Scenario: Reject mutual inline recursion across modules
+
+- **WHEN** `syntax.Expression` contains `statement.Statement` and `statement.Statement` contains `syntax.Expression`
+- **THEN** both nominal identities remain queryable and one canonical cycle makes both layouts unavailable
+
+#### Scenario: Ignore a harmless module cycle
+
+- **WHEN** two cyclically importing modules declare structs whose field dependency graph is acyclic
+- **THEN** their struct facts and layouts remain available without a diagnostic attributed solely to the import cycle
+
+#### Scenario: Accept a cycle that passes through explicit indirection
+
+- **WHEN** a struct declares a field whose type reaches the struct itself only behind an explicit heap indirection
+- **THEN** the struct's dependency state is available, its layout is finite, and no cycle diagnostic is produced
+
+#### Scenario: Reject a cycle through a generic that inlines its parameter
+
+- **WHEN** `Wrapper` holds its type parameter as an inline field and `Node` declares a field of type `Wrapper<Node>`
+- **THEN** the cycle remains inline throughout and `Node` is rejected exactly as a direct self-reference is
+
+#### Scenario: Accept a cycle through a generic that indirects its parameter
+
+- **WHEN** a generic reaches its type parameter only through an indirecting position and a struct declares a field of that generic applied to itself
+- **THEN** the struct is available, without the compiler recognizing the generic by name
+
+#### Scenario: Report a reference behind indirection as a dependency
+
+- **WHEN** a field's type mentions a nominal only inside an indirecting position
+- **THEN** the field still reports that nominal as a dependency while contributing no cycle edge

--- a/openspec/changes/add-box-heap-indirection/specs/bootstrap-target-layout/spec.md
+++ b/openspec/changes/add-box-heap-indirection/specs/bootstrap-target-layout/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Struct layout planning is finite and deterministic
+
+Struct layout SHALL follow canonical nominal type dependencies rather than source traversal order.
+An unavailable field type or inline-recursive dependency SHALL make only dependent struct layouts
+unavailable with their originating causes; unrelated scalar and struct layouts SHALL remain
+available. The layout of a compiler-owned indirection SHALL be independent of the layout of the type
+it indirects, so an indirected element type SHALL NOT be a layout dependency of the struct holding
+the indirection, and a struct that reaches itself only through an indirection SHALL have a finite,
+available layout. Identical target and declaration inputs SHALL produce byte-identical ordered
+entries and field offsets across fresh processes.
+
+#### Scenario: Refuse an inline recursive layout
+
+- **WHEN** a reachable nominal struct participates in a direct or mutual inline dependency cycle
+- **THEN** its layout remains unavailable and no placeholder size or backend type is created
+
+#### Scenario: Propagate an unavailable nested layout
+
+- **WHEN** an outer struct contains a struct whose field type is unavailable
+- **THEN** the outer layout is unavailable with that dependency cause while unrelated entries remain complete
+
+#### Scenario: Repeat aggregate layout planning
+
+- **WHEN** the same nested nominal types are planned repeatedly for one target
+- **THEN** their canonical entry order, sizes, alignments, field offsets, and encoding are byte-identical
+
+#### Scenario: Lay out a struct that reaches itself through indirection
+
+- **WHEN** a reachable struct holds an explicit heap indirection to its own type
+- **THEN** the catalog entry records a complete size, alignment, and field offsets, and planning terminates without visiting the struct a second time
+
+#### Scenario: Exclude an indirected element from layout dependencies
+
+- **WHEN** a struct holds a compiler-owned indirection over an element type
+- **THEN** the struct's catalog entry is computed from the indirection's own fixed representation and does not require the element's layout

--- a/openspec/changes/add-box-heap-indirection/tasks.md
+++ b/openspec/changes/add-box-heap-indirection/tasks.md
@@ -1,0 +1,63 @@
+## 1. Inline-Reach Dependency Graph
+
+- [ ] 1.1 Add the inline-reach walk and its monotone per-parameter fixed point over struct
+      declarations: descent stops at `RawBuffer<T>` and `Slot<T>`, and enters a user generic's type
+      argument only when that parameter is reached inline by the generic's own fields.
+- [ ] 1.2 Use the walk for SCC neighbour extraction at `DeclarationIndex.ts:2784-2791`, replacing
+      the `Type.nominals` call.
+- [ ] 1.3 Use the same walk and the same fixed point for the `selfEdge` test at
+      `DeclarationIndex.ts:3685-3693`, so both cycle sites agree.
+- [ ] 1.4 Leave `Type.nominals` and the reported `dependency` list at
+      `DeclarationIndex.ts:3706-3714` unchanged, so a field still names every type it references.
+- [ ] 1.5 Confirm the fixed point is order-independent and produces byte-identical facts across
+      fresh processes, matching the determinism the declaration index already promises.
+
+## 2. Box in Canonical Silk Source
+
+- [ ] 2.1 Add the canonical `silk/box` module: `Vacant`, `Occupied<T>` over `RawBuffer<T>`, and
+      `pub struct Box<T> { storage: Vacant | Occupied<T> }`.
+- [ ] 2.2 Add `Box.make<T>(value: T) -> Box<T> ! OutOfMemory ? &mut Allocator`, allocating one
+      element through `Allocator` and writing the value into slot zero.
+- [ ] 2.3 Add the borrow and consume accessors (`get`, `getMut`, `into`) so a boxed value is
+      reachable without unsafe code at the call site.
+- [ ] 2.4 Add `impl<T> Drop for Box<T>`: move the storage out with `Intrinsic.replace`, match the
+      union, and release the occupied case through `Slot.dropValue` before the buffer releases.
+      No failures and no requirements, per `DeclarationIndex.ts:3450-3459`.
+- [ ] 2.5 Register the module and its prelude alias in the standard-library manifest and regenerate
+      the compiler-shipped source table.
+
+## 3. No Compiler Privilege
+
+- [ ] 3.1 Confirm no new intrinsic, no `Type.intrinsicNominals` entry, no `Layout` branch, and no
+      `CleanupPlan` node were added, and that neither backend changed.
+- [ ] 3.2 Confirm `Box<T>` is `MoveOnly` for every `T` through the existing fall-through in
+      `Ownership.categoryOf` (`Ownership.ts:258-281`), with no ownership change.
+- [ ] 3.3 Confirm `Ownership.cleanupPlan`'s `seen` guard (`Ownership.ts:1671-1672`) is never reached
+      on a `Box`-mediated cycle, so no owner silently becomes `NoCleanup`.
+
+## 4. Acceptance
+
+- [ ] 4.1 Accept `struct Expr { left: Box<Expr> }` with no diagnostic, and accept a mutual cycle
+      that passes through `Box` across two modules.
+- [ ] 4.2 Keep rejecting `struct Node { next: Node }`, `struct Node { next: Pair<Node> }` where
+      `Pair<T> { value: T }`, and `struct Node { anchor: [Node; 0] }` with `SEM0020`.
+- [ ] 4.3 Add the leak test: a 3-level `Box` tree asserting acquire count equals release count on
+      the evaluator, with the same value from the Wasm backend and the native LLVM backend. Write it
+      so it fails when the `Drop` hook is removed — the unhooked tree traces 6 acquires against
+      2 releases while still compiling clean and returning the right answer.
+- [ ] 4.4 Pin that a polymorphically recursive `Box` shape is rejected with `SEM0053` by the
+      existing finite-discovery check rather than diverging.
+- [ ] 4.5 Pin that a deep `Box` chain exhausts the stack without leaking.
+- [ ] 4.6 Run the full compiler suite and report any test whose expected diagnostics change.
+
+## 5. Specification
+
+- [ ] 5.1 Amend `bootstrap-struct-types` to define inline reach and name explicit indirection as the
+      sanctioned way through a cycle, keeping the clause that forbids the compiler to add
+      indirection silently.
+- [ ] 5.2 Amend `bootstrap-target-layout` to pin that indirected element layout is not a layout
+      dependency of its holder.
+- [ ] 5.3 Amend `bootstrap-ownership` to state that an indirected value is released by its holder's
+      `Drop` hook at runtime, never by the statically unrolled plan.
+- [ ] 5.4 Add the `bootstrap-silk-stdlib` requirement for `Box<T>` as ordinary source with no
+      compiler privilege.


### PR DESCRIPTION
**Design proposal only. No implementation is included.** This PR contains one openspec change — `openspec/changes/add-box-heap-indirection/` — for review before any code is written. It relates to #19 and does not close it.

## Why the issue's plan was replaced rather than restated

Two load-bearing claims in #19 were measured against `main` (30310de) and are false. The proposal is built on what the code does.

**1. Intrinsic nominals do not break the SCC cycle.** `Type.nominals` (`Type.ts:694-713`) recurses into a nominal's type *arguments*, so `RawBuffer<Node>` yields `[RawBuffer, Node]`; `Node` survives the `byKey.has` filter at `DeclarationIndex.ts:2790` and the self-edge remains. Measured: `struct Node { next: RawBuffer<Node> }` produces `SEM0020` with `dependency: Unavailable` today. There is also a *second*, independent cycle site — the `selfEdge` test at `DeclarationIndex.ts:3685-3693` — that repeats the same call and must change with it.

**2. An intrinsic `Box` cannot carry the `Drop` hook the issue also requires.** `Ownership.cleanupPlan` returns `NoCleanup` unless `byCanonical` yields a `StructDeclaration` (`Ownership.ts:1673-1680`) and reaches `HookCleanup` only through a `SourceConformanceWitness` (`Ownership.ts:1703-1706`). Requirements 1 and 4 of the issue are not simultaneously satisfiable as written.

## What the proposal decides

- **`Box<T>` is ordinary stdlib Silk source**, a struct over `RawBuffer<T>` with `impl<T> Drop for Box<T>`, built the way `Vector<T>` already is — no new intrinsic, no new cleanup plan node, no backend code. The rejected intrinsic alternative is spelled out in `design.md` with its cost (a `BoxCleanup` node plus a synthesized drop thunk lowered in both Wasm and LLVM) and a recommendation.
- **Cycle detection switches from "mentioned" reach to "inline" reach.** Descent stops at `RawBuffer<T>`/`Slot<T>`, whose layouts are element-independent (`Layout.ts:644-651`), and enters a user generic's type argument only when that parameter is itself reached inline — a monotone fixed point, so no library declaration is recognized by spelling (`AGENTS.md`, minimal compiler privilege).

## The runtime cleanup path, and the leak test

Cleanup plans are statically unrolled (`WasmBackend.ts:1189-1204`), so the recursion must happen at runtime. It already can: `RawBufferCleanup` does not descend into its element (`Ownership.ts:1636-1645`), `HookCleanup` lowers to a **call**, and `Slot.dropValue` carries its own plan through MIR `SlotDrop` (`Mir.ts:1508-1509`), lowered in Wasm (`WasmBackend.ts:1353-1377`) and LLVM (`Backend.ts:3539-3573`), with hook instances discovered by `Instances.slotDropHookTargets` (`Instances.ts:542-567`). Depth is consumed by the call stack, which is requirement 7's stack exhaustion.

PR #92's tag-guarded `UnionCleanup` lowering is the precedent for the vacant/occupied storage idiom. Stated precisely in the design: for `Box<T>` itself the occupied case is hook-free in every instantiation, so #92 is what de-risks the idiom generally rather than a path this change extends with new code.

## Validation (throwaway spike, not shipped)

A spike implemented the fixed point at both cycle sites and wrote `Box` in test source.

| | result |
| --- | --- |
| `struct Node { next: RawBuffer<Node> }` | accepted, `dependency: Available` |
| `struct Cell<T> { buffer: RawBuffer<T> }` + `Node { next: Cell<Node> }` | accepted |
| `Pair<T> { value: T }` + `Node { next: Pair<Node> }` | `SEM0020` — unchanged |
| `struct Node { next: Node }`, `struct Node { anchor: [Node; 0] }` | `SEM0020` — unchanged |

3-level tree (7 nodes, 6 boxes): no diagnostics; evaluator `Completed` with **6 acquires / 6 releases**; Wasm `silk_main` → 42; native clang binary exit 42.

**Negative control** — byte-identical source with `impl Drop for Box` deleted: **no diagnostics**, correct answer, **6 acquires / 2 releases**. The leak is silent and passes every check the compiler has today; only the trace catches it. That is task 4.3.

Full compiler suite with the cycle change applied: **149 files, 1160 tests, all passing**.

## One question for review

Intrinsic `Box` (A) or stdlib `Box` (B)? The design recommends **B** on the evidence above and does not block on it — nothing else forks on the answer, only the shape of section 1 of `tasks.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R62yDJRabqYb1vvLrQHRPT)_