### PR TITLE
backend: reclaim Wasm heap memory on release

### DIFF
--- a/openspec/changes/add-wasm-heap-reclaim/design.md
+++ b/openspec/changes/add-wasm-heap-reclaim/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The Wasm backend's heap is a bump pointer over one private memory. Allocation aligns the pointer up,
+grows memory when the request runs past what is mapped, and never lowers the pointer again. Release
+emits nothing: the backend's release lowering only walked Drop hooks, and its hook-traversal
+predicate has no `AllocationCleanup` case at all, so a bare allocation drop produced no instructions
+whatsoever. The native LLVM backend, given the same MIR, calls libc `free` with the allocation's
+`$context` lane.
+
+The compiler-planned `Allocation` value already has six lanes — `$base`, `$bytes`, `$alignment`,
+`$reclaim`, `$context`, `$active` — and LLVM already treats `$context` as the pointer it hands to
+`free`. Wasm wrote the constant `0` there because it had nothing to record.
+
+## Goals / Non-Goals
+
+Goals:
+
+- A released block becomes available to a later request, so an allocate-and-drop loop keeps a
+  bounded heap for arbitrary interleaved patterns.
+- Alignment guarantees are exactly what the bump allocator gave: a payload satisfies the requested
+  power-of-two alignment.
+- Reclaim stays driven by the owner that consumed the reclaim ticket, at the point ownership ends.
+
+Non-goals: compaction, defragmentation, a moving allocator, coalescing adjacent free blocks, a
+public `free`, or any change to the `Allocator` service contract.
+
+## Decisions
+
+### Decision: a size-class free list, not a LIFO bump unwind
+
+Two allocators satisfy "repeated acquire and release cycles keep a bounded heap" while staying
+inside the non-goals. Rolling the bump pointer back when the released block is the most recent one
+costs almost nothing and needs no per-block metadata, but it bounds only nested allocation: in an
+interleaved pattern, releasing anything but the newest block reclaims nothing. A size-class free
+list needs a header per block, and bounds arbitrary interleavings.
+
+The free list is chosen. A self-hosted compiler's allocation traffic is interleaved — an AST node
+outlives the token buffer that produced it — so a bound that holds only for stack-shaped programs
+would not survive the first real workload. The acceptance suite pins this directly with a non-LIFO
+allocate-and-drop loop, kept separate from the count-parity test.
+
+### Decision: `$context` carries a block-header address
+
+Every block is a 16-byte header followed by its payload, so a payload always begins exactly one
+header past its block and release recovers the block by subtraction. The allocation's `$context`
+lane carries that header address, which is what the LLVM backend already does with the same lane for
+libc's benefit. This is the change that needs a spec amendment: `bootstrap-owned-allocation` said
+the lane holds "everything required for infallible release" without saying whether a backend may
+make that a pointer into its own heap.
+
+The lane stays compiler-private. It has no Silk-visible name, no Silk-visible type, and no
+construction path; a program can neither read it nor forge one.
+
+### Decision: classes are powers of two, with one irregular list
+
+Payload capacities are `1 << (4 + index)` from 16 bytes up to 1 GiB, giving 27 classes. The free
+list heads live in a fixed table at the base of the heap region, which wasm memory already zeroes,
+so a head is indexable from a class computed at run time — a wasm global cannot be.
+
+Every classified block starts 16-byte aligned and so has a 16-byte-aligned payload, which is what
+lets a block be reused by any later request in its class without re-checking alignment. A request
+whose alignment exceeds 16 bytes, or whose size exceeds the largest class, is served from a single
+irregular list whose head is measured against the request before it is reused. `Layout` admits any
+power-of-two alignment at run time, so the irregular path is a correctness requirement, not a
+convenience.
+
+### Decision: hooks first, then reclaim
+
+The Wasm hook walk works from byte offsets into a frame materialization, because a Drop hook takes
+`&mut self` and can write through it. The reclaim walk works from the owner's lanes, because that is
+where `$context` lives. Rather than fuse them, release runs the existing hook walk, which reloads
+the owner's slots afterwards, and then the reclaim walk over those reloaded slots. A hook therefore
+observes the block before it is released and can still hand back a different one, which is the same
+order the LLVM backend's single lane-driven walk produces.
+
+A null header is a no-op on release. That is what lets a union's conditional cleanup select an
+inactive case's reclaim context to zero rather than branch around the call — the shortcut the LLVM
+backend already takes through libc `free`, whose contract also ignores null.
+
+## Risks / Trade-offs
+
+Adjacent free blocks are never coalesced, so a program that allocates a large block, releases it,
+and then allocates many small ones holds the large block's capacity in its own class rather than
+splitting it. The heap stays bounded for repeated patterns, which is the property claimed;
+worst-case fragmentation across changing size mixes is not bounded, and buying that back means
+either splitting and coalescing or a moving allocator, which the issue puts out of scope.
+
+The free-list head table sits at the base of the heap region, which the shadow stack can already
+run into on deep enough recursion — the heap began at that same address before this change, so the
+collision is not new, but the table is now the first thing such an overflow would reach. Bounding
+the shadow stack is a separate concern from bounding the heap and is not addressed here.
+
+The private memory is now exported unconditionally rather than only when a host write needs it. That
+is how a host observes the heap at all — including how the acceptance test reads `memory.size` — and
+it matches the existing rule that every function is exported so the artifact is directly
+instantiable for inspection.

--- a/openspec/changes/add-wasm-heap-reclaim/proposal.md
+++ b/openspec/changes/add-wasm-heap-reclaim/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The Wasm backend allocates but never reclaims. Allocation is a bump pointer over `memory.grow`, and
+the release path emits nothing at all, so a program that acquires and drops in a loop grows the Wasm
+heap without limit while the same program on native LLVM holds a flat peak through libc `free`.
+
+Two things kept that from being a simple bug fix.
+
+- No spec states a Wasm reclaim policy. `bootstrap-backend` says only that "physical reclamation
+  policy may differ" between the backends, which is true and says nothing about whether a heap must
+  stay bounded. The single record of the shortcut was a code comment.
+- A free list needs somewhere to put per-block metadata. `bootstrap-owned-allocation` requires an
+  `Allocation` to carry "private unforgeable active reclaim authority containing everything required
+  for infallible release" but never says whether a backend may represent that authority as a pointer
+  into its own heap. The Wasm backend wrote the constant `0` into that lane precisely because it had
+  nothing to say there.
+
+Both are answered here so the implementation has a contract to be checked against rather than a
+comment to be trusted.
+
+## What Changes
+
+- State that a backend's reclaim authority is opaque backend-chosen data, and that representing it
+  as the address of a backend-private block header is one admitted representation. The authority
+  stays compiler-private and unforgeable either way: no Silk program can read, write, or construct
+  it, and no public `free` appears.
+- State the Wasm reclaim policy: released storage returns to the heap that issued it, and repeated
+  acquire and release cycles keep a bounded heap for arbitrary interleaved patterns, not only for
+  nested ones. Bounding only stack-shaped allocation would be met by rolling a bump pointer back on
+  the most recent block, which is not what a self-hosted compiler's allocation traffic looks like.
+- Keep reclaim ownership-driven. No scheduler, collector, background task, compaction, or moving
+  allocator, and no change to the `Allocator` service contract.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bootstrap-owned-allocation`: admit a block-header address as one representation of the private
+  reclaim authority an `Allocation` carries.
+- `bootstrap-backend`: require the WebAssembly heap to reclaim released blocks and keep a bounded
+  heap under arbitrary interleaved acquire and release, while count parity with native LLVM — which
+  already holds — stays a separate property from memory parity.

--- a/openspec/changes/add-wasm-heap-reclaim/specs/bootstrap-backend/spec.md
+++ b/openspec/changes/add-wasm-heap-reclaim/specs/bootstrap-backend/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: The WebAssembly heap reclaims released storage
+
+Direct WebAssembly SHALL return released storage to the heap that issued it, so that repeated
+acquire and release cycles keep a bounded heap. The bound SHALL hold for arbitrary interleaved
+acquire and release, not only for nested ones: a release whose block is not the most recent
+acquisition MUST still make that storage available to a later request. Reclaimed storage SHALL keep
+the alignment guarantee the request was served under. Reclaim SHALL be driven entirely by the owner
+that consumes the reclaim ticket, at the point ownership ends; the backend MUST NOT introduce a
+scheduler, a garbage collector, a background task, a moving allocator, or compaction, and MUST NOT
+publish a `free` operation to Silk.
+
+Release SHALL be emitted for every cleanup plan that consumes a reclaim ticket, including one that
+invokes no Drop hook. Where a plan carries both, the Drop hooks SHALL run before the storage they
+own is reclaimed.
+
+#### Scenario: Bound an interleaved allocate-and-drop loop
+
+- **WHEN** a Wasm program repeatedly acquires several blocks and releases them in an order that is not the reverse of their acquisition
+- **THEN** the final `memory.size` stays under a fixed limit that does not grow with the cycle count
+
+#### Scenario: Reclaim a bare allocation drop
+
+- **WHEN** an owner whose cleanup plan invokes no Drop hook and holds only a reclaim ticket is dropped
+- **THEN** Wasm emits the release rather than nothing, and the block becomes available to a later request
+
+#### Scenario: Run Drop hooks before reclaiming
+
+- **WHEN** an owner's cleanup plan carries both a Drop hook and a reclaim ticket
+- **THEN** the hook observes the storage before it is released, matching the order native LLVM produces
+
+### Requirement: Release-count parity is distinct from memory parity
+
+Wasm and native LLVM SHALL report equal acquire and release counts for the same program. That
+property is a consequence of ownership-driven cleanup rather than of physical reclamation, and it
+SHALL be pinned independently of any claim about how much memory either backend holds while running.
+A test asserting equal counts MUST NOT be read as asserting equal or bounded memory, and a heap
+bound MUST NOT be inferred from count parity.
+
+#### Scenario: Agree on release counts
+
+- **WHEN** the same allocate-and-drop program runs on Wasm and on native LLVM
+- **THEN** both report the same acquire and release counts, whatever each backend does with the storage

--- a/openspec/changes/add-wasm-heap-reclaim/specs/bootstrap-owned-allocation/spec.md
+++ b/openspec/changes/add-wasm-heap-reclaim/specs/bootstrap-owned-allocation/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Allocation is a self-contained affine owner
+
+The allocator capability SHALL accept a validated `Layout` through an explicit exclusive service
+requirement and return either the allocation-free typed failure `OutOfMemory` or one affine
+`Allocation`. A successful `Allocation` SHALL carry private unforgeable active reclaim authority
+containing everything required for infallible release. The representation of that authority is
+chosen by the backend and is not observable: a backend MAY carry the address of a backend-private
+block header there, and MAY require that header to find the storage a release returns. The authority
+MUST remain unnameable, unreadable, and unforgeable from Silk regardless of representation, and no
+public `free` may be derived from it. An `Allocation` MUST NOT borrow, retain, or later rediscover
+the provider that created it, and failed allocation MUST NOT create storage or reclaim authority.
+
+#### Scenario: Drop after provider borrow ends
+
+- **WHEN** an allocation escapes the call that borrowed `SystemAllocator`
+- **THEN** the provider borrow ends, the allocation remains valid, and its eventual Drop releases through its captured reclaim authority exactly once
+
+#### Scenario: Fail atomically under exhaustion
+
+- **WHEN** the selected allocator cannot satisfy one valid layout
+- **THEN** the Effect fails with `OutOfMemory` without allocating the failure, publishing an allocation owner, or scheduling cleanup for the rejected request
+
+#### Scenario: Transfer allocation ownership
+
+- **WHEN** an allocation moves through an ordinary function and its original binding leaves scope
+- **THEN** only the destination remains live and eventual cleanup consumes the same reclaim authority exactly once
+
+#### Scenario: Carry a backend block header as reclaim authority
+
+- **WHEN** a backend represents an allocation's reclaim authority as the address of its own block header rather than as a null placeholder
+- **THEN** the program observes no difference in the allocation's type, lanes, or behavior, and still cannot name, read, or construct that authority

--- a/openspec/changes/add-wasm-heap-reclaim/tasks.md
+++ b/openspec/changes/add-wasm-heap-reclaim/tasks.md
@@ -1,0 +1,39 @@
+## 1. Wasm Heap
+
+- [x] 1.1 Lay out the heap as a free-list head table followed by a bump region of 16-byte-header
+      blocks, and start the heap pointer past the table.
+- [x] 1.2 Synthesize the allocator: serve from the head of the matching size class when it fits,
+      otherwise carve a block off the bump region and grow memory only when it runs past what is
+      mapped, answering zero on a request that cannot be served.
+- [x] 1.3 Synthesize the release: push one block onto the head of its size class, treating a null
+      header as a no-op so a union's conditional cleanup can select an inactive context to zero.
+- [x] 1.4 Serve requests whose alignment exceeds a block's own 16 bytes, or whose size exceeds the
+      largest class, from the irregular list, measuring its head against the request before reuse.
+
+## 2. Reclaim Lowering
+
+- [x] 2.1 Add the `planReclaims` predicate the Wasm backend was missing beside `planHasHook`, so a
+      cleanup plan that reclaims without invoking a hook is no longer invisible.
+- [x] 2.2 Write the block-header address into the `$context` reclaim-authority lane at `Allocate`
+      instead of the constant `0`.
+- [x] 2.3 Walk a cleanup plan's lanes to release every block it still owns — allocation, raw buffer,
+      hook inner, struct field, array element, effect environment slot, and tag-guarded union case —
+      and do the same from an address for a slot drop.
+- [x] 2.4 Run the reclaim walk after the existing hook walk at every release site, and delete the
+      no-op comment the shortcut was recorded in.
+
+## 3. Acceptance
+
+- [x] 3.1 Assert an interleaved non-LIFO allocate-and-drop loop keeps the final `memory.size` under
+      a fixed limit, and that a tenfold cycle count costs no extra page.
+- [x] 3.2 Assert Wasm and native LLVM report the same release count, kept separate from the heap
+      bound.
+- [x] 3.3 Confirm the heap-bound assertions fail on the bump allocator and that the count-parity
+      assertion passes on it, so the two tests are pinning different properties.
+
+## 4. Specification
+
+- [x] 4.1 Admit a block-header address as one representation of an allocation's private reclaim
+      authority in `bootstrap-owned-allocation`.
+- [x] 4.2 State the Wasm reclaim policy and the count-versus-memory distinction in
+      `bootstrap-backend`.

--- a/openspec/specs/bootstrap-backend/spec.md
+++ b/openspec/specs/bootstrap-backend/spec.md
@@ -542,6 +542,49 @@ validation, aligned stride rounding, and overflow classification against the sel
 - **WHEN** the repeated size exceeds the target's `usize` range
 - **THEN** every engine produces the overflow member and no allocation occurs
 
+### Requirement: The WebAssembly heap reclaims released storage
+
+Direct WebAssembly SHALL return released storage to the heap that issued it, so that repeated
+acquire and release cycles keep a bounded heap. The bound SHALL hold for arbitrary interleaved
+acquire and release, not only for nested ones: a release whose block is not the most recent
+acquisition MUST still make that storage available to a later request. Reclaimed storage SHALL keep
+the alignment guarantee the request was served under. Reclaim SHALL be driven entirely by the owner
+that consumes the reclaim ticket, at the point ownership ends; the backend MUST NOT introduce a
+scheduler, a garbage collector, a background task, a moving allocator, or compaction, and MUST NOT
+publish a `free` operation to Silk.
+
+Release SHALL be emitted for every cleanup plan that consumes a reclaim ticket, including one that
+invokes no Drop hook. Where a plan carries both, the Drop hooks SHALL run before the storage they
+own is reclaimed.
+
+#### Scenario: Bound an interleaved allocate-and-drop loop
+
+- **WHEN** a Wasm program repeatedly acquires several blocks and releases them in an order that is not the reverse of their acquisition
+- **THEN** the final `memory.size` stays under a fixed limit that does not grow with the cycle count
+
+#### Scenario: Reclaim a bare allocation drop
+
+- **WHEN** an owner whose cleanup plan invokes no Drop hook and holds only a reclaim ticket is dropped
+- **THEN** Wasm emits the release rather than nothing, and the block becomes available to a later request
+
+#### Scenario: Run Drop hooks before reclaiming
+
+- **WHEN** an owner's cleanup plan carries both a Drop hook and a reclaim ticket
+- **THEN** the hook observes the storage before it is released, matching the order native LLVM produces
+
+### Requirement: Release-count parity is distinct from memory parity
+
+Wasm and native LLVM SHALL report equal acquire and release counts for the same program. That
+property is a consequence of ownership-driven cleanup rather than of physical reclamation, and it
+SHALL be pinned independently of any claim about how much memory either backend holds while running.
+A test asserting equal counts MUST NOT be read as asserting equal or bounded memory, and a heap
+bound MUST NOT be inferred from count parity.
+
+#### Scenario: Agree on release counts
+
+- **WHEN** the same allocate-and-drop program runs on Wasm and on native LLVM
+- **THEN** both report the same acquire and release counts, whatever each backend does with the storage
+
 ### Requirement: Owning union fields release conditionally
 
 Cleanup of a structural-union value whose members carry reclaim obligations SHALL release

--- a/openspec/specs/bootstrap-owned-allocation/spec.md
+++ b/openspec/specs/bootstrap-owned-allocation/spec.md
@@ -23,9 +23,12 @@ representational overflow as ordinary validation data before any allocator or ba
 The allocator capability SHALL accept a validated `Layout` through an explicit exclusive service
 requirement and return either the allocation-free typed failure `OutOfMemory` or one affine
 `Allocation`. A successful `Allocation` SHALL carry private unforgeable active reclaim authority
-containing everything required for infallible release. It MUST NOT borrow, retain, or later
-rediscover the provider that created it, and failed allocation MUST NOT create storage or reclaim
-authority.
+containing everything required for infallible release. The representation of that authority is
+chosen by the backend and is not observable: a backend MAY carry the address of a backend-private
+block header there, and MAY require that header to find the storage a release returns. The authority
+MUST remain unnameable, unreadable, and unforgeable from Silk regardless of representation, and no
+public `free` may be derived from it. An `Allocation` MUST NOT borrow, retain, or later rediscover
+the provider that created it, and failed allocation MUST NOT create storage or reclaim authority.
 
 #### Scenario: Drop after provider borrow ends
 
@@ -41,6 +44,11 @@ authority.
 
 - **WHEN** an allocation moves through an ordinary function and its original binding leaves scope
 - **THEN** only the destination remains live and eventual cleanup consumes the same reclaim authority exactly once
+
+#### Scenario: Carry a backend block header as reclaim authority
+
+- **WHEN** a backend represents an allocation's reclaim authority as the address of its own block header rather than as a null placeholder
+- **THEN** the program observes no difference in the allocation's type, lanes, or behavior, and still cannot name, read, or construct that authority
 
 ### Requirement: Raw typed storage is narrow and unsafe
 

--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -37,6 +37,62 @@ const planHasHook = (plan: Ownership.CleanupPlan): boolean =>
   (plan._tag === 'RawBufferCleanup' && planHasHook(plan.allocation))
 
 /**
+ * Tests whether one cleanup plan consumes a reclaim ticket at any nesting depth. A plan can
+ * reclaim without invoking a hook — a bare `Allocation` drop is exactly that — so this is the
+ * second half of "this release has an effect", beside `planHasHook`.
+ */
+const planReclaims = (plan: Ownership.CleanupPlan): boolean =>
+  plan._tag === 'AllocationCleanup' ||
+  plan._tag === 'RawBufferCleanup' ||
+  (plan._tag === 'HookCleanup' && planReclaims(plan.inner)) ||
+  (plan._tag === 'StructCleanup' && plan.fields.some((field) => planReclaims(field.cleanup))) ||
+  (plan._tag === 'ArrayCleanup' && planReclaims(plan.element)) ||
+  (plan._tag === 'UnionCleanup' && plan.cases.some((entry) => planReclaims(entry.cleanup))) ||
+  ((plan._tag === 'CallableCleanup' || plan._tag === 'EffectCleanup') &&
+    plan.slots.some((slot) => planReclaims(slot.cleanup)))
+
+/**
+ * The Wasm backend's heap is a size-class free list over one bump region, so a released block
+ * returns to the list its size class owns and the next request of that class reuses it. Repeated
+ * acquire/release cycles therefore keep a bounded heap for arbitrary interleaved patterns, not
+ * only for the nested ones a LIFO unwind would cover. Nothing here schedules, collects, moves, or
+ * compacts: release is an O(1) push driven entirely by the owner that consumed the ticket.
+ *
+ * Memory above the static data and the shadow stack is laid out as
+ *
+ * ```text
+ * [ 65536 .. heapBase )   one i32 free-list head per size class, plus the irregular list
+ * [ heapBase ..       )   blocks, each a 16-byte header followed by its payload
+ * ```
+ *
+ * and one block is
+ *
+ * ```text
+ * header+0   payload capacity in bytes
+ * header+4   size-class index, or -1 for an irregular block
+ * header+8   next free block while the block sits on a free list
+ * header+12  reserved, keeping the payload 16-byte aligned
+ * ```
+ *
+ * A block's payload therefore always begins 16 bytes past its header, which is what lets the
+ * compiler-private `$context` reclaim-authority lane carry the header address: release needs no
+ * lookup structure to find the block a base pointer belongs to.
+ *
+ * `heapHeaderBytes` is both the header's size and the alignment every block start keeps.
+ */
+const heapHeaderBytes = 16
+/** Size classes hold payload capacities `1 << (4 + index)`, so class 0 is 16 bytes. */
+const heapClassShift = 4
+const heapClassCount = 27
+/** Blocks too large or too over-aligned for a class share one irregular list. */
+const heapIrregularClass = heapClassCount
+const heapLargestClassBytes = 1 << (heapClassShift + heapClassCount - 1)
+/** The free-list head table sits at the first heap page; wasm memory starts it zeroed. */
+const heapTableBase = 65536
+const heapBase =
+  heapTableBase + Math.ceil(((heapIrregularClass + 1) * 4) / heapHeaderBytes) * heapHeaderBytes
+
+/**
  * A second `Backend` implementation emitting WebAssembly through the Silk wasm builder, for the
  * same MIR subset the bootstrap LLVM backend covers: logical scalar/aggregate locals, trapping
  * arithmetic, direct calls, checked replacement, and canonical structured control regions.
@@ -943,6 +999,248 @@ interface MemoryContext {
   readonly plan: LayoutPlan.Plan
   readonly staticOffsets: ReadonlyMap<string, number>
   readonly standardWrite?: FuncActor.Func
+  /** `(bytes, alignment) -> payload address`, answering 0 when the request cannot be served. */
+  readonly heapAllocate?: FuncActor.Func
+  /** `(header address) -> ()`, returning one block to its size class. Ignores a null header. */
+  readonly heapRelease?: FuncActor.Func
+}
+
+/**
+ * The body of the synthesized allocator. It serves a request from the head of the matching free
+ * list when that block fits, and otherwise carves a fresh block off the bump region, growing
+ * memory only when the region runs past what is already mapped.
+ */
+const heapAllocateBody = (
+  memory: Memory.Memory,
+  heapPointer: Global.Global,
+): ReadonlyArray<Instr.Instr> => {
+  const [bytes, alignment, align, klass, capacity, listAddress, block, payload, cursor] = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8,
+  ]
+  const load = (address: number, offset = 0): ReadonlyArray<Instr.Instr> => [
+    Instr.localGet(address),
+    Instr.memoryAccess('i32.load', memory, { offset }),
+  ]
+  const store = (
+    address: number,
+    value: ReadonlyArray<Instr.Instr>,
+    offset = 0,
+  ): ReadonlyArray<Instr.Instr> => [
+    Instr.localGet(address),
+    ...value,
+    Instr.memoryAccess('i32.store', memory, { offset }),
+  ]
+  /** Pages spanning `[0, cursor)`, as the existing bump growth check computed them. */
+  const pagesForCursor: ReadonlyArray<Instr.Instr> = [
+    Instr.localGet(cursor),
+    Instr.i32Const(1),
+    Instr.op('i32.sub'),
+    Instr.i32Const(16),
+    Instr.op('i32.shr_u'),
+    Instr.i32Const(1),
+    Instr.op('i32.add'),
+  ]
+  const refuse: ReadonlyArray<Instr.Instr> = [Instr.i32Const(0), Instr.op('return')]
+  return [
+    // align = max(alignment, 16). A block start is always 16-aligned, and a zero alignment — which
+    // `Layout` construction already rejects — must never widen the mask into every address.
+    Instr.i32Const(heapHeaderBytes),
+    Instr.localGet(alignment),
+    Instr.localGet(alignment),
+    Instr.i32Const(heapHeaderBytes),
+    Instr.op('i32.lt_u'),
+    Instr.op('select'),
+    Instr.localSet(align),
+    // A request is classified when the block's own 16-byte alignment already satisfies it and its
+    // capacity fits the largest class. Everything else shares the irregular list.
+    Instr.localGet(align),
+    Instr.i32Const(heapHeaderBytes),
+    Instr.op('i32.eq'),
+    Instr.localGet(bytes),
+    Instr.i32Const(heapLargestClassBytes),
+    Instr.op('i32.le_u'),
+    Instr.op('i32.and'),
+    Instr.ifElse(
+      Instr.emptyBlockType,
+      [
+        // klass = bytes <= 16 ? 0 : ceil(log2(bytes)) - 4, capacity = 1 << (klass + 4)
+        Instr.i32Const(0),
+        Instr.i32Const(32),
+        Instr.localGet(bytes),
+        Instr.i32Const(1),
+        Instr.op('i32.sub'),
+        Instr.op('i32.clz'),
+        Instr.op('i32.sub'),
+        Instr.i32Const(heapClassShift),
+        Instr.op('i32.sub'),
+        Instr.localGet(bytes),
+        Instr.i32Const(1 << heapClassShift),
+        Instr.op('i32.le_u'),
+        Instr.op('select'),
+        Instr.localSet(klass),
+        Instr.i32Const(1),
+        Instr.localGet(klass),
+        Instr.i32Const(heapClassShift),
+        Instr.op('i32.add'),
+        Instr.op('i32.shl'),
+        Instr.localSet(capacity),
+        Instr.localGet(klass),
+        Instr.i32Const(2),
+        Instr.op('i32.shl'),
+        Instr.i32Const(heapTableBase),
+        Instr.op('i32.add'),
+        Instr.localSet(listAddress),
+      ],
+      [
+        Instr.i32Const(-1),
+        Instr.localSet(klass),
+        Instr.localGet(bytes),
+        Instr.localSet(capacity),
+        Instr.i32Const(heapTableBase + heapIrregularClass * 4),
+        Instr.localSet(listAddress),
+      ],
+    ),
+    // Reuse the head of the list when it serves the request. Every classified block in a list has
+    // the class's capacity and a 16-aligned payload, so only an irregular head needs measuring.
+    ...load(listAddress),
+    Instr.localTee(block),
+    Instr.ifElse(
+      Instr.emptyBlockType,
+      [
+        Instr.localGet(klass),
+        Instr.i32Const(0),
+        Instr.op('i32.ge_s'),
+        ...load(block),
+        Instr.localGet(bytes),
+        Instr.op('i32.ge_u'),
+        Instr.localGet(block),
+        Instr.i32Const(heapHeaderBytes),
+        Instr.op('i32.add'),
+        Instr.localGet(align),
+        Instr.i32Const(1),
+        Instr.op('i32.sub'),
+        Instr.op('i32.and'),
+        Instr.op('i32.eqz'),
+        Instr.op('i32.and'),
+        Instr.op('i32.or'),
+        Instr.ifElse(
+          Instr.emptyBlockType,
+          [
+            ...store(listAddress, load(block, 8)),
+            ...store(block, [Instr.i32Const(0)], 8),
+            Instr.localGet(block),
+            Instr.i32Const(heapHeaderBytes),
+            Instr.op('i32.add'),
+            Instr.op('return'),
+          ],
+          [],
+        ),
+      ],
+      [],
+    ),
+    // Carve a fresh block. The bump cursor stays 16-aligned so every block start is, which is what
+    // keeps a classified payload's 16-byte alignment an invariant rather than a coincidence.
+    Instr.globalGet(heapPointer),
+    Instr.i32Const(heapHeaderBytes - 1),
+    Instr.op('i32.add'),
+    Instr.i32Const(-heapHeaderBytes),
+    Instr.op('i32.and'),
+    Instr.localSet(cursor),
+    Instr.localGet(cursor),
+    Instr.i32Const(heapHeaderBytes),
+    Instr.op('i32.add'),
+    Instr.localGet(align),
+    Instr.i32Const(1),
+    Instr.op('i32.sub'),
+    Instr.op('i32.add'),
+    Instr.i32Const(0),
+    Instr.localGet(align),
+    Instr.op('i32.sub'),
+    Instr.op('i32.and'),
+    Instr.localTee(payload),
+    Instr.localGet(cursor),
+    Instr.op('i32.lt_u'),
+    Instr.ifElse(Instr.emptyBlockType, refuse, []),
+    Instr.localGet(payload),
+    Instr.i32Const(heapHeaderBytes),
+    Instr.op('i32.sub'),
+    Instr.localSet(block),
+    Instr.localGet(payload),
+    Instr.localGet(capacity),
+    Instr.op('i32.add'),
+    Instr.i32Const(heapHeaderBytes - 1),
+    Instr.op('i32.add'),
+    Instr.localTee(cursor),
+    Instr.localGet(payload),
+    Instr.op('i32.lt_u'),
+    Instr.ifElse(Instr.emptyBlockType, refuse, []),
+    Instr.localGet(cursor),
+    Instr.i32Const(-heapHeaderBytes),
+    Instr.op('i32.and'),
+    Instr.localSet(cursor),
+    ...pagesForCursor,
+    Instr.memorySize(memory),
+    Instr.op('i32.gt_u'),
+    Instr.ifElse(
+      Instr.emptyBlockType,
+      [
+        ...pagesForCursor,
+        Instr.memorySize(memory),
+        Instr.op('i32.sub'),
+        Instr.memoryGrow(memory),
+        Instr.i32Const(-1),
+        Instr.op('i32.eq'),
+        Instr.ifElse(Instr.emptyBlockType, refuse, []),
+      ],
+      [],
+    ),
+    Instr.localGet(cursor),
+    Instr.globalSet(heapPointer),
+    ...store(block, [Instr.localGet(capacity)]),
+    ...store(block, [Instr.localGet(klass)], 4),
+    ...store(block, [Instr.i32Const(0)], 8),
+    ...store(block, [Instr.i32Const(0)], 12),
+    Instr.localGet(payload),
+  ]
+}
+
+/**
+ * The body of the synthesized release. It pushes one block onto the head of its size class's free
+ * list and returns. A null header is a no-op, which is what lets a union's conditional cleanup
+ * select the inactive case's reclaim context to zero instead of branching around the call — the
+ * same shortcut the LLVM backend takes through libc `free`.
+ */
+const heapReleaseBody = (memory: Memory.Memory): ReadonlyArray<Instr.Instr> => {
+  const [header, listAddress] = [0, 1]
+  const klass: ReadonlyArray<Instr.Instr> = [
+    Instr.localGet(header),
+    Instr.memoryAccess('i32.load', memory, { offset: 4 }),
+  ]
+  return [
+    Instr.localGet(header),
+    Instr.op('i32.eqz'),
+    Instr.ifElse(Instr.emptyBlockType, [Instr.op('return')], []),
+    // An unsigned comparison folds the irregular block's -1 class in with any out-of-range index,
+    // so a header can never steer the push past the end of the head table.
+    ...klass,
+    Instr.i32Const(heapIrregularClass),
+    ...klass,
+    Instr.i32Const(heapClassCount),
+    Instr.op('i32.lt_u'),
+    Instr.op('select'),
+    Instr.i32Const(2),
+    Instr.op('i32.shl'),
+    Instr.i32Const(heapTableBase),
+    Instr.op('i32.add'),
+    Instr.localSet(listAddress),
+    Instr.localGet(header),
+    Instr.localGet(listAddress),
+    Instr.memoryAccess('i32.load', memory),
+    Instr.memoryAccess('i32.store', memory, { offset: 8 }),
+    Instr.localGet(listAddress),
+    Instr.localGet(header),
+    Instr.memoryAccess('i32.store', memory),
+  ]
 }
 
 /** Local names reach the `name` custom section, so release builds declare them unnamed. */
@@ -1186,7 +1484,7 @@ const emitOperation = (
   /**
    * Runs every Drop hook one cleanup plan invokes: the owner materializes to its frame root,
    * each hook receives the address of its (possibly nested) value, and the owner's slots
-   * reload afterward. Allocation and raw-buffer releases stay no-ops on the bump allocator.
+   * reload afterward. The blocks the plan still owns are reclaimed separately, after the hooks.
    */
   const hookReleaseInstructions = (
     cleanup: Ownership.CleanupPlan,
@@ -1379,6 +1677,213 @@ const emitOperation = (
     }
     return walk(cleanup, 0)
   }
+  const semanticLanesOf = (type: SilkType.Type): ReadonlyArray<LayoutPlan.CallingLane> => {
+    const shape = LayoutPlan.callingShape(plan, type)
+    if (shape === undefined) {
+      throw new RangeError(`Wasm cleanup lost calling shape for ${SilkType.encode(type)}`)
+    }
+    return shape.lanes
+  }
+  const requireRelease = (): FuncActor.Func => {
+    const release = memory?.heapRelease
+    if (release === undefined) throw new RangeError('Wasm reclaim lost its heap release helper')
+    return release
+  }
+  /**
+   * Returns every block one cleanup plan still owns, reading each `$context` lane out of the
+   * owner's own slots. Hooks are not this walk's business — `hookReleaseInstructions` has already
+   * run them and reloaded the slots, so a context read here is the post-hook one, which is the
+   * order the LLVM backend's single lane-driven walk produces too.
+   */
+  const reclaimReleaseInstructions = (
+    cleanup: Ownership.CleanupPlan,
+    values: ReadonlyArray<number>,
+  ): ReadonlyArray<Instr.Instr> => {
+    if (!planReclaims(cleanup)) return []
+    switch (cleanup._tag) {
+      case 'AllocationCleanup':
+      case 'RawBufferCleanup': {
+        const context = values.at(4)
+        if (context === undefined) {
+          throw new RangeError('Wasm allocation cleanup lost its reclaim context')
+        }
+        return [Instr.localGet(context), Instr.call(requireRelease())]
+      }
+      case 'HookCleanup':
+        return reclaimReleaseInstructions(cleanup.inner, values)
+      case 'EffectCleanup':
+        return cleanup.slots.flatMap((slot) =>
+          reclaimReleaseInstructions(
+            slot.cleanup,
+            values.slice(slot.laneOffset, slot.laneOffset + slot.laneCount),
+          ),
+        )
+      case 'StructCleanup': {
+        const lanes = semanticLanesOf(cleanup.type)
+        return cleanup.fields.flatMap((field) =>
+          reclaimReleaseInstructions(
+            field.cleanup,
+            lanes.flatMap((lane, ordinal) => {
+              const first = lane.path.at(0)
+              const value = values.at(ordinal)
+              return first !== undefined &&
+                first._tag === 'FieldId' &&
+                value !== undefined &&
+                first.ordinal === field.field.ordinal &&
+                first.struct.ordinal === field.field.struct.ordinal &&
+                first.struct.sourceId === field.field.struct.sourceId
+                ? [value]
+                : []
+            }),
+          ),
+        )
+      }
+      case 'ArrayCleanup': {
+        const lanes = semanticLanesOf(cleanup.type)
+        return Array.from({ length: cleanup.length }, (_, index) =>
+          reclaimReleaseInstructions(
+            cleanup.element,
+            lanes.flatMap((lane, ordinal) => {
+              const first = lane.path.at(0)
+              const value = values.at(ordinal)
+              return first !== undefined &&
+                first._tag === 'ElementSelector' &&
+                first.index === index &&
+                value !== undefined
+                ? [value]
+                : []
+            }),
+          ),
+        ).flat()
+      }
+      case 'UnionCleanup': {
+        const shape = LayoutPlan.callingShape(plan, cleanup.type)
+        const tag = values.at(0)
+        if (shape === undefined || tag === undefined) {
+          throw new RangeError('Wasm union cleanup lost its shape')
+        }
+        // Only the live case owns the payload, so each reclaiming case runs guarded on the tag.
+        return cleanup.cases.flatMap((caseEntry) => {
+          const physical = LayoutPlan.memberFieldSlots(shape, caseEntry.member, [])
+          const memberLanes = semanticLanesOf(caseEntry.member)
+          if (physical === undefined || physical.length !== memberLanes.length) return []
+          // A member's lane can sit in a physically wider union slot. This backend reads slots
+          // directly rather than coercing them, so a widened lane is left to the owner that
+          // eventually destructures the union.
+          const selected = physical.flatMap((ordinal, index) => {
+            const value = values.at(ordinal)
+            const physicalLane = shape.lanes.at(ordinal)
+            const memberLane = memberLanes.at(index)
+            return value === undefined ||
+              physicalLane === undefined ||
+              memberLane === undefined ||
+              laneValueType(plan, physicalLane) !== laneValueType(plan, memberLane)
+              ? []
+              : [value]
+          })
+          if (selected.length !== memberLanes.length) return []
+          const inner = reclaimReleaseInstructions(caseEntry.cleanup, selected)
+          return inner.length === 0
+            ? []
+            : [
+                Instr.localGet(tag),
+                Instr.i32Const(caseEntry.ordinal),
+                Instr.op('i32.eq'),
+                Instr.ifElse(Instr.emptyBlockType, inner, []),
+              ]
+        })
+      }
+      default:
+        return []
+    }
+  }
+  /** The same reclaim walk for a value the backend only holds the address of. */
+  const reclaimReleaseAtAddress = (
+    cleanup: Ownership.CleanupPlan,
+    address: number,
+    byteOffset = 0,
+  ): ReadonlyArray<Instr.Instr> => {
+    if (!planReclaims(cleanup)) return []
+    if (memory === undefined) throw new RangeError('Wasm slot reclaim has no private memory')
+    switch (cleanup._tag) {
+      case 'AllocationCleanup':
+      case 'RawBufferCleanup': {
+        const contextOffset = SilkType.isRawBuffer(cleanup.type)
+          ? aggregateFieldOffset(cleanup.type, '$allocation') +
+            aggregateFieldOffset(SilkType.allocation, '$context')
+          : aggregateFieldOffset(SilkType.allocation, '$context')
+        return [...loadAt(address, byteOffset + contextOffset), Instr.call(requireRelease())]
+      }
+      case 'HookCleanup':
+        return reclaimReleaseAtAddress(cleanup.inner, address, byteOffset)
+      case 'StructCleanup': {
+        const representation = LayoutPlan.entry(memory.plan, cleanup.type)?.representation
+        if (representation?._tag !== 'Aggregate') return []
+        return cleanup.fields.flatMap((field) => {
+          const layoutField = representation.fields.find(
+            (candidate) =>
+              candidate.id.ordinal === field.field.ordinal &&
+              candidate.id.struct.ordinal === field.field.struct.ordinal &&
+              candidate.id.struct.sourceId === field.field.struct.sourceId,
+          )
+          return layoutField === undefined
+            ? []
+            : reclaimReleaseAtAddress(field.cleanup, address, byteOffset + layoutField.offset)
+        })
+      }
+      case 'ArrayCleanup': {
+        const representation = LayoutPlan.entry(memory.plan, cleanup.type)?.representation
+        if (representation?._tag !== 'Repeated') return []
+        return Array.from({ length: cleanup.length }, (_, index) =>
+          reclaimReleaseAtAddress(
+            cleanup.element,
+            address,
+            byteOffset + index * representation.stride,
+          ),
+        ).flat()
+      }
+      case 'UnionCleanup': {
+        const representation = LayoutPlan.entry(memory.plan, cleanup.type)?.representation
+        if (representation?._tag !== 'Union') return []
+        return cleanup.cases.flatMap((caseEntry) => {
+          const inner = reclaimReleaseAtAddress(
+            caseEntry.cleanup,
+            address,
+            byteOffset + representation.payloadOffset,
+          )
+          return inner.length === 0
+            ? []
+            : [
+                ...loadAt(address, byteOffset),
+                Instr.i32Const(caseEntry.ordinal),
+                Instr.op('i32.eq'),
+                Instr.ifElse(Instr.emptyBlockType, inner, []),
+              ]
+        })
+      }
+      default:
+        return []
+    }
+  }
+  /**
+   * One owned value's complete release: its Drop hooks, then the blocks its reclaim tickets still
+   * hold. Both halves are conditional on the plan actually carrying them, so a bare allocation
+   * drop — which invokes no hook at all — still emits its reclaim.
+   */
+  const releaseInstructions = (
+    cleanup: Ownership.CleanupPlan,
+    local: Mir.LocalId,
+  ): ReadonlyArray<Instr.Instr> => [
+    ...hookReleaseInstructions(cleanup, local),
+    ...reclaimReleaseInstructions(cleanup, slots(local)),
+  ]
+  const releaseAtAddress = (
+    cleanup: Ownership.CleanupPlan,
+    address: number,
+  ): ReadonlyArray<Instr.Instr> => [
+    ...hookReleaseAtAddress(cleanup, address),
+    ...reclaimReleaseAtAddress(cleanup, address),
+  ]
   const flushBorrowRoot = (root: Mir.LocalId): ReadonlyArray<Instr.Instr> => {
     const pointer = layout.borrowPointers.get(root.ordinal)
     if (pointer === undefined) return []
@@ -1654,61 +2159,30 @@ const emitOperation = (
         ...Array.from({ length: propagationShape.laneCount - 1 }, () => Instr.i32Const(0)),
         Instr.op('return'),
       ]
+      if (context.heapAllocate === undefined) {
+        throw new RangeError('Wasm allocation lost its heap allocator')
+      }
       return [
-        Instr.globalGet(context.heapPointer),
-        Instr.localGet(alignment),
-        Instr.i32Const(1),
-        Instr.op('i32.sub'),
-        Instr.op('i32.add'),
-        Instr.i32Const(0),
-        Instr.localGet(alignment),
-        Instr.op('i32.sub'),
-        Instr.op('i32.and'),
-        Instr.localSet(base),
-        Instr.localGet(base),
         Instr.localGet(bytes),
-        Instr.op('i32.add'),
-        Instr.localTee(layout.scratch),
-        Instr.localGet(base),
-        Instr.op('i32.lt_u'),
+        Instr.localGet(alignment),
+        Instr.call(context.heapAllocate),
+        Instr.localTee(base),
+        // No block payload can sit at address zero, so zero is the allocator's whole refusal
+        // vocabulary: an unserviceable request leaves through the same typed failure as before.
+        Instr.op('i32.eqz'),
         Instr.ifElse(Instr.emptyBlockType, fail, []),
-        Instr.localGet(layout.scratch),
-        Instr.i32Const(1),
-        Instr.op('i32.sub'),
-        Instr.i32Const(16),
-        Instr.op('i32.shr_u'),
-        Instr.i32Const(1),
-        Instr.op('i32.add'),
-        Instr.memorySize(context.memory),
-        Instr.op('i32.gt_u'),
-        Instr.ifElse(
-          Instr.emptyBlockType,
-          [
-            Instr.localGet(layout.scratch),
-            Instr.i32Const(1),
-            Instr.op('i32.sub'),
-            Instr.i32Const(16),
-            Instr.op('i32.shr_u'),
-            Instr.i32Const(1),
-            Instr.op('i32.add'),
-            Instr.memorySize(context.memory),
-            Instr.op('i32.sub'),
-            Instr.memoryGrow(context.memory),
-            Instr.i32Const(-1),
-            Instr.op('i32.eq'),
-            Instr.ifElse(Instr.emptyBlockType, fail, []),
-          ],
-          [],
-        ),
-        Instr.localGet(layout.scratch),
-        Instr.globalSet(context.heapPointer),
         Instr.localGet(bytes),
         Instr.localSet(destinationBytes),
         Instr.localGet(alignment),
         Instr.localSet(destinationAlignment),
         Instr.i32Const(1),
         Instr.localSet(reclaim),
-        Instr.i32Const(0),
+        // The reclaim-authority lane carries this block's header address. A payload always begins
+        // one header past its block, so release recovers the block with a subtraction the backend
+        // already knows, and needs no side table keyed by base pointer.
+        Instr.localGet(base),
+        Instr.i32Const(heapHeaderBytes),
+        Instr.op('i32.sub'),
         Instr.localSet(rawContext),
         Instr.i32Const(1),
         Instr.localSet(active),
@@ -1912,7 +2386,7 @@ const emitOperation = (
       })
     }
     case 'SlotDrop':
-      return hookReleaseAtAddress(operation.cleanup, scalar(operation.slot))
+      return releaseAtAddress(operation.cleanup, scalar(operation.slot))
     case 'ShortCircuit': {
       const right = [
         ...operation.right.operations.flatMap((nested) =>
@@ -2513,8 +2987,7 @@ const emitOperation = (
       return [...instructions, ...flushBorrowRoot(operation.root)]
     }
     case 'Drop':
-      // The bump allocator owns no host resources, so only Drop hooks have a Wasm effect.
-      return hookReleaseInstructions(operation.cleanup, operation.local)
+      return releaseInstructions(operation.cleanup, operation.local)
     case 'MakeEffect':
     case 'MakeCallable': {
       const destination = slots(operation.destination)
@@ -2626,9 +3099,9 @@ const emitOperation = (
       ]
       const propagationPayloadCount = operation.propagationLaneCount - 1
       const failure = [
-        // Owners still live at this site run their Drop hooks before the failure leaves.
+        // Owners still live at this site release before the failure leaves.
         ...(operation.releases ?? []).flatMap((release) =>
-          hookReleaseInstructions(release.cleanup, release.local),
+          releaseInstructions(release.cleanup, release.local),
         ),
         ...mapTag,
         Instr.localGet(layout.scratch),
@@ -2689,9 +3162,9 @@ const emitOperation = (
       ]
       const propagationPayloadCount = operation.propagationLaneCount - 1
       const failure = [
-        // Owners still live at this site run their Drop hooks before the failure leaves.
+        // Owners still live at this site release before the failure leaves.
         ...(operation.releases ?? []).flatMap((release) =>
-          hookReleaseInstructions(release.cleanup, release.local),
+          releaseInstructions(release.cleanup, release.local),
         ),
         ...mapTag,
         Instr.localGet(layout.scratch),
@@ -2793,7 +3266,7 @@ const emitOperation = (
             Instr.emptyBlockType,
             [
               ...copy(selected, payload),
-              ...hookReleaseInstructions(failure.cleanup, failure.payload),
+              ...releaseInstructions(failure.cleanup, failure.payload),
               Instr.i32Const(failure.tag),
               Instr.localSet(destination),
             ],
@@ -3995,6 +4468,9 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
       staticEnd += data.bytes.length
     }
     staticEnd = alignUp(staticEnd, 16)
+    // A cleanup plan can reclaim a block this module never allocated itself — a caller's owner
+    // dropped here — so the release helper is needed wherever a reclaim ticket is consumed too.
+    const releasesBlocks = (plan: Ownership.CleanupPlan): boolean => planReclaims(plan)
     const needsHeap = program.functions.some((fn) =>
       Mir.operations(fn).some(
         (operation) =>
@@ -4007,7 +4483,14 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
           operation._tag === 'SlotWrite' ||
           operation._tag === 'SlotTake' ||
           operation._tag === 'SlotCopy' ||
-          operation._tag === 'SlotDrop',
+          operation._tag === 'SlotDrop' ||
+          (operation._tag === 'Drop' && releasesBlocks(operation.cleanup)) ||
+          ((operation._tag === 'RunEffect' ||
+            operation._tag === 'RunEffectValue' ||
+            operation._tag === 'RunStaticEffect') &&
+            (operation.releases ?? []).some((release) => releasesBlocks(release.cleanup))) ||
+          (operation._tag === 'CloseEffectEntry' &&
+            operation.failures.some((failure) => releasesBlocks(failure.cleanup))),
       ),
     )
     const needsHostWrite = program.functions.some((fn) =>
@@ -4025,7 +4508,10 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
           debug ? { name: 'silk_memory' } : {},
         )
       : undefined
-    if (needsHostWrite && privateMemory !== undefined) {
+    // Every function is exported so the artifact is directly instantiable for inspection; the
+    // private memory is exported for the same reason, and because a host that only wants to watch
+    // the heap should not have to import a standard-stream write to see it.
+    if (privateMemory !== undefined) {
       yield* ExportActor.memory(builder, StandardStreams.wasmMemoryExport, privateMemory)
     }
     const stackPointer = needsMemory
@@ -4051,15 +4537,32 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
           )
       }
     }
+    // The bump region begins past the free-list head table, which wasm memory already zeroes.
     const heapPointer = needsMemory
       ? yield* Global.make(
           builder,
           i32,
           true,
-          [Instr.i32Const(65536)],
+          [Instr.i32Const(heapBase)],
           debug ? { name: 'silk_heap_pointer' } : {},
         )
       : undefined
+    const heapAllocate =
+      needsHeap && privateMemory !== undefined && heapPointer !== undefined
+        ? yield* FuncActor.declare(
+            builder,
+            yield* WasmType.func(builder, [i32, i32], [i32]),
+            debug ? { name: 'silk_heap_allocate' } : {},
+          )
+        : undefined
+    const heapRelease =
+      needsHeap && privateMemory !== undefined
+        ? yield* FuncActor.declare(
+            builder,
+            yield* WasmType.func(builder, [i32], []),
+            debug ? { name: 'silk_heap_release' } : {},
+          )
+        : undefined
     const standardWrite = needsHostWrite
       ? yield* Import.func(
           builder,
@@ -4069,6 +4572,19 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
           debug ? { name: 'silk_standard_stream_write_v1' } : {},
         )
       : undefined
+    if (heapAllocate !== undefined && privateMemory !== undefined && heapPointer !== undefined) {
+      const named = (name: string): FuncActor.Local => (debug ? { type: i32, name } : { type: i32 })
+      yield* FuncActor.define(builder, heapAllocate, {
+        locals: ['align', 'class', 'capacity', 'list', 'block', 'payload', 'cursor'].map(named),
+        body: heapAllocateBody(privateMemory, heapPointer),
+      })
+    }
+    if (heapRelease !== undefined && privateMemory !== undefined) {
+      yield* FuncActor.define(builder, heapRelease, {
+        locals: [debug ? { type: i32, name: 'list' } : { type: i32 }],
+        body: heapReleaseBody(privateMemory),
+      })
+    }
 
     // Declare every function first so calls resolve regardless of definition order, mirroring the
     // LLVM backend's declare-then-define pass structure.
@@ -4159,6 +4675,8 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
               plan: program.layout,
               staticOffsets,
               ...(standardWrite === undefined ? {} : { standardWrite }),
+              ...(heapAllocate === undefined ? {} : { heapAllocate }),
+              ...(heapRelease === undefined ? {} : { heapRelease }),
             })
       // A body-less function is a declaration the frontend could not resolve; the LLVM backend
       // leaves it undefined, but wasm rejects an undefined function at emission, so it becomes a

--- a/packages/compiler/test/WasmHeapReclaim.test.ts
+++ b/packages/compiler/test/WasmHeapReclaim.test.ts
@@ -1,0 +1,213 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+import * as StandardStreams from '../src/StandardStreams.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-wasm-heap-reclaim-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+const pagesOf = (instance: WebAssembly.Instance): number => {
+  const memory = instance.exports[StandardStreams.wasmMemoryExport]
+  assert.instanceOf(memory, WebAssembly.Memory)
+  if (!(memory instanceof WebAssembly.Memory)) return Number.POSITIVE_INFINITY
+  return memory.buffer.byteLength / 65536
+}
+
+/**
+ * An allocate-and-drop loop whose drops are deliberately not the reverse of its allocations: `a`
+ * is released while the younger `b` is still live, and `b` while the younger `c` is. A bump
+ * pointer that only unwinds its most recent block reclaims one of the three per iteration, so this
+ * program separates a real free list from a LIFO unwind — both of which pass a nested loop.
+ *
+ * Each block is 512 payload bytes, so a thousand iterations acquire roughly 1.5 MiB. The heap that
+ * serves it stays inside a couple of pages only if released blocks come back.
+ */
+const interleaved = `effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut index = 0
+  while index < 1000 {
+    let firstLayout = Layout.of<[i64; 64]>()
+    let firstPending = Allocator.allocate(move firstLayout) |> Effect.provideMut(&mut allocator)
+    let first = run firstPending
+    let secondLayout = Layout.of<[i64; 64]>()
+    let secondPending = Allocator.allocate(move secondLayout) |> Effect.provideMut(&mut allocator)
+    let second = run secondPending
+    drop first
+    let thirdLayout = Layout.of<[i64; 64]>()
+    let thirdPending = Allocator.allocate(move thirdLayout) |> Effect.provideMut(&mut allocator)
+    let third = run thirdPending
+    drop second
+    drop third
+    index = index + 1
+  }
+  return 42
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'keeps the Wasm heap bounded across interleaved non-LIFO allocate and drop cycles',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'wasm-heap-reclaim/interleaved',
+        ascii(interleaved),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
+
+      // Three thousand blocks of 512 bytes passed through this heap. A module that never reclaims
+      // needs upwards of twenty pages to hold them; one that does needs the two it started with.
+      assert.isAtMost(pagesOf(instance), 4)
+    }),
+  60_000,
+)
+
+/**
+ * The same interleaving, run long enough that the bound has to come from reuse rather than from
+ * slack: ten times the cycles must not cost a single extra page over the shorter run.
+ */
+const sustained = interleaved.replace('index < 1000', 'index < 10000')
+
+it.effect(
+  'holds the same Wasm heap bound when the interleaved cycle count grows tenfold',
+  () =>
+    Effect.gen(function* () {
+      const shorter = yield* Analysis.ofSourceRealized(
+        'wasm-heap-reclaim/interleaved',
+        ascii(interleaved),
+        'wasm32-unknown-unknown',
+      )
+      const longer = yield* Analysis.ofSourceRealized(
+        'wasm-heap-reclaim/sustained',
+        ascii(sustained),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(longer), [])
+
+      const shorterWasm = yield* Analysis.codegenWasm(shorter, { mode: 'release' })
+      const longerWasm = yield* Analysis.codegenWasm(longer, { mode: 'release' })
+      const shorterInstance = new WebAssembly.Instance(
+        new WebAssembly.Module(shorterWasm.bytes.slice()),
+        {},
+      )
+      const longerInstance = new WebAssembly.Instance(
+        new WebAssembly.Module(longerWasm.bytes.slice()),
+        {},
+      )
+      assert.strictEqual((shorterInstance.exports.silk_main as () => number)(), 42)
+      assert.strictEqual((longerInstance.exports.silk_main as () => number)(), 42)
+      assert.strictEqual(pagesOf(longerInstance), pagesOf(shorterInstance))
+    }),
+  120_000,
+)
+
+/**
+ * Count parity is a separate property from memory parity: the acquire and release counts a
+ * provider folds into an ordinary Silk value are backend-independent, and were already equal
+ * before either backend reclaimed anything. This test pins that they stay equal, and says nothing
+ * about how much memory either engine holds while doing it.
+ */
+const counted = `import silk.metrics {
+  AllocationMetrics,
+  copy as copyMetrics,
+  make as zeroedMetrics,
+  recordAcquire,
+  recordRelease
+}
+
+struct CountingAllocator {
+  inner: SystemAllocator
+  metrics: AllocationMetrics
+}
+
+effect fn allocate(self: &mut CountingAllocator, layout: Layout) -> Allocation ! OutOfMemory {
+  let pending = Allocator.allocate(move layout) |> Effect.provideMut(&mut self.inner)
+  let block = run pending
+  recordAcquire(&mut self.metrics)
+  return move block
+}
+
+impl Allocator for CountingAllocator { allocate: CountingAllocator.allocate }
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = CountingAllocator {
+    inner: SystemAllocator.make(),
+    metrics: zeroedMetrics()
+  }
+  let firstLayout = Layout.of<[i32; 8]>()
+  let firstPending = Allocator.allocate(move firstLayout) |> Effect.provideMut(&mut allocator)
+  let first = run firstPending
+  let secondLayout = Layout.of<[i32; 8]>()
+  let secondPending = Allocator.allocate(move secondLayout) |> Effect.provideMut(&mut allocator)
+  let second = run secondPending
+
+  // Released oldest first, so the release order is not the reverse of the acquire order.
+  drop first
+  recordRelease(&mut allocator.metrics)
+
+  let thirdLayout = Layout.of<[i32; 8]>()
+  let thirdPending = Allocator.allocate(move thirdLayout) |> Effect.provideMut(&mut allocator)
+  let third = run thirdPending
+  drop second
+  recordRelease(&mut allocator.metrics)
+  drop third
+  recordRelease(&mut allocator.metrics)
+
+  let observed = copyMetrics(&allocator.metrics)
+  if observed.acquired == 3 {} else { return 1 }
+  return usize.toI32(observed.released)
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect(
+  'reports the same release count on Wasm and on native LLVM',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'wasm-heap-reclaim/counted',
+        ascii(counted),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      const wasmReleases = (instance.exports.silk_main as () => number)()
+
+      const compiled = yield* Driver.compile({
+        compilation: {
+          root: SourceFile.make('wasm-heap-reclaim/counted', ascii(counted)),
+        },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'counted'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const native = spawnSync(compiled.path, [], { encoding: 'utf8' })
+
+      assert.strictEqual(wasmReleases, 3)
+      assert.strictEqual(native.status, wasmReleases, native.stderr)
+    }),
+  60_000,
+)


### PR DESCRIPTION
Closes #20

Implements **option B** from the decision comment (2026-08-13): the Wasm heap becomes a real size-class free list, and "bounded" means bounded for arbitrary interleaved alloc/free.

## What was wrong

Two things, not one:

- The release path emitted nothing for allocations — `WasmBackend.ts:1171`'s comment ("releases stay no-ops on the bump allocator") was the only record.
- `planHasHook` (`WasmBackend.ts:30-37`) had **no `AllocationCleanup` case**, so a cleanup plan that reclaims without invoking a Drop hook was invisible to the backend entirely. A bare allocation drop produced no instructions at all. Fixed by adding `planReclaims` beside it, and running a reclaim walk at every release site.

## How it works

Every block is a 16-byte header followed by its payload, so a payload always begins exactly one header past its block:

```
header+0   payload capacity in bytes
header+4   size-class index, or -1 for an irregular block
header+8   next free block while the block sits on a free list
header+12  reserved, keeping the payload 16-byte aligned
```

That is what lets the compiler-private `$context` reclaim-authority lane carry the **header address** instead of the constant `0` (`WasmBackend.ts:1653-1654` before this change) — the same lane native LLVM already hands to libc `free`. Release recovers the block by subtraction; no side table.

Free-list heads live in a fixed table at the base of the heap region, which wasm memory already zeroes (a wasm global cannot be indexed by a class computed at run time). Classes hold payload capacities `1 << (4 + index)` from 16 bytes to 1 GiB. Every classified block starts 16-byte aligned, so its payload is too, and any later request in its class can reuse it without re-checking alignment. A request whose alignment exceeds 16 bytes, or whose size exceeds the largest class, is served from one irregular list whose head is measured against the request before reuse — `Layout` admits any run-time power-of-two alignment, so that path is a correctness requirement, not a nicety.

Drop hooks run before the storage they own is reclaimed (the hook walk reloads the owner's slots, and the reclaim walk reads those), which is the order LLVM's single lane-driven walk produces. A null header is a no-op on release, so a union's conditional cleanup can select an inactive case's context to zero rather than branch — the same shortcut LLVM takes through `free`.

The private memory is now exported whenever the module has one, rather than only when a host write needs it. That is how a host observes the heap at all, including how the acceptance test reads `memory.size`, and it matches the existing rule that every function is exported so the artifact is directly instantiable for inspection.

## Acceptance criteria

- [x] An acceptance test runs an allocate-and-drop loop on Wasm and asserts the final `memory.size` stays under a fixed limit — `WasmHeapReclaim.test.ts`, plus a second test asserting a tenfold cycle count costs no extra page.
- [x] A test asserts that Wasm and native LLVM give equal release counts for the same program — kept **separate** from the heap-bound test, per the decision comment.
- [x] The comment at `WasmBackend.ts:1171` is removed.
- [x] Requirement 1: bounded heap under repeated acquire/release — for **arbitrary interleaved** patterns, verified by a deliberately non-LIFO loop.
- [x] Requirement 2: alignment guarantees preserved, including alignments above 16 bytes.
- [x] Requirement 3: equal acquire/release counts on both backends.
- [x] Requirement 4: no scheduler, garbage collector, or background task. No compaction, defragmentation, moving allocator, `Allocator` contract change, or public `free`.

## The bounded test must fail on the bump allocator — it does

Reverting only the allocator logic (keeping the memory export so the test can read the heap):

```
× keeps the Wasm heap bounded across interleaved non-LIFO allocate and drop cycles
    AssertionError: expected 25 to be at most 4
× holds the same Wasm heap bound when the interleaved cycle count grows tenfold
    AssertionError: expected 236 to equal 25
✓ reports the same release count on Wasm and on native LLVM
```

25 pages at 1 000 cycles, 236 at 10 000 — and count parity passes on the old allocator, confirming the two tests pin different properties rather than the same one twice.

The interleaved program releases the *older* of two live blocks each time, so a LIFO bump-pointer unwind would reclaim one block in three and stay unbounded. It separates option B from option A, which the issue's own nested examples do not.

## Spec

Amended through openspec (`openspec/changes/add-wasm-heap-reclaim/`, synced into the main specs):

- `bootstrap-owned-allocation`: an allocation's private reclaim authority has a backend-chosen representation, and a backend **may** carry the address of a backend-private block header there (`spec.md:25-26`). It stays unnameable, unreadable, and unforgeable from Silk either way.
- `bootstrap-backend`: states the Wasm reclaim policy that no spec previously named — released storage returns to the heap that issued it, the bound holds for arbitrary interleaved patterns, release is emitted even for a plan with no Drop hook — and states that release-count parity is a **distinct property** from memory parity, so neither can be inferred from the other.

## Trade-off

Adjacent free blocks are never coalesced, so worst-case fragmentation across a changing size mix is not bounded — only repeated patterns are, which is the property claimed. Buying more back means splitting and coalescing or a moving allocator, both out of scope here.

## Tests

`Tests: baseline 0 failures, after 0 failures, +3 new tests` (146 → 147 compiler test files, 1153 → 1156 tests).

Full `turbo run test --continue`: 18/20 tasks green. The two red tasks are the pre-registered local-only failures, untouched by this change — `packages/wasm` `Extended.test.ts` "threads address types through memory instructions", and `compiler-cli` `FormatCommand`/`FormatWorkflow` (chmod-as-root). `biome check .` and `turbo run typecheck` are clean; no new diagnostics, so no documentation pages needed regenerating.

LLVM, native, and evaluator behavior are unchanged — three-engine parity holds on every existing suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDTfottHTAAgrVPg4mxG3F)_