### PR TITLE
ownership: document the deferred-body publication boundary on the fact fields

### DIFF
--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -1320,11 +1320,10 @@ export const discover = (
       ?.functions.find(
         (candidate) => candidate.declaration.id.ordinal === fn.declaration.id.ordinal,
       )
-    // Deferred effect-body bindings publish only through exit releases, so both fact sources
-    // feed hook reachability.
+    // Deferred effect-body bindings publish only through exit releases, so the joined binding
+    // facts and the exit releases both feed hook reachability.
     const cleanupHooks = [
-      ...(functionOwnership?.bindings.map((binding) => binding.cleanup) ?? []),
-      ...(functionOwnership?.deferredBindings.map((binding) => binding.cleanup) ?? []),
+      ...Ownership.allBindings(functionOwnership).map((binding) => binding.cleanup),
       ...(functionOwnership?.exits.flatMap((exit) =>
         exit.releases.map((release) => release.cleanup),
       ) ?? []),

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -3700,7 +3700,7 @@ const lowerSequence = (
       droppedExpression._tag === 'BindingReference' ? droppedExpression.binding.ordinal : undefined
     const bindingFact =
       droppedBinding !== undefined
-        ? [...(fn.ownership?.bindings ?? []), ...(fn.ownership?.deferredBindings ?? [])].find(
+        ? Ownership.allBindings(fn.ownership).find(
             (binding) =>
               binding.site._tag === 'Let' && binding.site.binding.ordinal === droppedBinding,
           )

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -210,10 +210,20 @@ export type Verdict =
 export interface FunctionOwnership {
   readonly _tag: 'FunctionOwnership'
   readonly declaration: DeclarationIndex.DeclarationFact
+  /**
+   * Bindings this function's own statements introduce: parameters, `let` statements, and match
+   * patterns the enclosing flow reaches. Deliberately excludes deferred effect bodies, so it is
+   * not the whole set of bindings the function owns — an `effect fn` is entirely a deferred
+   * body, and publishes little beyond its parameters here. Read {@link allBindings} instead
+   * whenever completeness matters; reach for this field only to ask the narrower question of
+   * what the enclosing flow itself introduced.
+   */
   readonly bindings: ReadonlyArray<BindingFact>
   /**
    * Bindings owned by deferred effect bodies: published separately because their releases lower
-   * through the body's compiled runner, not through the enclosing function's statements.
+   * through the body's compiled runner, not through the enclosing function's statements. An
+   * `effect fn`'s whole body is deferred, so its `let` and pattern bindings arrive here rather
+   * than in {@link FunctionOwnership.bindings}.
    */
   readonly deferredBindings: ReadonlyArray<BindingFact>
   readonly exits: ReadonlyArray<ExitPlan>
@@ -224,6 +234,20 @@ export interface FunctionOwnership {
   readonly borrowedReplacements: ReadonlyArray<BorrowedReplacementFact>
   readonly verdict: Verdict
 }
+
+/**
+ * Every binding one function owns, enclosing statements and deferred effect bodies alike. The
+ * two fact sets are published apart because their releases lower through different bodies, so a
+ * consumer asking "what does this function own?" — cleanup emission, drop lowering — must join
+ * them rather than read {@link FunctionOwnership.bindings} and silently miss an `effect fn`'s
+ * entire body.
+ */
+export const allBindings = (
+  ownership: FunctionOwnership | undefined,
+): ReadonlyArray<BindingFact> =>
+  ownership === undefined
+    ? Object.freeze([])
+    : Object.freeze([...ownership.bindings, ...ownership.deferredBindings])
 
 export interface MatchOwnership {
   readonly _tag: 'MatchOwnership'

--- a/packages/compiler/test/Ownership.test.ts
+++ b/packages/compiler/test/Ownership.test.ts
@@ -676,3 +676,39 @@ pub fn main() -> i32 { return run Effect.catch(store(), recover) }`,
     [],
   )
 })
+
+it('publishes an effect fn body pattern binding as a deferred fact that allBindings joins', () => {
+  const source = (modifiers: string): string =>
+    `struct Left { value: i32 }
+struct Right { value: i32 }
+${modifiers} fn inspect(input: Left | Right) -> i32 {
+  return match &input {
+    Left { value } => value
+    Right { value } => value
+  }
+}`
+  const plain = check('ownership://pattern-plain.silk', source('pub'))
+  const deferred = check('ownership://pattern-effect.silk', source('pub effect'))
+  const names = (facts: ReadonlyArray<Ownership.BindingFact>): ReadonlyArray<string | undefined> =>
+    facts.filter((binding) => binding.site._tag === 'Pattern').map((binding) => binding.name)
+
+  assert.deepEqual(plain.diagnostics, [])
+  assert.deepEqual(deferred.diagnostics, [])
+
+  // A plain body's pattern bindings reach the enclosing fact set.
+  const inspected = plain.functions.at(0)
+  assert.deepEqual(names(inspected?.bindings ?? []), ['value', 'value'])
+  assert.deepEqual(names(inspected?.deferredBindings ?? []), [])
+
+  // An effect fn is entirely a deferred body, so the same patterns publish on the other field.
+  // This is the documented publication boundary, not a tracking hole — see FunctionOwnership.
+  const lazy = deferred.functions.at(0)
+  assert.deepEqual(names(lazy?.bindings ?? []), [])
+  assert.deepEqual(names(lazy?.deferredBindings ?? []), ['value', 'value'])
+
+  // allBindings is the join a consumer needing completeness must use: it answers the same for
+  // both shapes, where reading `bindings` alone does not.
+  assert.deepEqual(names(Ownership.allBindings(inspected)), ['value', 'value'])
+  assert.deepEqual(names(Ownership.allBindings(lazy)), ['value', 'value'])
+  assert.deepEqual(Ownership.allBindings(undefined), [])
+})


### PR DESCRIPTION
Closes #99

Reading 1 (working as intended), per the decision recorded on the issue on 2026-08-13. Documentation and one small helper; no behaviour change.

## What was actually going on

Confirmed the issue's measurement, and pinned down where the missing facts live. For

```silk
struct Left { value: i32 }
struct Right { value: i32 }
pub fn inspect(input: Left | Right) -> i32 {
  return match &input {
    Left { value } => value
    Right { value } => value
  }
}
```

- `pub fn` → `bindings` = `input:Parameter, value:Pattern, value:Pattern`, `deferredBindings` = empty
- `pub effect fn` → `bindings` = `input:Parameter`, `deferredBindings` = `value:Pattern, value:Pattern`

So the pattern bindings are not merely reachable by lowering through the body — they are already **published**, on `deferredBindings`. An `effect fn`'s entire body is one deferred block, so everything past the parameters moves to the other field. This is squarely a publication boundary.

## Why the docs still needed a change

`deferredBindings` already carried a doc comment describing its own half. `bindings` carried none. A consumer arriving at `functions[].bindings` and asking "is this complete?" found nothing at the field it was reading — it had to notice the neighbouring field's comment and infer the complement. That is the gap the issue's acceptance criterion names, so this is not redundant prose.

Changes:

- **`FunctionOwnership.bindings`** now states the exclusion, names the `effect fn` case explicitly (the surprising part), and points at the join.
- **`FunctionOwnership.deferredBindings`** gains one sentence naming the `effect fn` case, which its previous "deferred effect bodies" phrasing did not obviously cover.
- **`Ownership.allBindings(ownership)`** — the join, as the guard.

## On the assertion / guard

A true runtime assertion catching a consumer reading the outer set for an `effect fn` isn't available cleanly: `bindings` is a frozen plain array on a frozen fact object, so intercepting the read means a `Proxy` over every `FunctionOwnership`, on a hot path, to catch a mistake that has no legitimate-use exception to test against. That is the "noisy" case the issue anticipates, so I skipped it.

`allBindings` is what I did instead. The two existing consumers — instance cleanup-hook discovery (`Instances.ts`) and drop lowering (`Lower.ts`) — were both already correct, spreading the two arrays by hand; they now go through the helper. The completeness question is answered by a name at the call site rather than by remembering to concatenate, which is the guard the issue was reaching for without a wide refactor. Both consumers were verified correct before the change, so this is a rename of an existing correct pattern, not a fix.

Reading 2 (publishing the bindings outward) is deliberately **not** implemented: no consumer needs it, and the issue gates it on one being named.

## Verification

The new test pins both halves of the boundary — plain `fn` publishes patterns to `bindings`, `effect fn` publishes the same patterns to `deferredBindings`, and `allBindings` answers identically for both — so the documented contract now fails loudly if it drifts. The existing `OWN0001`-inside-a-lazy-body test already covers the soundness half.

Tests: baseline 4 failures, after 4 failures, +1 new test.

All four are the documented pre-existing local failures, unrelated to this diff (file-permission and wasm address-type cases): `compiler-cli` `FormatCommand`/`FormatWorkflow` ×3 (chmod is a no-op as root), `packages/wasm` `Extended.test.ts > threads address types through memory instructions` ×1. Compiler 1245/1245 pass; `lsp`, `llvm`, `docs`, `documentation` all green; `biome check` and `typecheck` clean.

`pnpm documentation:check` passes unchanged — as expected, since these are compiler-internal TSDoc comments, not stdlib Silk doc comments, so no generated pages move.

---
_Generated by [Claude Code](https://claude.ai/code/session_019kqrr83VxXCFPD38qRBK1w)_