### PR TITLE
type-system: accept an interface with multiple operations as a generic bound

### DIFF
--- a/openspec/changes/accept-multi-operation-interface-bounds/design.md
+++ b/openspec/changes/accept-multi-operation-interface-bounds/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Bounds are monomorphization-time only. An interface selects compiler-known operations during
+specialization; it creates no effect requirement, no provider slot, and no runtime dispatch
+(`numeric.silk`). That property is preserved here in full — the change is about what the compiler
+records for a bound and what it checks before substituting a type argument, not about what reaches
+the engines.
+
+## Goals / Non-Goals
+
+Goals:
+
+- One bound may name an interface declaring any number of operations.
+- Every operation the bound declares is usable in the generic body, at the contract the interface
+  declares for it.
+- A type argument is admitted only against a witness that covers the bound's whole contract, and a
+  rejection names the operation that is missing.
+- A bound may name an interface another module declares.
+
+Non-Goals: `HashKey` and `Order` themselves, more than one bound on one parameter, dynamic
+dispatch, and any runtime representation change.
+
+## Decisions
+
+### The bound is a resolved contract, not a spelling
+
+`TypeParameterFact.bound` becomes
+
+```ts
+export type BoundFact =
+  | {
+      readonly _tag: 'ResolvedBound'
+      readonly spelling: string
+      readonly path: TypePathFact
+      readonly capability: CanonicalId
+      readonly operations: ReadonlyArray<string>
+    }
+  | { readonly _tag: 'UnresolvedBound'; readonly spelling: string; readonly path: TypePathFact }
+```
+
+Collection keeps the syntax it can see: the spelling and its one-segment type path. Header
+completion — the pass that already resolves declared types, conformance capabilities, and rows
+through each module's own resolver — resolves that path and, when it names an interface, records
+the interface's canonical identity together with its ordered operation names.
+
+Two consumers then read one fact instead of re-deriving it. Constraint checking builds the
+capability from `capability` rather than searching one module's interfaces by spelling, which is
+what admits a bound on an interface another module declares. Operator selection asks
+`operations` whether the bound declares the operation the operator spells, instead of repeating
+the same search.
+
+Recording the operation names on the bound, rather than only the interface identity, is what makes
+the fact answer the question the bound exists to answer: which operations this parameter offers.
+
+### An unresolved bound is still reported at the specialization
+
+Header completion deliberately drops the resolver's own diagnostics for a bound. A bound that names
+nothing, or names a declaration that is not an interface, stays `UnresolvedBound` and is reported
+where it was reported before: at the call that would have had to satisfy it, where the type
+argument is known. A declaration whose bogus bound no call ever specializes keeps producing no
+diagnostic, exactly as before.
+
+### Existence is not coverage
+
+`conforms` answers whether a provider has a witness. For an interface capability that meant
+counting conformance declarations, with no attention to their operations. Specialization now asks a
+second question through `unmappedInterfaceOperations`: which operations of the interface the
+selected conformance leaves unmapped. Each one produces its own diagnostic naming
+`Provider does not implement Bound.operation`, so a bound with two operations cannot be
+half-satisfied by a witness that supplies one.
+
+This is deliberately a separate question rather than a stricter `conforms`. `conforms` also answers
+for `Drop` and `Report`, whose completeness rules are their own, and its existing callers ask only
+about existence.
+
+### An operator on a bound-typed operand takes the operation's contract
+
+An operator whose operand is a bound parameter is elaborated against the compiler-known operation
+for a stand-in actor, then generalized. Generalizing every position to the parameter is only
+correct while every bound operation happens to result in the parameter, which is true of `add` and
+false of `lessThan`. The rule is instead: substitute the parameter for the stand-in actor's own
+type wherever it appears in the compiler-known contract, and leave every other position alone.
+`add` gives `(T, T) -> T`; `lessThan` gives `(T, T) -> bool` — in both cases exactly the contract
+the interface declares.
+
+### What a generic body can call
+
+An operation whose name an operator spells — `add`, `subtract`, `lessThan`, `equals` — is called
+through that operator, and every such operation of the bound is callable. An interface operation
+whose name no operator spells has no call surface in a generic body: interfaces are not actors, and
+`Bound.operation(value)` resolves to a public function of the module declaring `Bound`, not to the
+bound's operation.
+
+That surface is left to the change that needs it. `HashKey` (#34) will need one for `hash`, and
+choosing its spelling is a language decision — the parallel with services suggests
+`Bound.operation(args)`, and unlike an operator it must consult the witness's selected operation at
+specialization rather than reusing the width-neutral scalar lowering an operator already has.
+Nothing here forecloses it.

--- a/openspec/changes/accept-multi-operation-interface-bounds/proposal.md
+++ b/openspec/changes/accept-multi-operation-interface-bounds/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+A generic bound is written `T: Integer` and, until now, that spelling was all the compiler kept:
+`TypeParameterFact` declared `readonly bound?: string`. Two consequences follow from a bare
+spelling, and neither is visible while the only shipped interface — `Integer` (`numeric.silk`) —
+declares one operation and is only ever bounded inside its own module.
+
+- The spelling was matched against interfaces of **one** module: the module declaring the bounded
+  function. A bound could therefore never name an interface another module declares, so
+  `import silk.numeric { Integer }` followed by `fn twice<T: Integer>` was rejected as an unknown
+  interface constraint. Only `silk/numeric` could bound anything by `Integer`.
+- A witness was admitted by existence, not by coverage. `conforms` counted the conformance
+  declarations matching one capability and provider and never looked at their operations, so a
+  conformance that maps some of an interface's operations satisfied specialization exactly as well
+  as one that maps all of them. With one operation there is no difference to see.
+
+`HashKey` (#34) and `Order` (#36) both need a bound with more than one operation, and both are
+blocked on those two properties.
+
+## What Changes
+
+- Replace the bare-spelling bound with a `BoundFact` that starts as the retained spelling and its
+  syntax and becomes `ResolvedBound` during header completion, carrying the canonical identity of
+  the interface it names and that interface's ordered operation contract.
+- Resolve the bound in the bounded declaration's own module scope, so a bound may name any
+  interface that declaration can see, including one another module declares.
+- Check the witness completely at specialization: a type argument is admitted only when its
+  conformance maps every operation the bound declares, and each unmapped operation is reported by
+  name.
+- Read the bound's recorded contract when deciding whether an operator on a bound-typed operand is
+  the bound's own operation, and give that operator the operation's declared result type rather
+  than the parameter — so a bound may declare `lessThan` and have it result in `bool`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bootstrap-type-generics`: record a bound as its resolved interface contract rather than a bare
+  spelling, admit a bound that names an interface from another module, make every operation of a
+  bound callable in the generic body at that operation's declared contract, and require a complete
+  witness at specialization.
+
+## Impact
+
+The change affects the declaration index's type-parameter fact and header completion, and
+elaboration's constraint checking and operator selection. It is type-system and resolution work
+only: no runtime representation changes, no instance key or MIR shape changes, and the three
+engines are unaffected except through which specializations analysis admits. `Integer` keeps
+working as the single-operation case with no change to its source.
+
+It does not add `HashKey` or `Order`, more than one bound on one parameter (`T: A + B`), any
+dynamic dispatch or vtable, or a call surface for an interface operation whose name is not spelled
+by an operator.

--- a/openspec/changes/accept-multi-operation-interface-bounds/specs/bootstrap-type-generics/spec.md
+++ b/openspec/changes/accept-multi-operation-interface-bounds/specs/bootstrap-type-generics/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: A bound records the interface contract it names
+
+A type parameter's bound SHALL retain the spelling and syntax its declaration supplies and SHALL be
+resolved, during header completion, in the bounded declaration's own module scope. A bound that
+names an interface SHALL record that interface's canonical identity together with its ordered
+operation names; a bound that names nothing, or names a declaration that is not an interface, SHALL
+remain unresolved and be reported at the specialization that would have had to satisfy it. A bound
+MUST NOT be restricted to interfaces declared by the bounded declaration's own module.
+
+#### Scenario: Bound an interface another module declares
+
+- **WHEN** a module imports `Integer` from `silk/numeric` and declares `fn twice<T: Integer>(value: T) -> T`
+- **THEN** the bound resolves to the imported interface and the declaration specializes for every conforming scalar
+
+#### Scenario: Record a two-operation contract
+
+- **WHEN** a declaration is bounded by an interface declaring `add` and `subtract`
+- **THEN** its type parameter records the interface's canonical identity and both operation names in declaration order
+
+#### Scenario: Report a bound that names no interface
+
+- **WHEN** a bound names a struct, or a name nothing declares, and a call specializes that parameter
+- **THEN** the call reports an unknown interface constraint naming the bound's spelling
+
+### Requirement: Every operation of a bound is callable at its declared contract
+
+A generic body SHALL be able to call each operation its parameter's bound declares, over the
+canonical parameter, checked once before any concrete argument exists. An operator on a bound-typed
+operand SHALL select the bound's operation exactly when the bound's recorded contract names the
+operation that operator spells, and SHALL take that operation's declared parameter and result
+types — substituting the parameter only where the compiler-known operation carries its actor's own
+type. An operator the bound does not declare MUST remain unavailable on that parameter.
+
+#### Scenario: Call two operations of one bound
+
+- **WHEN** a body bounded by an interface declaring `add` and `subtract` evaluates `(left + right) - left`
+- **THEN** both operations are selected from the bound and the body checks once over the parameter
+
+#### Scenario: Keep a bound comparison at its declared result
+
+- **WHEN** a bound declares `lessThan(left: T, right: T) -> bool` and the body compares two bound-typed values
+- **THEN** the comparison results in `bool` rather than the bounded parameter
+
+#### Scenario: Refuse an undeclared operator
+
+- **WHEN** a body multiplies two values bounded by an interface declaring only `add` and `subtract`
+- **THEN** the declaration is rejected before any concrete specialization can make the operation appear valid
+
+### Requirement: Specialization requires a complete witness
+
+Specialization SHALL admit a type argument for a bounded parameter only when that argument's
+conformance to the bound maps every operation the interface declares. Each operation the selected
+conformance leaves unmapped SHALL be reported by name at the specialization, and a bound with more
+than one operation MUST NOT be satisfied by a witness supplying only some of them.
+
+#### Scenario: Reject a partial witness by operation name
+
+- **WHEN** a bound declares `add` and `subtract` and the type argument's conformance maps only `add`
+- **THEN** the specialization is rejected with a diagnostic naming `subtract` as the operation the argument does not implement
+
+#### Scenario: Admit a complete witness
+
+- **WHEN** the type argument's conformance maps every operation the bound declares
+- **THEN** the specialization is admitted and selects each concrete operation without runtime dispatch

--- a/openspec/changes/accept-multi-operation-interface-bounds/tasks.md
+++ b/openspec/changes/accept-multi-operation-interface-bounds/tasks.md
@@ -1,0 +1,34 @@
+## 1. Bound Form
+
+- [x] 1.1 Replace `TypeParameterFact.bound`'s bare spelling with a `BoundFact` retaining the
+      spelling and its one-segment type path, and collect it only from a real bound type path
+      instead of falling back to the parameter's own name during recovery.
+- [x] 1.2 Resolve every declaration's bounds during header completion, in that declaration's own
+      module scope, recording the named interface's canonical identity and ordered operation names.
+- [x] 1.3 Drop the resolver's own diagnostics for a bound so an unresolved bound keeps being
+      reported at the specialization that needs it, not at the declaration.
+
+## 2. Constraint Checking
+
+- [x] 2.1 Build the specialization's capability from the bound's recorded canonical identity rather
+      than searching the declaring module's interfaces by spelling.
+- [x] 2.2 Add `unmappedInterfaceOperations` returning, in declaration order, the interface
+      operations one provider's selected conformance leaves unmapped.
+- [x] 2.3 Report each unmapped operation by name at the specialization, alongside the existing
+      no-witness and unknown-constraint reports.
+
+## 3. Operator Selection
+
+- [x] 3.1 Decide an operator on a bound-typed operand from the bound's recorded operation names.
+- [x] 3.2 Substitute the bounded parameter only where the compiler-known operation carries its
+      actor's own type, so a bound comparison keeps its `bool` result.
+
+## 4. Acceptance
+
+- [x] 4.1 Add tests declaring a two-operation interface, bounding a generic by it, calling both
+      operations, and evaluating the result — at one provider and at two.
+- [x] 4.2 Add a test asserting a type argument whose conformance omits one operation is rejected
+      with a diagnostic naming that operation.
+- [x] 4.3 Add tests for a bound naming an imported interface, for a bound comparison's `bool`
+      result, and for the recorded bound contract on the declaration index.
+- [x] 4.4 Keep `Integer` working unchanged as the single-operation case, with its source untouched.

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -45,6 +45,27 @@ export interface CanonicalId {
   readonly name: string
 }
 
+/**
+ * The interface one type parameter is bounded by. A bound starts as the bare spelling its syntax
+ * retains and becomes `ResolvedBound` once header completion finds the interface that spelling
+ * names in the bounded declaration's own module scope — which is what lets a bound name an
+ * interface another module declares. A resolved bound carries the interface's complete ordered
+ * operation contract, so every consumer reads one fact instead of re-deriving it from a name.
+ */
+export type BoundFact =
+  | {
+      readonly _tag: 'ResolvedBound'
+      readonly spelling: string
+      readonly path: TypePathFact
+      readonly capability: CanonicalId
+      readonly operations: ReadonlyArray<string>
+    }
+  | {
+      readonly _tag: 'UnresolvedBound'
+      readonly spelling: string
+      readonly path: TypePathFact
+    }
+
 /** One ordered, declaration-owned generic type parameter with exact source provenance. */
 export interface TypeParameterFact {
   readonly _tag: 'TypeParameterDeclaration'
@@ -52,7 +73,7 @@ export interface TypeParameterFact {
   readonly name: DeclaredName
   readonly syntax: SyntaxTree.Node
   readonly duplicateOf?: Type.Parameter
-  readonly bound?: string
+  readonly bound?: BoundFact
 }
 
 /** The canonical, duplicate, or unidentified canonical-identity state of one header. */
@@ -1505,14 +1526,31 @@ const collectTypeParameters = (
   const diagnostics: Array<Diagnostic.Diagnostic> = []
   const facts = SyntaxTree.directNodes(list, 'TypeParameter').map((parameterNode, ordinal) => {
     const name = presentName(source, parameterNode)
-    const boundToken = SyntaxTree.directToken(
-      SyntaxTree.directNode(parameterNode, 'TypePath') ?? parameterNode,
-      'Identifier',
-    )
-    const bound =
-      SyntaxTree.directToken(parameterNode, 'Colon') === undefined || boundToken === undefined
+    // A bound is the one type node the parameter carries after its colon. Taking the node rather
+    // than the parameter's own identifier keeps a damaged or applied bound from being read as a
+    // bound on the parameter's own name.
+    const boundNode = parameterNode.children.find(SyntaxTree.isNode)
+    const boundToken =
+      boundNode === undefined
         ? undefined
-        : spelling(source, boundToken)
+        : SyntaxTree.tokens(boundNode).find((token) => token.kind === 'Identifier')
+    const bound: BoundFact | undefined =
+      SyntaxTree.directToken(parameterNode, 'Colon') === undefined ||
+      boundNode === undefined ||
+      boundToken === undefined
+        ? undefined
+        : Object.freeze({
+            _tag: 'UnresolvedBound' as const,
+            spelling: spelling(source, boundToken),
+            path: Object.freeze({
+              _tag: 'TypePath' as const,
+              spelling: spelling(source, boundToken),
+              segments: Object.freeze([
+                Object.freeze({ spelling: spelling(source, boundToken), token: boundToken }),
+              ]),
+              syntax: boundNode,
+            }),
+          })
     const duplicateOf = name._tag === 'Present' ? environment.get(name.spelling) : undefined
     const type =
       duplicateOf ??
@@ -2629,6 +2667,54 @@ const memberByNominal = (
   )
 }
 
+/**
+ * Resolves every type parameter's bound to the interface its spelling names in the bounded
+ * declaration's own module scope, recording that interface's ordered operation contract.
+ *
+ * The resolver's own diagnostics are deliberately dropped: a bound that names nothing, or names a
+ * declaration that is not an interface, stays `UnresolvedBound` and is reported once at the
+ * specialization that would have had to satisfy it, where the type argument is known.
+ */
+const resolveBounds = (
+  module: string,
+  typeParameters: ReadonlyArray<TypeParameterFact>,
+  resolver: TypeResolver,
+  modules: ReadonlyArray<ModuleHeaders>,
+): ReadonlyArray<TypeParameterFact> => {
+  if (typeParameters.every((parameter) => parameter.bound === undefined)) return typeParameters
+  return Object.freeze(
+    typeParameters.map((parameter): TypeParameterFact => {
+      const bound = parameter.bound
+      if (bound === undefined) return parameter
+      const resolved = resolver(module, bound.path).fact
+      const capability =
+        resolved._tag === 'Resolved' && Type.isNominal(resolved.type) ? resolved.type : undefined
+      const declaration =
+        capability === undefined ? undefined : memberByNominal(modules, capability)
+      if (
+        capability === undefined ||
+        declaration?._tag !== 'InterfaceDeclaration' ||
+        declaration.canonical._tag !== 'Canonical'
+      )
+        return Object.freeze({ ...parameter, bound })
+      return Object.freeze({
+        ...parameter,
+        bound: Object.freeze({
+          _tag: 'ResolvedBound' as const,
+          spelling: bound.spelling,
+          path: bound.path,
+          capability: declaration.canonical.id,
+          operations: Object.freeze(
+            declaration.operations.flatMap((operation) =>
+              operation.name._tag === 'Present' ? [operation.name.spelling] : [],
+            ),
+          ),
+        }),
+      })
+    }),
+  )
+}
+
 /** Resolves one retained type fact through a supplied module resolver and complete index. */
 export const resolveTypeFact = (
   index: Index,
@@ -2864,6 +2950,12 @@ export const complete = (self: Index, resolver: TypeResolver): Index => {
         diagnostics.push(...requirementRow.diagnostics)
         return Object.freeze({
           ...member,
+          typeParameters: resolveBounds(
+            module.module,
+            member.typeParameters,
+            resolver,
+            self.modules,
+          ),
           parameters: Object.freeze(parameters),
           returnType: result.fact,
           failureRow: failureRow.fact,
@@ -2925,7 +3017,11 @@ export const complete = (self: Index, resolver: TypeResolver): Index => {
         diagnostics.push(...resolved.diagnostics)
         return Object.freeze({ ...field, declaredType: resolved.fact })
       })
-      return Object.freeze({ ...member, fields: Object.freeze(fields) })
+      return Object.freeze({
+        ...member,
+        typeParameters: resolveBounds(module.module, member.typeParameters, resolver, self.modules),
+        fields: Object.freeze(fields),
+      })
     })
     const conformances = module.conformances.map((conformance) => {
       const capability = resolveDeclaredType(
@@ -3772,27 +3868,64 @@ export const complete = (self: Index, resolver: TypeResolver): Index => {
   })
 }
 
-/** Tests whether one nominal provider has a compiler-shipped or source-declared witness. */
-export const conforms = (self: Index, provider: Type.Type, capability: Type.Nominal): boolean => {
-  const interface_ = self.modules
+const interfaceByCapability = (self: Index, capability: Type.Nominal): InterfaceFact | undefined =>
+  self.modules
     .find((module) => module.module === capability.module)
     ?.interfaces.find(
       (candidate) =>
         candidate.canonical._tag === 'Canonical' && candidate.canonical.id.name === capability.name,
     )
-  if (interface_ !== undefined) {
-    const matches = self.modules.flatMap((module) =>
-      module.conformances.filter(
-        (conformance) =>
-          conformance.capability._tag === 'Resolved' &&
-          Type.equals(conformance.capability.type, capability) &&
-          conformance.provider._tag === 'Resolved' &&
-          Type.equals(conformance.provider.type, provider),
-      ),
-    )
-    return matches.length === 1
-  }
-  return witness(self, provider, capability) !== undefined
+
+const interfaceConformance = (
+  self: Index,
+  provider: Type.Type,
+  capability: Type.Nominal,
+): ConformanceFact | undefined => {
+  const matches = self.modules.flatMap((module) =>
+    module.conformances.filter(
+      (conformance) =>
+        conformance.capability._tag === 'Resolved' &&
+        Type.equals(conformance.capability.type, capability) &&
+        conformance.provider._tag === 'Resolved' &&
+        Type.equals(conformance.provider.type, provider),
+    ),
+  )
+  return matches.length === 1 ? matches.at(0) : undefined
+}
+
+/** Tests whether one nominal provider has a compiler-shipped or source-declared witness. */
+export const conforms = (self: Index, provider: Type.Type, capability: Type.Nominal): boolean =>
+  interfaceByCapability(self, capability) !== undefined
+    ? interfaceConformance(self, provider, capability) !== undefined
+    : witness(self, provider, capability) !== undefined
+
+/**
+ * Returns, in declaration order, the operations one interface declares that the provider's selected
+ * conformance leaves unmapped. An empty result means the witness covers the whole contract — which
+ * is the only state under which specialization may substitute the provider for a bounded parameter.
+ * A capability that is not an interface, or a provider with no single conformance, has no partial
+ * witness to report and returns nothing.
+ */
+export const unmappedInterfaceOperations = (
+  self: Index,
+  provider: Type.Type,
+  capability: Type.Nominal,
+): ReadonlyArray<string> => {
+  const interface_ = interfaceByCapability(self, capability)
+  const conformance = interfaceConformance(self, provider, capability)
+  if (interface_ === undefined || conformance === undefined) return Object.freeze([])
+  const mapped = new Set(
+    conformance.operations.flatMap((mapping) =>
+      mapping.name._tag === 'Present' ? [mapping.name.spelling] : [],
+    ),
+  )
+  return Object.freeze(
+    interface_.operations.flatMap((operation) =>
+      operation.name._tag === 'Present' && !mapped.has(operation.name.spelling)
+        ? [operation.name.spelling]
+        : [],
+    ),
+  )
 }
 
 /** Selects the unique compiler-shipped or source-declared witness for one provider. */

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -3550,41 +3550,37 @@ const interfaceConstraintDiagnostics = (
 ): ReadonlyArray<Diagnostic.Diagnostic> => {
   if (reference._tag !== 'Resolved' || contract.fact._tag !== 'Compatible') return Object.freeze([])
   const substitution = contract.fact.substitution
-  const module =
-    reference.declaration.canonical._tag === 'Canonical'
-      ? reference.declaration.canonical.id.module
-      : reference.declaration.id.sourceId
   return Object.freeze(
     reference.declaration.typeParameters.flatMap((parameter) => {
-      if (parameter.bound === undefined) return []
+      const bound = parameter.bound
+      if (bound === undefined) return []
       const provider = substitution.get(Type.key(parameter.type))
       if (provider === undefined || !Type.isTypeArgument(provider)) return []
-      const interface_ = index.modules
-        .find((candidate) => candidate.module === module)
-        ?.interfaces.find(
-          (candidate) =>
-            candidate.name._tag === 'Present' && candidate.name.spelling === parameter.bound,
-        )
-      if (interface_?.canonical._tag !== 'Canonical')
+      if (bound._tag !== 'ResolvedBound')
         return [
           Diagnostic.invalidConformance(
-            `unknown interface constraint ${parameter.bound}`,
+            `unknown interface constraint ${bound.spelling}`,
             parameter.syntax.span,
           ),
         ]
-      const capability = Type.nominal(
-        interface_.canonical.id.module,
-        interface_.canonical.id.name,
-        [provider],
+      const capability = Type.nominal(bound.capability.module, bound.capability.name, [provider])
+      if (!DeclarationIndex.conforms(index, provider, capability))
+        return [
+          Diagnostic.invalidConformance(
+            `${Type.encode(provider)} does not implement ${bound.spelling}`,
+            span,
+          ),
+        ]
+      // A witness that exists is not yet a witness that is complete: specialization admits the type
+      // argument only when the conformance maps every operation the bound declares, so a bound with
+      // more than one operation cannot be half-satisfied.
+      return DeclarationIndex.unmappedInterfaceOperations(index, provider, capability).map(
+        (operation) =>
+          Diagnostic.invalidConformance(
+            `${Type.encode(provider)} does not implement ${bound.spelling}.${operation}`,
+            span,
+          ),
       )
-      return DeclarationIndex.conforms(index, provider, capability)
-        ? []
-        : [
-            Diagnostic.invalidConformance(
-              `${Type.encode(provider)} does not implement ${parameter.bound}`,
-              span,
-            ),
-          ]
     }),
   )
 }
@@ -4708,25 +4704,16 @@ const analyzeOperatorExpression = (
   const genericInterface =
     selectedFirstType?._tag === 'Available' && Type.isParameter(selectedFirstType.type)
       ? declaration.typeParameters.some((parameter) => {
-          if (!Type.equals(parameter.type, selectedFirstType.type) || parameter.bound === undefined)
-            return false
-          const module =
-            declaration.canonical._tag === 'Canonical'
-              ? declaration.canonical.id.module
-              : declaration.id.sourceId
-          const interface_ = resolution.index.modules
-            .find((candidate) => candidate.module === module)
-            ?.interfaces.find(
-              (candidate) =>
-                candidate.name._tag === 'Present' && candidate.name.spelling === parameter.bound,
-            )
-          const operationName = `${operator.slice(0, 1).toLowerCase()}${operator.slice(1)}`
-          return (
-            interface_?.operations.some(
-              (candidate) =>
-                candidate.name._tag === 'Present' && candidate.name.spelling === operationName,
-            ) ?? false
+          // Every operation the bound declares is callable on a bound-typed operand, so an operator
+          // stays generic exactly when the bound's contract names the operation it spells.
+          const bound = parameter.bound
+          if (
+            !Type.equals(parameter.type, selectedFirstType.type) ||
+            bound?._tag !== 'ResolvedBound'
           )
+            return false
+          const operationName = `${operator.slice(0, 1).toLowerCase()}${operator.slice(1)}`
+          return bound.operations.includes(operationName)
         })
       : false
   const selectedActor: Operator.Actor =
@@ -4739,10 +4726,24 @@ const analyzeOperatorExpression = (
   const signature = builtinSignature(target.actor, target.operation)
   if (signature === undefined) throw new RangeError('Compiler operator table is inconsistent')
   const genericType = selectedFirstType?._tag === 'Available' ? selectedFirstType.type : undefined
+  // A bound operator's contract is the compiler-known operation with the stand-in actor replaced by
+  // the bound parameter. Only the positions that carry the actor's own type become generic, so a
+  // comparison the bound declares keeps its `bool` result instead of widening to the parameter.
+  const actorType: SemanticType | undefined = Scalar.isSpelling(target.actor)
+    ? target.actor
+    : undefined
+  const overActor = (type: SemanticType): SemanticType =>
+    genericType !== undefined && actorType !== undefined && Type.equals(type, actorType)
+      ? genericType
+      : type
   const operatorParameters = genericInterface
-    ? Object.freeze(operandNodes.map(() => genericType ?? signature.result))
+    ? Object.freeze(
+        signature.parameters.length === operandNodes.length
+          ? signature.parameters.map(overActor)
+          : operandNodes.map(() => genericType ?? signature.result),
+      )
     : signature.parameters
-  const operatorResult = genericInterface ? (genericType ?? signature.result) : signature.result
+  const operatorResult = genericInterface ? overActor(signature.result) : signature.result
   const reference: CallReferenceFact = Object.freeze({
     _tag: 'ResolvedBuiltin',
     spelling: `${target.actor}.${target.operation}`,

--- a/packages/compiler/test/InterfaceBounds.test.ts
+++ b/packages/compiler/test/InterfaceBounds.test.ts
@@ -1,0 +1,167 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+
+const encoder = new TextEncoder()
+
+const snapshot = (source: string) =>
+  Analysis.ofSourceRealized('interface-bounds/main', encoder.encode(source))
+
+const evaluate = (source: string) =>
+  Effect.map(snapshot(source), (self) => ({ self, outcome: Analysis.evaluate(self) }))
+
+const messages = (self: Analysis.FrontendSnapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(self).map((diagnostic) => diagnostic.message)
+
+/** Evaluated scalars can be BigInt, which plain JSON serialization refuses. */
+const describe = (outcome: unknown): string =>
+  JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2)
+
+/**
+ * Two operations on one bound. `combine` calls both — `+` selects `add` and `-` selects
+ * `subtract` — over the canonical parameter, once, before any concrete argument exists.
+ */
+const twoOperations = `pub interface Arith<T> {
+  fn add(left: T, right: T) -> T
+  fn subtract(left: T, right: T) -> T
+}
+impl Arith<i32> for i32 { add: Intrinsic.i32Add subtract: Intrinsic.i32Subtract }
+pub fn combine<T: Arith>(left: T, right: T) -> T { return (left + right) - left }
+pub fn main() -> i32 { return combine(40, 44) }`
+
+it.effect('calls every operation of a two-operation bound in one generic body', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(twoOperations)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    // (40 + 44) - 40 selects `subtract`, not a second `add`.
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 44)
+  }),
+)
+
+it.effect('specializes one two-operation bound per conforming provider', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`pub interface Arith<T> {
+  fn add(left: T, right: T) -> T
+  fn subtract(left: T, right: T) -> T
+}
+impl Arith<i32> for i32 { add: Intrinsic.i32Add subtract: Intrinsic.i32Subtract }
+impl Arith<u8> for u8 { add: Intrinsic.u8Add subtract: Intrinsic.u8Subtract }
+pub fn combine<T: Arith>(left: T, right: T) -> T { return (left + right) - left }
+pub fn main() -> i32 {
+  let narrow = combine<u8>(200, 55)
+  return combine<i32>(40, 42)
+}`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+/**
+ * A bound whose operations do not all return the parameter. `lessThan` is declared over `T` but
+ * results in `bool`, so the operator keeps the operation's own declared result.
+ */
+const comparisonBound = `pub interface Ranked<T> {
+  fn lessThan(left: T, right: T) -> bool
+  fn subtract(left: T, right: T) -> T
+}
+impl Ranked<i32> for i32 { lessThan: Intrinsic.i32LessThan subtract: Intrinsic.i32Subtract }
+pub fn gap<T: Ranked>(left: T, right: T) -> T {
+  if left < right { return right - left }
+  return left - right
+}
+pub fn main() -> i32 { return gap(2, 44) }`
+
+it.effect('keeps a bound comparison at its declared result type', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(comparisonBound)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('rejects a type argument whose witness omits one bound operation', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(`pub interface Arith<T> {
+  fn add(left: T, right: T) -> T
+  fn subtract(left: T, right: T) -> T
+}
+impl Arith<i32> for i32 { add: Intrinsic.i32Add }
+pub fn combine<T: Arith>(left: T, right: T) -> T { return (left + right) - left }
+pub fn main() -> i32 { return combine(40, 44) }`)
+    // The specialization names the operation the witness never supplied, not just the interface.
+    assert.include(messages(self), 'Invalid conformance: i32 does not implement Arith.subtract')
+  }),
+)
+
+it.effect('accepts an interface another module declares as a bound', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`import silk.numeric { Integer }
+pub fn twice<T: Integer>(value: T) -> T { return value + value }
+pub fn main() -> i32 { return twice(21) }`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('keeps the single-operation Integer bound working unchanged', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`import silk.numeric { add }
+pub fn main() -> i32 {
+  let narrow = add<u8>(1, 2)
+  return add<i32>(40, 2)
+}`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('rejects a type argument with no witness for the bound', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(`pub interface Arith<T> {
+  fn add(left: T, right: T) -> T
+  fn subtract(left: T, right: T) -> T
+}
+impl Arith<i32> for i32 { add: Intrinsic.i32Add subtract: Intrinsic.i32Subtract }
+pub fn combine<T: Arith>(left: T, right: T) -> T { return (left + right) - left }
+pub fn main() -> i32 {
+  let wide = combine<i64>(40, 44)
+  return 0
+}`)
+    assert.include(messages(self), 'Invalid conformance: i64 does not implement Arith')
+  }),
+)
+
+it.effect('reports a bound that names no reachable interface', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(`pub struct Holder<T> { value: T }
+pub fn combine<T: Holder>(left: T, right: T) -> T { return left + right }
+pub fn main() -> i32 { return combine(40, 2) }`)
+    assert.include(messages(self), 'Invalid conformance: unknown interface constraint Holder')
+  }),
+)
+
+it.effect('records the resolved bound contract on the declaration it belongs to', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(twoOperations)
+    const declaration = Analysis.declarationIndex(self)
+      .modules.find((module) => module.module === 'interface-bounds/main')
+      ?.declarations.find(
+        (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === 'combine',
+      )
+    const bound = declaration?.typeParameters.at(0)?.bound
+    assert.strictEqual(bound?._tag, 'ResolvedBound')
+    if (bound?._tag !== 'ResolvedBound') return
+    assert.strictEqual(bound.spelling, 'Arith')
+    assert.deepEqual(bound.capability, {
+      _tag: 'CanonicalDeclarationId',
+      module: 'interface-bounds/main',
+      name: 'Arith',
+    })
+    assert.deepEqual(bound.operations, ['add', 'subtract'])
+  }),
+)


### PR DESCRIPTION
Closes #103

## What the bare spelling cost

`TypeParameterFact` declared `bound?: string`, and that spelling was matched against the interfaces of **one** module — the module declaring the bounded function. Two properties followed, both invisible while the only shipped interface (`Integer`) declares one operation and is only ever bounded inside `silk/numeric`:

- **A bound could not name an interface another module declares.** `import silk.numeric { Integer }` followed by `fn twice<T: Integer>(value: T)` was rejected as `unknown interface constraint Integer`. Nothing outside `silk/numeric` could bound anything by it.
- **A witness was admitted by existence, not coverage.** `conforms` counted the conformance declarations matching one capability and provider and never read their operations, so a conformance mapping *some* of an interface's operations satisfied specialization exactly as well as one mapping all of them.

## What changed

- `bound` becomes a `BoundFact`: the retained spelling and its type path, resolved during header completion in the bounded declaration's own module scope into the named interface's canonical identity plus its ordered operation names.
- Specialization builds the capability from that recorded identity, and admits the type argument only when its conformance maps every operation the bound declares — reporting each unmapped one by name (`i32 does not implement Arith.subtract`).
- Operator selection reads the same recorded contract instead of repeating the module-scoped search, and takes the operation's declared types: the parameter is substituted only where the compiler-known operation carries its actor's own type, so a bound may declare `lessThan(left: T, right: T) -> bool` and have the comparison result in `bool` rather than widening to `T`.

Type-system and resolution only — no runtime representation change, no instance-key or MIR change, engines untouched except through which specializations analysis admits. Diagnostics reuse `SEM0083`, so no new documentation pages.

## Acceptance criteria

- [x] A test declares a two-operation interface, bounds a generic by it, and calls both operations — `calls every operation of a two-operation bound in one generic body`, evaluated end to end, plus `specializes one two-operation bound per conforming provider` at `i32` and `u8`.
- [x] A test shows a type argument missing one operation is rejected, naming the operation — `rejects a type argument whose witness omits one bound operation`.
- [x] `Integer` keeps working unchanged as the single-operation case — its source is untouched; `keeps the single-operation Integer bound working unchanged` specializes `add` at two widths, and `accepts an interface another module declares as a bound` now bounds a user declaration by it.
- [x] An openspec change records the bound form — `openspec/changes/accept-multi-operation-interface-bounds` (proposal, design, tasks, and a `bootstrap-type-generics` delta with three added requirements).

## Out of scope, as chartered

`HashKey` (#34) and `Order` (#36) themselves are untouched.

**Multiple bounds per parameter (`T: A + B`) did not fall out for free** — `parseTypeParameterList` parses exactly one type after the colon, so `<T: Arith + Ranked>` fails at the parser (`Unexpected '+'; expected '>'`). The bound fact is now a single record rather than a bare string, so widening it to a list is a parser change plus a loop at each of the two consumers, but it is not done here.

## One decision this change surfaces but does not take

An operation whose name an operator spells (`add`, `subtract`, `lessThan`, `equals`) is callable in a generic body through that operator, and every such operation of a bound now is. **An interface operation whose name no operator spells still has no call surface**: interfaces are not actors, so `Bound.operation(value)` resolves to a public function of the module declaring `Bound` (which is why `Integer.add(40, 2)` resolves today), not to the bound's operation.

That matters for #34 — `HashKey` needs `hash`, which no operator spells. Choosing the spelling is a language decision (the services parallel suggests `Bound.operation(args)`), and unlike an operator it must consult the witness's selected operation at specialization rather than reusing the width-neutral scalar lowering an operator already gets. Nothing here forecloses it; `design.md` records the constraint. Flagging rather than blocking, since every acceptance criterion above is met without it.

## Tests

Baseline 0 real failures, after 0 real failures, +9 new tests.

- `pnpm --filter @silk-effect/compiler test`: 147 files / 1162 tests passed, plus the serial native-acceptance file — 0 failures, before and after.
- Ignored locally and unchanged from baseline: `packages/wasm` `Extended.test.ts > threads address types` and the `llvm` parity script.
- 4 of the 9 new tests were verified to fail against unmodified `src`: the bound comparison's result type, the missing-operation rejection, the cross-module bound, and the recorded bound contract. The other 5 are regression guards over behavior that had to keep working.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuYU6DrTLr8fn56bS5yXLU)_