### PR TITLE
backend: size Wasm lane loads and stores by their element

### DIFF
--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -1416,9 +1416,26 @@ const emitOperation = (
     if (field === undefined) throw new RangeError(`Wasm raw storage lost field ${name}`)
     return field.offset
   }
-  const loadAt = (address: number, offset = 0): ReadonlyArray<Instr.Instr> => {
+  /**
+   * A lane-less load reads a four-byte compiler field — a count, a base pointer, a union tag.
+   * A load that lands in an element lane must pass that lane, so the access is exactly as wide
+   * as the element: a narrow lane shares its four-byte window with its neighbours, and a fixed
+   * `i32.load` would read theirs along with its own.
+   */
+  const loadAt = (
+    address: number,
+    offset = 0,
+    lane?: LayoutPlan.CallingLane,
+  ): ReadonlyArray<Instr.Instr> => {
     const context = requireMemory()
-    return [Instr.localGet(address), Instr.memoryAccess('i32.load', context.memory, { offset })]
+    return [
+      Instr.localGet(address),
+      Instr.memoryAccess(
+        lane === undefined ? 'i32.load' : laneLoadMnemonic(plan, lane),
+        context.memory,
+        { offset },
+      ),
+    ]
   }
   const storeAt = (
     address: number,
@@ -1901,7 +1918,7 @@ const emitOperation = (
         Instr.localGet(pointer),
         ...(offset === 0 ? [] : [Instr.i32Const(offset), Instr.op('i32.add')]),
         Instr.localGet(source),
-        Instr.memoryAccess('i32.store', memory.memory),
+        Instr.memoryAccess(laneStoreMnemonic(memory.plan, lane), memory.memory),
       ]
     })
   }
@@ -2454,7 +2471,7 @@ const emitOperation = (
         if (destination === undefined || offset === undefined) {
           throw new RangeError('Wasm Slot.take lost an element lane')
         }
-        return [...loadAt(address, offset), Instr.localSet(destination)]
+        return [...loadAt(address, offset, lane), Instr.localSet(destination)]
       })
     }
     case 'SlotDrop':
@@ -2737,7 +2754,7 @@ const emitOperation = (
           const offset = LayoutPlan.laneOffset(plan, target, [...staticSelectors, ...lane.path])
           if (destination === undefined || offset === undefined)
             throw new RangeError('Wasm reference read lost a lane offset')
-          return [...loadAt(address, offset), Instr.localSet(destination)]
+          return [...loadAt(address, offset, lane), Instr.localSet(destination)]
         })
       }
       if (rootSemantic !== undefined && SilkType.isSlice(rootSemantic)) {

--- a/packages/compiler/test/SlotLaneWidth.test.ts
+++ b/packages/compiler/test/SlotLaneWidth.test.ts
@@ -1,0 +1,221 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-slot-lane-width-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+/**
+ * A slot lane narrower than four bytes shares its four-byte window with its neighbours, so a
+ * fixed-width `i32.load` for the lane at index 0 swallows whatever the neighbour wrote. Each case
+ * writes two elements inside one window and reads both back through `Slot.copy` and `Slot.take`:
+ * the sum only survives when every lane load is exactly as wide as its element.
+ */
+interface Case {
+  /** The element type the buffer is instantiated at. */
+  readonly element: string
+  /** The index sharing a four-byte window with index 0 at this element's stride. */
+  readonly neighbour: number
+  /** The value written at index 0. Negative for signed elements, to pin sign extension too. */
+  readonly first: string
+  /** The value written at `neighbour`. */
+  readonly second: string
+  /** `100 + 2 * first + 2 * second`, as the program computes it. */
+  readonly expected: number
+}
+
+const cases: ReadonlyArray<Case> = [
+  { element: 'u8', neighbour: 3, first: '7', second: '11', expected: 136 },
+  { element: 'i8', neighbour: 3, first: '-7', second: '11', expected: 108 },
+  { element: 'u16', neighbour: 1, first: '7', second: '11', expected: 136 },
+  { element: 'i16', neighbour: 1, first: '-7', second: '11', expected: 108 },
+  { element: 'u32', neighbour: 1, first: '7', second: '11', expected: 136 },
+  { element: 'i32', neighbour: 1, first: '-7', second: '11', expected: 108 },
+  { element: 'u64', neighbour: 1, first: '7', second: '11', expected: 136 },
+  { element: 'i64', neighbour: 1, first: '-7', second: '11', expected: 108 },
+  { element: 'usize', neighbour: 1, first: '7', second: '11', expected: 136 },
+  { element: 'isize', neighbour: 1, first: '-7', second: '11', expected: 108 },
+  { element: 'f32', neighbour: 1, first: '-7.0', second: '11.0', expected: 108 },
+  { element: 'f64', neighbour: 1, first: '-7.0', second: '11.0', expected: 108 },
+]
+
+const program = (entry: Case): string => `effect fn store() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let layout = Layout.of<[${entry.element}; 4]>()
+  let recipe = Allocator.allocate(move layout) |> Effect.provideMut(&mut allocator)
+  let allocation = run recipe
+  unsafe {
+    let mut buffer = RawBuffer.from<${entry.element}>(move allocation, 4)
+    let firstWritten = Slot.write<${entry.element}>(RawBuffer.slot(&mut buffer, 0), ${entry.first})
+    let secondWritten = Slot.write<${entry.element}>(RawBuffer.slot(&mut buffer, ${entry.neighbour}), ${entry.second})
+    let firstCopy = Slot.copy(RawBuffer.slot(&mut buffer, 0))
+    let secondCopy = Slot.copy(RawBuffer.slot(&mut buffer, ${entry.neighbour}))
+    let firstTake = Slot.take(RawBuffer.slot(&mut buffer, 0))
+    let secondTake = Slot.take(RawBuffer.slot(&mut buffer, ${entry.neighbour}))
+    drop buffer
+    return 100 + ${entry.element}.toI32(firstCopy) + ${entry.element}.toI32(secondCopy) + ${entry.element}.toI32(firstTake) + ${entry.element}.toI32(secondTake)
+  }
+  return 0
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(store(), recover) }`
+
+for (const entry of cases) {
+  it.effect(`reads a ${entry.element} slot lane at its own width on every engine`, () =>
+    Effect.gen(function* () {
+      const source = program(entry)
+      const name = `slot-lane-width/${entry.element}`
+      const snapshot = yield* Analysis.ofSourceRealized(
+        name,
+        ascii(source),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(
+        evaluated._tag,
+        'Completed',
+        JSON.stringify(evaluated, (_, value) => (typeof value === 'bigint' ? `${value}n` : value)),
+      )
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, entry.expected)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), entry.expected)
+
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make(name, ascii(source)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, entry.element),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, entry.expected, run.stderr)
+    }),
+  )
+}
+
+/** The reproduction as issue #114 states it: two `7u8` in one word, taken back and summed. */
+const reported = `effect fn store() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let layout = Layout.of<[u8; 4]>()
+  let recipe = Allocator.allocate(move layout) |> Effect.provideMut(&mut allocator)
+  let allocation = run recipe
+  unsafe {
+    let mut buffer = RawBuffer.from<u8>(move allocation, 4)
+    let firstWritten = Slot.write<u8>(RawBuffer.slot(&mut buffer, 0), 7)
+    let secondWritten = Slot.write<u8>(RawBuffer.slot(&mut buffer, 3), 7)
+    let first = Slot.take(RawBuffer.slot(&mut buffer, 0))
+    let second = Slot.take(RawBuffer.slot(&mut buffer, 3))
+    drop buffer
+    return u8.toI32(first) + u8.toI32(second)
+  }
+  return 0
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+
+pub fn main() -> i32 { return run Effect.catch(store(), recover) }`
+
+it.effect('sums two u8 slots in one word to 14 on every engine', () =>
+  Effect.gen(function* () {
+    const name = 'slot-lane-width/reported'
+    const snapshot = yield* Analysis.ofSourceRealized(
+      name,
+      ascii(reported),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 14)
+
+    const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+    assert.strictEqual((instance.exports.silk_main as () => number)(), 14)
+
+    const compiled = yield* Driver.compile({
+      compilation: { root: SourceFile.make(name, ascii(reported)) },
+      toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+      profile: 'release',
+      destination: join(destinationRoot, 'reported'),
+    }).pipe(Effect.provide(SourceResolver.empty))
+    assert.strictEqual(compiled._tag, 'Compiled')
+    if (compiled._tag !== 'Compiled') return
+    const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+    assert.strictEqual(run.status, 14, run.stderr)
+  }),
+)
+
+/**
+ * Reading a field through a reference lands in the same lane-load helper the slot reads use, so
+ * a struct packed with sub-word fields catches a fixed-width load there the same way: every
+ * field but the last would otherwise drag its neighbours in, and the signed ones pin the
+ * sign-extending mnemonic rather than the zero-extending one.
+ */
+const packedReference = `struct Packed {
+  first: u8
+  second: i8
+  third: u16
+  fourth: i16
+}
+
+fn peek(self: &Packed) -> i32 {
+  return u8.toI32(self.first) + i8.toI32(self.second) + u16.toI32(self.third) + i16.toI32(self.fourth)
+}
+
+pub fn main() -> i32 {
+  let packed = Packed { first: 7, second: -5, third: 200, fourth: -9 }
+  return 50 + peek(&packed)
+}`
+
+it.effect('reads a sub-word field through a reference at its own width on every engine', () =>
+  Effect.gen(function* () {
+    const name = 'slot-lane-width/packed-reference'
+    const expected = 243
+    const snapshot = yield* Analysis.ofSourceRealized(
+      name,
+      ascii(packedReference),
+      'wasm32-unknown-unknown',
+    )
+    assert.deepEqual(Analysis.diagnostics(snapshot), [])
+
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed')
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, expected)
+
+    const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+    assert.strictEqual((instance.exports.silk_main as () => number)(), expected)
+
+    const compiled = yield* Driver.compile({
+      compilation: { root: SourceFile.make(name, ascii(packedReference)) },
+      toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+      profile: 'release',
+      destination: join(destinationRoot, 'packed-reference'),
+    }).pipe(Effect.provide(SourceResolver.empty))
+    assert.strictEqual(compiled._tag, 'Compiled')
+    if (compiled._tag !== 'Compiled') return
+    const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+    assert.strictEqual(run.status, expected, run.stderr)
+  }),
+)


### PR DESCRIPTION
Closes #114

## What was wrong

`WasmBackend` reached memory through a `loadAt` helper that always emitted `i32.load`, while its store counterpart `storeAt` already took the lane and picked a mnemonic from it. Every lane narrower than four bytes therefore shared its window with its neighbours on the way in.

`loadAt` now takes the lane the access lands in, exactly as `storeAt` does, and the two lane-load callers pass it. A lane-less call still means a genuine four-byte compiler field, and those callers are unchanged.

## Sweeping the class, not the instance

Per requirement 2, every fixed-width memory access in the backend was checked. Three were wrong:

| site | symptom | verified |
|---|---|---|
| `Slot.take` / `Slot.copy` lane loads | the reported bug | yes — fails pre-fix |
| `ReadPlace` through a reference | a struct field narrower than four bytes dragged in its neighbours | yes — fails pre-fix |
| Effect-borrow writeback (`flushBorrowRoot`) | walks lanes with per-lane offsets but stored each with a fixed `i32.store` | no — see below |

The reported `u8` case is one face of the first row. The same fixed load also meant lanes **wider** than four bytes did not miscompile so much as fail outright: an `i32.load` result cannot feed an `i64` or float local, so a `u64`, `i64`, `f32` or `f64` element **never emitted a module at all** on Wasm. Those four are fixed by the same change.

The third row is hardening, not a demonstrated defect, and is called out as such. Its read counterpart `reloadRoot` already used `laneLoadMnemonic`, so the asymmetry looked like an oversight — but no program in the suite reaches that path with a narrow lane, and I could not construct one, so it is unverified by test.

Checked and **already correct**, reported per the issue's request:

- `storeAt` — both callers (`SlotWrite`, `WritePlace`) already pass the lane.
- `RawBufferRead` / `RawBufferWrite`, slice element read and write, `materializeRoot`, `reloadRoot` — all already use the lane mnemonics.
- The byte-compare loop already uses an explicit `i32.load8_u`.
- Every remaining fixed-width access is a real four-byte field: heap allocator metadata and free-list links, `RawBuffer` `count` and `$base`, and union tags — which `Layout` pins at four bytes via `payloadOffset = alignUp(4, payloadAlignment)`.

## Acceptance criteria

- [x] The reproduction gives `14` on all three engines. Verified failing pre-fix at exactly **`117440526`** (`0x07000007`), the value the issue predicts.
- [x] A test covers `Slot.take` and `Slot.copy` for each scalar element width — `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `usize`, `isize`, `f32`, `f64`.
- [x] The regression test is verified to fail on Wasm pre-fix — 9 of the 14 new tests fail before the change, and each fix site was reverted in isolation to confirm it is load-bearing.

## Notes on the tests

Every case asserts on **values** across all three engines — evaluator, direct Wasm instantiation, and a native LLVM binary's exit status — since the issue notes that asserting on completion is exactly what let this hide. Signed cases write a negative value to pin the sign-extending mnemonic rather than the zero-extending one, and narrow cases place their two writes inside one four-byte window so a wide load is forced to show itself.

Tests: baseline 0 real failures, after 0 real failures, +14 new tests.

The full `packages/compiler` suite is 1255 passed / 3 failed; all three failures are the documented parallel-load timeouts and pass when their files are run alone. `pnpm check`'s only named failure is the documented `packages/wasm` `Extended.test.ts` "threads address types" case, which this branch does not touch. Typecheck, lint, and docs typecheck all pass. No new diagnostics, so no documentation regeneration was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMctJJf1bGTQLTXmxUEaYt)_