### PR TITLE
Design explicit Effect suspension boundary

### DIFF
--- a/openspec/changes/add-effect-suspension-boundary/.openspec.yaml
+++ b/openspec/changes/add-effect-suspension-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-effect-suspension-boundary/design.md
+++ b/openspec/changes/add-effect-suspension-boundary/design.md
@@ -1,0 +1,333 @@
+## Context
+
+See [proposal.md](proposal.md) for motivation. The current representation separates a hidden
+construction-site Effect environment from a generated runner. `RunEffectValue` executes such an
+environment; MIR normalization can replace eligible local single-use runs with `RunStaticEffect`.
+Both LLVM and Wasm currently lower either operation to an ordinary target call. There is no
+`musttail` or `return_call` premise to extend, and measured tail recursion fails at the same depth
+as non-tail recursion.
+
+The evaluator is already different: `executeMachine` drives generator-backed activations from a
+heap array and enforces `maxCallDepth` from the number of source-logical activations. It therefore
+does not need stack protection, but it does need suspension, allocation, tracing, and resource
+accounting semantics that match compiled execution.
+
+Four existing constraints shape the design:
+
+- only the sealed `Intrinsic` namespace may expose compiler-known callable behavior;
+- Effects carry exact typed failure and requirement rows;
+- allocations are observable through the selected source-defined `Allocator`, with typed
+  `OutOfMemory` and self-contained reclaim authority; and
+- source cleanup is deterministic for structured exits and typed failure, but traps carry no
+  unwind promise.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- make explicitly suspended non-tail self- and mutual-Effect recursion stack safe on native and
+  Wasm;
+- keep the public abstraction source-defined and the continuation representation target-neutral;
+- preserve exact ownership, failure propagation, service requirements, tracing, and `CallDepth`;
+- make continuation allocation and exhaustion honest in the Effect type; and
+- demonstrate zero suspension overhead in closed non-suspending artifacts.
+
+**Non-Goals:**
+
+- infer suspension or automatically transform recursion;
+- make ordinary function calls, recursive traversal, or Drop hooks stack safe;
+- add concurrency, scheduling fairness, interruption, cancellation, fibers, promises, or a public
+  pending state;
+- add a universal Effect interpreter or make every Effect use a continuation ABI; or
+- solve the separate borrow-heavy Wasm `unreachable` observed in a deep `Box` walk.
+
+## Decisions
+
+### 1. `Effect.suspend` widens rows explicitly
+
+The public source definition is designed as:
+
+```silk
+pub effect fn suspend<A, !E, ?R>(
+  deferred: once Effect<A ! E ? R>
+) -> A ! E | OutOfMemory ? R | &mut Allocator {
+  return run Intrinsic.suspendEffect(move deferred)
+}
+```
+
+A scalar non-tail cycle therefore states the cost in its own signature:
+
+```silk
+effect fn count(value: i32) -> i32 ! OutOfMemory ? &mut Allocator {
+  if value == 0 { return 0 }
+  let next = run Effect.suspend(effect { return run count(value - 1) })
+  return next + 1
+}
+```
+
+Continuation state cannot be hidden or infallible: native and Wasm need storage proportional to
+the number and layout of retained logical activations, and no finite machine can promise that
+storage always exists. A hidden backend heap would violate allocator-service selection, erase
+deterministic allocation failure, and create cleanup authority absent from the source contract.
+A trap would make ordinary resource exhaustion unrecoverable and disagree with every other owned
+allocation. Widening only the explicit boundary keeps the cost honest and preserves zero-cost
+synchronous Effects.
+
+Alternatives rejected:
+
+- **Hidden infallible allocation:** violates the existing owned-allocation contract and cannot be
+  tested deterministically.
+- **Trap on exhaustion:** places expected exhaustion outside the typed channel.
+- **Add allocation rows to every Effect:** destroys pay-for-use and overstates requirements.
+- **Use a fixed stack or arena:** merely moves the hidden finite limit and still needs an exhaustion
+  policy.
+
+### 2. Admit one transfer-shaped intrinsic, not an abstraction-shaped runtime API
+
+Add one safe generic intrinsic, represented here as `Intrinsic.suspendEffect`, whose logical
+contract is the same widened Effect contract as the wrapper. It transfers a deferred Effect to the
+active compiler-owned driver. It does not expose frame allocation, frame push/pop, resume labels,
+step results, or pending values. `Effect.suspend` is ordinary source and no compiler phase branches
+on `silk.effects` or its spelling.
+
+The operation is safe because its compiler contract performs layout, ownership transfer,
+allocation, and cleanup; callers establish no raw-memory invariant. The intrinsic inventory remains
+the source of signature, target availability, and verification coverage.
+
+Alternatives rejected:
+
+- **Recognize `Effect.suspend` by name:** violates minimal compiler privilege.
+- **Expose `Continuation<T>` plus management operations:** leaks backend representation and permits
+  invalid ownership states.
+- **Take a zero-argument function thunk:** Silk has no anonymous function literal able to capture
+  the recursive variable; an Effect is already the lazy capture value.
+
+### 3. Mark suspendability by reachability and split synchronous from suspendable entry
+
+After instance discovery, compute a deterministic fixed point over the concrete call graph. A
+runner is suspendable when it directly contains the suspension intrinsic or can call/apply/run a
+suspendable instance. This fact is recorded in shared target-aware MIR and participates in
+verification and encoding.
+
+Ordinary `RunEffectValue` and `RunStaticEffect` remain direct synchronous operations only when the
+selected runner is proven non-suspendable. A run of a suspendable runner enters the private driver
+through a distinct target-neutral MIR operation. A suspension point has a stable resume identity
+and a continuation descriptor containing:
+
+- the deferred runner identity, type arguments, captures, and provider arguments;
+- the exact typed outcome and propagation mappings;
+- locals live after the child, with logical types, planned layouts, and Copy/borrow/move access;
+- success and failure resume regions; and
+- releases and loan endings for every path.
+
+The MIR descriptor does not prescribe whether a target stores a function pointer, table index, or
+numeric resume tag. MIR regions remain a DAG; recursion exists only in the module call graph and the
+runner's data-driven resume loop.
+
+Static Effect normalization may still fold construction into `RunStaticEffect` for a runner proven
+synchronous. Suspendable or unknown candidates retain materialization and use the suspendable run
+form. The existing `Options.suspension` shortcut must be replaced by the reachability fact rather
+than treating suspension as a global compilation mode.
+
+Alternatives rejected:
+
+- **Annotate only the intrinsic call:** callers would still recursively enter suspendable callees
+  with ordinary calls.
+- **Make all runs driver calls:** violates the established synchronous artifact guarantee.
+- **Encode backend frame fields directly in MIR:** couples the target-neutral contract to ABI
+  choices and breaks deterministic cross-target planning.
+
+### 4. Continuations are single-block owned records allocated before the child starts
+
+At each suspension point, layout planning produces one record containing a private header plus all
+live post-resume values. One validated allocation is requested through `&mut Allocator`; successful
+storage is initialized transactionally and then becomes a single affine continuation owner. If
+allocation fails, no value has moved, the deferred body does not begin, and ordinary typed-failure
+cleanup runs in the current activation.
+
+After successful initialization, the allocation service call ends and its exclusive provider loan
+is closed before the driver begins the deferred child. The continuation retains only its
+self-contained reclaim authority. This is crucial when the child also needs `&mut Allocator`: it
+must borrow the service afresh rather than conflict with an allocation borrow retained by its
+parent. A provider selected for continuation storage must itself be proven non-suspendable; this
+prevents recursively needing continuation storage in order to allocate continuation storage.
+
+Frames are allocated individually rather than through a growable private vector. That directly
+uses the existing allocation and reclaim model, gives one failure point per logical boundary, and
+allows incremental cleanup without an additional hidden capacity policy. Backends may choose a
+target-private header before the compiler-planned payload, provided the allocator sees the complete
+validated request and the layout meets the requested alignment.
+
+Alternatives rejected:
+
+- **Grow one hidden frame stack:** growth policy and spare capacity become observable allocation
+  behavior with extra rollback complexity.
+- **Keep the allocator provider borrowed in the frame:** conflicts with nested allocation and
+  violates self-contained reclaim authority.
+- **Permit a suspending allocator implementation:** creates an unbootstrappable recursive boundary.
+
+### 5. The private protocol is iterative and target-specific
+
+The target-neutral protocol has two conceptual outcomes that never appear as Silk values:
+
+- **Complete(outcome):** the current runner produced its typed success/failure outcome.
+- **Transfer(frame, child):** the current runner saved post-resume state and asks the driver to run
+  a deferred child.
+
+The driver owns the linked continuation top. On `Transfer`, it installs the already initialized
+frame and invokes the child entry. On `Complete`, it either returns the final Effect outcome or
+pops one frame, resumes it with the child outcome, destroys transferred payload state as dictated
+by the resume path, and reclaims the frame. The loop performs no recursive driver-to-driver call.
+
+For LLVM, reachable suspendable runners receive private step entry functions with an erased driver
+context and target-planned payload pointers; direct synchronous runners retain the current outcome
+return ABI. For Wasm, reachable suspendable runners receive equivalent private step entries and a
+driver loop using private linear-memory frame addresses and compiler-owned dispatch identities.
+The exact header lane widths and dispatch encoding are backend choices derived from target layout,
+not source or MIR types.
+
+No target-tail-call feature is used: non-tail state lives in frames, and the driver loop itself is
+ordinary iteration. No exception, `setjmp`, JavaScript promise, or host callback represents typed
+control flow.
+
+### 6. Ownership plans frame initialization, resumption, and cleanup
+
+Liveness at the suspension point determines the frame payload. Copy locals are copied when needed;
+affine locals move exactly once into initialized slots; borrows move as dependencies whose roots
+remain live and immovable. Frame initialization is ordered so every prefix has a compiler-known
+rollback cleanup. The continuation becomes published to the driver only after the full payload is
+initialized.
+
+On child success or typed failure, the chosen resume path consumes the child payload once, runs the
+same MIR releases and loan endings the unsuspended path would run, and then drops remaining frame
+fields in lexical order before reclaiming storage. A typed failure cannot be returned to an outer
+handler until every exited continuation has completed its cleanup. Tests record one owner per
+level so missing, duplicate, or reordered cleanup is visible.
+
+Source traps and unrecoverable target defects preserve Silk's existing no-unwind contract: the
+design does not claim that source Drop hooks run. An orderly driver teardown that still has control
+may reclaim compiler-private raw frame blocks, but that bookkeeping is not reported as source
+cleanup and must never execute or duplicate source Drop. This keeps defect handling from silently
+creating stronger source semantics.
+
+### 7. Evaluation reuses the activation machine and preserves logical `CallDepth`
+
+The evaluator models the same suspension allocation and ownership events, but needs no second
+physical continuation stack. Its existing heap `ActivationRecord` stack is the logical stack. A
+suspension request retains the parent activation, pushes the deferred child, and resumes the parent
+with the typed result exactly as an ordinary generated call does.
+
+`maxCallDepth` continues to count active source-logical invocations. A parent retained across
+suspension remains one unit; its child adds one. Compiler-generated driver, allocation adapter, and
+resume helpers add zero logical units. Thus the default limit can block a program that is physically
+stack safe, and raising it permits the same program without risking JavaScript stack overflow. The
+blocked result's active path includes suspended parents and points at the attempted child boundary.
+
+A separate continuation-count limit is not introduced: it would overlap `CallDepth`, while actual
+storage exhaustion is already represented by `OutOfMemory`. Step accounting continues to count
+executed MIR operations, including explicit suspension and allocation operations.
+
+Alternatives rejected:
+
+- **Exclude suspended parents from `CallDepth`:** permits unbounded heap continuations despite the
+  existing definition of active invocation.
+- **Count private helper calls:** makes evaluator limits depend on implementation decomposition.
+- **Add a continuation limit now:** duplicates existing logical-depth and storage-exhaustion bounds.
+
+### 8. Existing source combinators need no pending-aware branch
+
+`map`, `flatMap`, `result`, `catch`, `retry`, and provision remain unchanged ordinary Silk control
+flow. Suspendability propagates through their specialized concrete call graphs. If a protected or
+selected Effect can suspend, its `run` becomes a suspendable MIR execution boundary and the
+combinator's locals after that run become ordinary continuation payload. Consequently `map` keeps
+its mapper and `flatMap` keeps the success callback state without either knowing a private pending
+representation.
+
+Conformance covers suspension before a mapper, suspension selected by `flatMap`, typed failure
+through `result` and `catch`, and provision where provider loans and acquired owners cross only the
+lexical boundaries already prescribed by their source definitions.
+
+### 9. Pay-for-use is proven at four layers
+
+Text scans are insufficient because nameless allocations or branches can remain. Tests use a
+pinned closed synchronous corpus and assert:
+
+1. **Reachability:** no concrete function is marked suspendable.
+2. **MIR:** no suspendable run, suspension point, continuation descriptor, or driver entry exists;
+   existing `RunStaticEffect` normalization verdicts and direct-call shape remain pinned.
+3. **LLVM:** parsed bitcode/IR and linked symbols contain no private driver, frame allocation,
+   resume dispatch, or complete-versus-transfer branch; the synchronous entry/call skeleton matches
+   the pinned fixture.
+4. **Wasm:** decoded sections/instructions/imports contain no driver function/table, continuation
+   allocation path, resume dispatch, or complete-versus-transfer branch; the synchronous entry/call
+   skeleton matches the pinned fixture.
+
+Positive suspendable fixtures assert the inverse so the absence checks cannot pass because
+inspection stopped recognizing the feature. Compiler-private symbol names and operation tags are
+central constants consumed by emitters and tests, not loose regex vocabulary.
+
+### 10. `Box` is characterization, not suspension acceptance
+
+Add three fixtures with equivalent chain length and payload, each classifying exactly one recursive
+phase on native release and Wasm:
+
+- **build:** construct recursively through the Effect and consume the completed chain with an
+  iterative `Box.into` teardown;
+- **walk:** construct iteratively, traverse through the recursive borrowed walk, and then use the
+  same iterative consuming teardown; and
+- **drop:** construct iteratively and trigger ordinary recursive `Box.drop` cleanup without a
+  recursive Effect build or walk.
+
+The iterative teardown releases every allocation normally. It does not suppress cleanup, retain a
+chain past process exit, or introduce a characterization-only leak.
+
+The fixture records success, process signal, host exception, or Wasm trap plus the tested depth and
+engine versions. It does not assert that `Effect.suspend` fixes any phase. A limiting ordinary walk,
+Drop, or the borrow-heavy Wasm `unreachable` is filed separately and remains outside this design.
+
+## Risks / Trade-offs
+
+- **[One allocation per suspension is expensive]** → The feature is explicit, non-suspending code
+  remains unchanged, and characterization will measure frame size and allocation counts before
+  considering a separate batching optimization.
+- **[Suspendability spreads through generic combinators]** → Compute it after concrete instance
+  discovery and pin deterministic fixed-point results for `map` and `flatMap` specializations.
+- **[Frame liveness or rollback bugs duplicate affine values]** → Make ownership-produced live sets
+  part of verified MIR and sweep every allocation/initialization failure ordinal with one tracked
+  owner per level.
+- **[Exclusive allocator access can conflict with the child]** → End the allocation call's provider
+  loan before publishing the transfer; retain only reclaim authority, and reject suspending
+  allocator implementations.
+- **[Private ABI divergence between native and Wasm]** → Compare typed outcomes, allocation/release
+  traces, frame logical layouts, and cleanup order against evaluation while allowing only physical
+  header differences.
+- **[Trap cleanup is misunderstood as guaranteed]** → Keep source trap tests negative: no Drop trace
+  is promised. Test private frame reclamation separately from source cleanup.
+- **[Pay-for-use assertions become vocabulary scans]** → Inspect parsed MIR, LLVM, Wasm sections,
+  instructions, symbols, imports, and a pinned synchronous call skeleton, with positive controls.
+- **[Deep acceptance tests are slow]** → Keep million/one-hundred-thousand release tests in the
+  release-candidate lane and use smaller structural tests in the ordinary suite.
+
+## Migration Plan
+
+1. Land Box phase-isolation and scalar exhaustion fixtures without changing runtime behavior.
+2. Add the intrinsic catalog entry, public source wrapper, row typing, suspendability analysis, and
+   target-neutral MIR behind verifier-complete tests.
+3. Add evaluator semantics and deterministic allocation-failure/`CallDepth` tests.
+4. Add native then Wasm private runners with three-engine outcome and cleanup parity tests.
+5. Strengthen pay-for-use inspection and enable deep release-candidate acceptance tests.
+6. Sync these delta specs only after implementation passes repository checks and
+   `pnpm release:candidate`.
+
+Before the implementation merges, rollback is removal of the new source API, intrinsic, MIR forms,
+and unreachable private runner code as one change. After release, the project remains pre-stable and
+may remove the API rather than preserve a faulty ABI; no serialized continuation or public ABI is
+promised.
+
+## Open Questions
+
+- The exact private intrinsic spelling may change during implementation as long as the catalog
+  contains exactly one operation and no public contract depends on that spelling.
+- The LLVM private header field order and Wasm resume-dispatch encoding are target-local choices to
+  settle with focused prototypes; they do not change MIR, source rows, cleanup, or pay-for-use
+  requirements.

--- a/openspec/changes/add-effect-suspension-boundary/proposal.md
+++ b/openspec/changes/add-effect-suspension-boundary/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Recursive Effects currently consume one native or host-Wasm call frame per logical invocation, so a
+terminating non-tail Effect can end in `SIGSEGV` or a host `RangeError` instead of producing its
+typed outcome. Silk needs an explicit suspension boundary now that deep source-defined Effect
+programs are practical, while preserving the synchronous shape and cost of programs that never use
+that boundary.
+
+## What Changes
+
+- Add public `Effect.suspend`, implemented in ordinary Silk over one minimal sealed `Intrinsic`
+  operation, to defer one Effect execution through a stack-safe compiler-owned continuation runner.
+- Make continuation storage explicit at the suspension boundary: `Effect.suspend` adds
+  `OutOfMemory` and an exclusive `Allocator` requirement, while Effects that cannot suspend keep
+  their existing rows and runtime shape.
+- Add a target-neutral MIR suspension operation and continuation descriptors. Native LLVM and
+  direct WebAssembly realize those descriptors with private iterative runners; the evaluator maps
+  them onto its existing heap activation machine.
+- Preserve logical `CallDepth` accounting, typed outcomes, ownership, and cleanup across suspended
+  self-recursion, mutual recursion, and ordinary `Effect.map` / `Effect.flatMap` composition.
+- Prove pay-for-use structurally: non-suspending programs contain no suspension MIR, private runner
+  ABI, continuation allocation path, or complete-versus-pending dispatch.
+- Add reproducible native and Wasm characterization that isolates deep `Box` chain construction,
+  traversal, and destruction. These measurements identify separate ordinary-recursion defects and
+  are not acceptance criteria for `Effect.suspend`.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `bootstrap-flow-functions`: Define `Effect.suspend`, its explicit channels, suspended recursion,
+  source-defined combinator composition, and the synchronous pay-for-use guarantee.
+- `bootstrap-intrinsic-boundary`: Admit exactly one minimal target-neutral suspension primitive and
+  prohibit name-based privilege for the public wrapper.
+- `bootstrap-mir`: Represent suspendable calls, continuation state, resume points, ownership, and
+  verification without target ABI details.
+- `bootstrap-backend`: Require bounded-stack private native and Wasm runners and absence of their
+  machinery from non-suspending artifacts.
+- `bootstrap-evaluation`: Preserve source-logical `CallDepth` and deterministic allocation behavior
+  while executing suspension through the heap activation machine.
+- `bootstrap-owned-allocation`: Route continuation storage through the existing explicit allocator,
+  typed `OutOfMemory`, and self-contained reclaim authority contract.
+- `bootstrap-ownership`: Transfer live values into continuation frames and clean each obligation
+  exactly once on every exit where the language promises cleanup.
+
+## Impact
+
+The change affects Effect intrinsic admission and elaboration, HIR/MIR lowering and verification,
+MIR normalization, evaluator activation records and traces, native LLVM emission, direct Wasm
+emission, ownership/cleanup planning, the shipped `silk.effects` source, runtime artifact inspection,
+and three-engine conformance tests. It introduces no scheduler, fiber, cancellation, public pending
+state, universal Effect interpreter, or automatic stack safety for ordinary functions and Drop
+hooks.

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-backend/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-backend/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Native and Wasm execute suspended Effects with bounded machine stack
+
+Native LLVM and direct WebAssembly SHALL realize target-neutral suspension as private iterative
+execution boundaries whose machine-stack usage is bounded by a constant independent of the number
+of active suspended logical invocations. A suspended child SHALL complete or suspend through the
+private runner, then resume its parent with the exact typed outcome and live continuation state.
+Neither backend MAY depend on LLVM `musttail`, WebAssembly tail-call instructions, host exception
+unwinding, a JavaScript promise, or recursive host calls to provide this guarantee.
+
+#### Scenario: Run deep non-tail suspension on native
+
+- **WHEN** a native release artifact executes one million non-tail recursive Effect levels separated by `Effect.suspend`
+- **THEN** it returns the expected result without `SIGSEGV` and without machine-stack growth proportional to the logical depth
+
+#### Scenario: Run deep non-tail suspension on Wasm
+
+- **WHEN** a direct Wasm artifact executes one hundred thousand non-tail recursive Effect levels separated by `Effect.suspend`
+- **THEN** it returns the expected result without a host `RangeError`, an `unreachable` trap, or host-stack growth proportional to the logical depth
+
+#### Scenario: Preserve typed failure through the private runner
+
+- **WHEN** a deep suspended child produces a typed failure
+- **THEN** native and Wasm resume and clean the same logical continuations as evaluation before returning the unchanged failure member and payload
+
+### Requirement: Suspension runner ABIs remain private and pay for use
+
+Continuation frame headers, resume discriminants, step results, driver loops, target function
+references, and storage layouts SHALL remain backend-private and unreachable from Silk source.
+A compiled program whose reachable MIR contains no suspension operation MUST NOT emit or link those
+forms, a continuation allocation path, or a complete-versus-pending branch, and its established
+synchronous entry and Effect-call artifact shape SHALL remain unchanged.
+
+#### Scenario: Inspect a non-suspending native artifact
+
+- **WHEN** a closed synchronous Effect program is compiled to native release bitcode
+- **THEN** structural inspection finds its established direct Effect calls and no suspension driver, continuation allocator, resume dispatch, or pending branch
+
+#### Scenario: Inspect a non-suspending Wasm artifact
+
+- **WHEN** the same closed synchronous Effect program is compiled to direct WebAssembly
+- **THEN** structural and linkage inspection finds no suspension table, driver, continuation allocation path, or pending branch
+

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-evaluation/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-evaluation/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Evaluation executes suspension through logical activations
+
+Evaluation SHALL execute explicit suspension by retaining the parent logical activation in its heap
+activation machine, evaluating the deferred child, and resuming the parent with the child's exact
+typed outcome. It SHALL model continuation allocation, initialization, ownership transfer, and
+release through the selected allocator with the same deterministic allocation ordinals and events
+as the native and Wasm engines. Evaluation MUST NOT recurse on the JavaScript stack or expose a
+pending value as a source result.
+
+#### Scenario: Complete deep suspension under raised limits
+
+- **WHEN** a terminating suspended Effect recursion is evaluated with step and call-depth limits above its logical work
+- **THEN** evaluation completes with the same result, allocation events, and cleanup trace as native and Wasm without depending on the JavaScript call stack
+
+#### Scenario: Sweep continuation allocation failure
+
+- **WHEN** deterministic allocation failure rejects each continuation allocation ordinal in turn
+- **THEN** evaluation returns `OutOfMemory` at that boundary, creates no owner for the rejected request, and cleans every previously created logical continuation exactly once
+
+## MODIFIED Requirements
+
+### Requirement: Evaluation limits are deterministic blocked data
+
+Evaluation SHALL accept positive maximum-step and maximum-call-depth limits with stable defaults.
+Each executed MIR operation consumes one step and each active source-logical invocation consumes one
+depth unit, including an invocation retained as a suspended heap continuation. Compiler-generated
+driver, resume, and storage helpers MUST NOT consume additional source-logical depth units.
+Exhaustion SHALL produce an `EvaluationLimit` blocked outcome naming `Steps` or `CallDepth`, the
+configured limit, the active function, the source span that attempted further work, and the complete
+active source-logical call identities. Evaluation MUST NOT depend on JavaScript stack overflow or
+wall-clock time.
+
+#### Scenario: Bound direct non-termination
+
+- **WHEN** a function recursively calls itself without reaching a base case
+- **THEN** evaluation blocks at the configured call-depth limit with a deterministic active call path
+
+#### Scenario: Bound suspended logical recursion
+
+- **WHEN** an Effect crosses suspension boundaries until another source-logical invocation would exceed `maxCallDepth`
+- **THEN** evaluation blocks with `CallDepth` at that exact boundary and reports every retained suspended invocation in the active call path
+
+#### Scenario: Bound an infinite loop
+
+- **WHEN** a reachable loop executes beyond the configured step limit
+- **THEN** evaluation blocks at the next operation with the `Steps` limit and exact operation span
+
+#### Scenario: Repeat a limited evaluation
+
+- **WHEN** an equivalent program is evaluated repeatedly under equal limits
+- **THEN** its blocked reason, active frames, source provenance, and trace are identical
+

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-flow-functions/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-flow-functions/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Effect suspension is explicit lazy composition
+
+The canonical ordinary Silk function
+`Effect.suspend<A, !E, ?R>(deferred: once Effect<A ! E ? R>)` SHALL defer execution of `deferred`
+until the returned Effect is run. Its result contract SHALL be
+`A ! E | OutOfMemory ? R | &mut Allocator`: continuation storage exhaustion is an explicit typed
+failure and allocator requirement only at a suspension boundary. The compiler MUST NOT recognize
+the public function by actor, module, or operation spelling.
+
+#### Scenario: Keep suspension lazy
+
+- **WHEN** an Effect with observable work is passed to `Effect.suspend` and the returned Effect is not run
+- **THEN** the deferred work does not execute and dropping the returned Effect releases its captures exactly once
+
+#### Scenario: Report continuation exhaustion explicitly
+
+- **WHEN** the selected allocator refuses storage for a continuation at `Effect.suspend`
+- **THEN** the suspended Effect fails with `OutOfMemory`, the deferred body does not start, and no continuation owner is created
+
+### Requirement: Explicitly suspended Effect cycles are stack safe
+
+A terminating self-recursive or mutually-recursive Effect cycle SHALL use native and WebAssembly
+machine stack bounded by a constant independent of logical recursion depth when every recursive
+cycle crosses `Effect.suspend`. The guarantee SHALL include non-tail work and owned state retained
+after the suspended child completes. Recursion that does not cross `Effect.suspend`, ordinary
+function recursion, and recursive Drop hooks SHALL receive no stack-safety guarantee.
+
+#### Scenario: Resume non-tail self-recursion
+
+- **WHEN** a recursive Effect suspends before its recursive run and adds one to the returned value at each of one million levels
+- **THEN** native execution returns the expected value without exhausting the machine stack
+
+#### Scenario: Resume mutual recursion
+
+- **WHEN** two Effects call each other through explicit suspension until a finite counter reaches zero
+- **THEN** native, WebAssembly, and evaluation produce the same typed result with machine-stack use bounded on native and WebAssembly
+
+#### Scenario: Exclude ordinary recursive cleanup
+
+- **WHEN** an ordinary Drop hook recursively destroys a deep heap-linked value without crossing an Effect suspension boundary
+- **THEN** this capability makes no stack-safety promise for that destruction
+
+### Requirement: Source-defined Effect combinators compose across suspension
+
+`Effect.map`, `Effect.flatMap`, outcome reification, recovery, retry, and provision SHALL compose
+with a suspended Effect through their existing ordinary Silk definitions and public signatures.
+They MUST NOT inspect or expose a pending state, continuation frame, driver token, or private runner
+ABI. The suspended Effect's existing failure and requirement rows, including `OutOfMemory` and
+`&mut Allocator`, SHALL compose by the ordinary row rules.
+
+#### Scenario: Map after suspension
+
+- **WHEN** a suspended Effect succeeds and its result is transformed with `Effect.map`
+- **THEN** the mapper runs once after resumption and receives the original success value
+
+#### Scenario: Flat-map into suspension
+
+- **WHEN** `Effect.flatMap` selects a suspended Effect from an input success
+- **THEN** execution waits for the suspended child and preserves the unioned failure and requirement rows without exposing a pending representation
+
+## MODIFIED Requirements
+
+### Requirement: Synchronous Effects retain a suspension-compatible abstraction
+
+The public Effect contract SHALL NOT expose a concrete callback ABI, scheduler object, continuation
+frame, runtime requirement record, or complete-or-suspended representation. A closed Effect call
+graph that cannot reach the suspension intrinsic MUST NOT contain continuation allocation,
+scheduler or fiber linkage, atomic synchronization, a mandatory complete-versus-pending branch, or
+a private suspension dispatcher. Existing source-defined combinators SHALL compose with
+suspendable Effects without changing their contracts or recognizing a private pending state.
+
+#### Scenario: Run a closed synchronous pipeline
+
+- **WHEN** a closed Effect call graph cannot reach suspension, fork, interruption, or a fiber observation
+- **THEN** execution retains its direct synchronous entry and call shape and links no continuation or concurrency runtime solely because it uses library Effect combinators
+
+#### Scenario: Preserve the runner seam under suspension
+
+- **WHEN** a source-defined combinator runs an Effect whose reachable call graph can suspend
+- **THEN** the compiler-owned execution boundary resumes the composition without changing the combinator's public signature or exposing a pending state
+

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-intrinsic-boundary/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-intrinsic-boundary/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: One target-neutral suspension primitive is admitted
+
+The sealed `Intrinsic` namespace SHALL contain exactly one safe Effect suspension operation whose
+contract transfers one deferred Effect to the compiler-owned execution boundary and later returns
+that Effect's typed outcome. The operation SHALL preserve generic success, failure, and requirement
+rows while explicitly adding `OutOfMemory` and exclusive `Allocator` access for continuation
+storage. It MUST NOT expose a continuation type, callback ABI, scheduler, fiber, pending token,
+target address, or backend frame layout.
+
+#### Scenario: Audit the suspension seam
+
+- **WHEN** the deterministic intrinsic catalog and its consumers are inspected
+- **THEN** exactly one suspension operation is present with evaluator, LLVM, and Wasm availability and no public continuation-management operations
+
+#### Scenario: Give a same-named function no privilege
+
+- **WHEN** user source defines `Effect.suspend` or another function with the same spelling as the canonical wrapper
+- **THEN** it receives ordinary function behavior unless its body explicitly calls the sealed intrinsic
+
+### Requirement: The public suspension API remains ordinary Silk
+
+The canonical `Effect.suspend` operation SHALL be a shipped ordinary Silk declaration over the
+single suspension intrinsic. Generic lifting, row composition, documentation, imports, navigation,
+and reusable composition policy MUST remain in source and MUST NOT be selected by standard-library
+module identity.
+
+#### Scenario: Navigate to Effect.suspend
+
+- **WHEN** tooling resolves a call to canonical `Effect.suspend`
+- **THEN** it navigates to shipped Silk source whose only compiler privilege is its explicit sealed intrinsic call
+

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-mir/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-mir/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: MIR represents suspension and continuation state target-neutrally
+
+MIR SHALL represent an explicit suspension boundary with the deferred Effect runner, arguments,
+typed outcome, stable resume point, live logical values, capture access, provider references, and
+cleanup obligations needed after resumption. Continuation descriptors SHALL use canonical logical
+types and compiler-planned layouts while omitting native addresses, WebAssembly table indexes,
+target blocks, branch depths, allocator implementations, scheduler objects, and public pending
+values. Each function's structured control regions SHALL remain acyclic even when the module call
+graph contains suspended self- or mutual-recursion cycles.
+
+#### Scenario: Retain state after a suspended child
+
+- **WHEN** a non-tail Effect keeps an affine owner and a scalar local across a suspended recursive run
+- **THEN** MIR names both live values, their ownership transfer, the child outcome, the resume point, and the exact cleanup obligations without choosing a target ABI
+
+#### Scenario: Encode mutual suspended recursion deterministically
+
+- **WHEN** equivalent mutually recursive Effects are lowered in repeated fresh processes
+- **THEN** their suspension operations, continuation descriptors, resume identities, logical layouts, and cleanup plans encode byte-identically
+
+### Requirement: MIR verifies suspension completeness and ownership
+
+MIR verification SHALL reject a suspension whose deferred runner or typed outcome disagrees with
+the call contract; whose resume point is missing or ambiguous; whose live value is omitted,
+duplicated, or assigned incompatible access; whose continuation layout is incomplete; or whose
+success and failure resumes do not preserve cleanup and propagation. Verification SHALL also reject
+private continuation forms in a program whose reachable MIR contains no suspension operation.
+
+#### Scenario: Reject a missing live owner
+
+- **WHEN** hand-built MIR suspends while an affine local remains needed after resumption but omits that local from its continuation descriptor
+- **THEN** verification reports the missing continuation ownership before evaluation or backend emission
+
+#### Scenario: Reject suspension machinery without suspension
+
+- **WHEN** a MIR module contains a continuation descriptor or private suspension entry but no reachable suspension operation
+- **THEN** verification rejects the unused machinery instead of allowing a hidden runtime cost
+

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-owned-allocation/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-owned-allocation/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Continuation storage uses explicit typed allocation
+
+Each `Effect.suspend` boundary that requires retained continuation state SHALL request a validated
+compiler-planned layout through the active exclusive `Allocator` service requirement. A successful
+request SHALL produce one self-contained affine reclaim obligation owned privately by the
+continuation; exhaustion SHALL produce the allocation-free typed failure `OutOfMemory`. The
+compiler and backends MUST NOT use a hidden allocator, select an allocator implementation, convert
+exhaustion to a trap, or add allocation failure and allocator requirements to Effects that cannot
+reach suspension. A provider implementation selected to allocate continuation storage MUST have a
+closed call graph that cannot itself reach suspension; analysis SHALL reject a selected provider
+that would recursively require continuation storage in order to allocate continuation storage.
+
+#### Scenario: Observe continuation allocation through a source allocator
+
+- **WHEN** a suspended recursive Effect runs with a source-defined counting allocator
+- **THEN** every successful continuation request and release is observed through that allocator's ordinary service contract
+
+#### Scenario: End allocator access before running the child
+
+- **WHEN** continuation allocation succeeds and the deferred Effect also requires exclusive allocator access
+- **THEN** the allocation call's provider loan ends before the deferred child starts, while the continuation retains only self-contained reclaim authority
+
+#### Scenario: Reject one continuation request atomically
+
+- **WHEN** the selected allocator refuses a valid continuation layout
+- **THEN** the boundary fails with `OutOfMemory` without starting the deferred child, publishing a partial continuation, or creating a reclaim obligation
+
+#### Scenario: Keep synchronous Effects allocation-free
+
+- **WHEN** an Effect call graph cannot reach the suspension intrinsic
+- **THEN** no continuation storage request is made and no `OutOfMemory` or `Allocator` row is added because suspension exists elsewhere in the program
+
+#### Scenario: Reject a recursively suspending continuation allocator
+
+- **WHEN** the allocator implementation selected for continuation storage can reach `Effect.suspend`
+- **THEN** analysis rejects that provider selection before MIR or backend emission
+
+### Requirement: Continuation storage releases through captured authority
+
+A successfully initialized continuation SHALL retain its own unforgeable reclaim authority and
+MUST NOT retain or rediscover the allocator provider after the allocation call ends. Its storage
+SHALL release exactly once after its live values have been moved onward or cleaned, including when
+the resumed computation returns normally or propagates typed failure. A target trap retains the
+existing no-cleanup guarantee.
+
+#### Scenario: Release after provider borrow ends
+
+- **WHEN** a continuation remains active after its allocator call's provider borrow ends
+- **THEN** eventual cleanup releases storage exactly once through captured reclaim authority without consulting the provider again

--- a/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-ownership/spec.md
+++ b/openspec/changes/add-effect-suspension-boundary/specs/bootstrap-ownership/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Suspension transfers one ownership obligation per live value
+
+At a suspension boundary, ownership SHALL derive the exact live set needed after the deferred child
+completes. Copy values MAY be copied; affine values SHALL move into one continuation slot; and
+shared or exclusive borrows and provider references SHALL retain their existing lexical
+dependencies until resumption or exit. A value MUST NOT remain independently owned by both the
+suspended activation and its continuation frame.
+
+#### Scenario: Hold one owner per recursive level
+
+- **WHEN** every level of a suspended recursive Effect creates one affine owner used after its child completes
+- **THEN** ownership moves each owner into exactly one continuation slot and rejects any duplicate use from the suspended activation
+
+#### Scenario: Retain an exclusive provider dependency
+
+- **WHEN** a suspended Effect holds an exclusive provider reference across its deferred child
+- **THEN** ownership keeps the provider immovable and exclusively borrowed until the continuation resumes and ends the loan
+
+### Requirement: Continuation cleanup preserves structured-exit semantics
+
+On successful resumption, ordinary return, fallthrough, explicit structured exit, or typed failure,
+each continuation SHALL move or clean every live source value exactly once in the existing lexical
+order, then consume its private storage obligation exactly once without replacing the original
+typed outcome. If continuation allocation fails before transfer, the current activation SHALL
+retain and clean its values normally. A source trap or target defect that cannot return to the
+runner SHALL retain the existing no-unwind guarantee: it MUST NOT report that source Drop ran or
+duplicate an obligation. Any compiler-private continuation storage reached by an orderly runner
+teardown after an internal defect SHALL be consumed exactly once without being reported as source
+cleanup.
+
+#### Scenario: Clean deep success in order
+
+- **WHEN** suspended recursion succeeds while every level retains one owner
+- **THEN** owners release exactly once in the same inner-to-outer order as the equivalent unsuspended execution
+
+#### Scenario: Clean deep typed failure in order
+
+- **WHEN** an inner suspended level fails with a typed payload while outer levels retain owners
+- **THEN** every exited level releases its owner exactly once before the unchanged failure reaches its handler
+
+#### Scenario: Preserve trap semantics
+
+- **WHEN** a resumed suspended computation reaches a source trap
+- **THEN** the runner exposes no typed failure or successful Drop trace and makes no claim that normal source cleanup ran
+

--- a/openspec/changes/add-effect-suspension-boundary/tasks.md
+++ b/openspec/changes/add-effect-suspension-boundary/tasks.md
@@ -1,0 +1,52 @@
+## 1. Design Gate and Characterization
+
+- [x] 1.1 Add a reproducible scalar non-tail Effect fixture that records native release, direct Wasm, and raised-limit evaluator behavior before suspension is implemented.
+- [x] 1.2 Add separate native release and direct Wasm fixtures for deep `Box` chain build, walk, and drop, ensuring each measured process excludes the other two phases and records success, signal, host exception, or trap with engine versions.
+- [x] 1.3 Run the Box phase matrix, publish the results with the fixture, and open separate defects for every limiting ordinary walk, recursive Drop, or borrow-heavy Wasm `unreachable`; do not add those failures to `Effect.suspend` acceptance.
+- [ ] 1.4 Obtain explicit approval of this proposal, delta specs, allocation policy, evaluator accounting, and private-runner design before starting task group 2.
+
+## 2. Intrinsic and Source Surface
+
+- [ ] 2.1 Add exactly one safe generic Effect suspension operation to the sealed intrinsic catalog with evaluator, LLVM, and Wasm availability, widened `OutOfMemory ? &mut Allocator` rows, and inventory/hover/completion verification.
+- [ ] 2.2 Add the ordinary Silk `Effect.suspend` wrapper with the exact widened public signature, regenerate the embedded standard-library artifact, and verify navigation resolves to source rather than compiler-known spelling.
+- [ ] 2.3 Add analysis tests proving a same-named user function receives no privilege and that the continuation-storage allocator implementation must have a closed non-suspendable call graph.
+
+## 3. Suspendability and Target-Neutral MIR
+
+- [ ] 3.1 Compute deterministic suspendability after concrete instance discovery as a fixed point over direct calls, callable applications, and Effect runner edges; cover self cycles, mutual cycles, and generic `map`/`flatMap` specializations.
+- [ ] 3.2 Extend ownership liveness at explicit suspension points to classify every post-resume local as Copy, borrowed dependency, or affine transfer and to produce initialization rollback plus success/failure cleanup plans.
+- [ ] 3.3 Add target-neutral MIR suspendable-run operations, suspension points, stable resume identities, continuation descriptors, logical layouts, typed outcome mappings, provider arguments, loan endings, and releases.
+- [ ] 3.4 Update MIR normalization so `RunStaticEffect` remains eligible only for proven non-suspendable runners and unknown/suspendable candidates retain the appropriate run representation without a global suspension mode.
+- [ ] 3.5 Extend MIR encoding, walking, local-use accounting, and verification; add deterministic round-trip and malformed-MIR tests for missing live owners, incompatible runners/outcomes, invalid resumes, and suspension machinery without reachable suspension.
+
+## 4. Continuation Allocation and Evaluation
+
+- [ ] 4.1 Plan one validated target layout per continuation, including the private header and compiler-planned live payload, with transactional initialization and prefix rollback before publication.
+- [ ] 4.2 Route continuation acquisition through the selected `&mut Allocator`, end its exclusive provider loan before child execution, retain only self-contained reclaim authority, and test nested suspension that reborrows the allocator.
+- [ ] 4.3 Add allocation-failure sweep tests proving rejected requests create no child execution or owner and every previously initialized continuation and source owner cleans exactly once without replacing `OutOfMemory`.
+- [ ] 4.4 Teach the evaluator activation machine to execute suspension, model continuation allocation/release events, and resume success or typed failure without JavaScript recursion or a source-visible pending value.
+- [ ] 4.5 Preserve logical `CallDepth`: suspended parents remain active, children add one unit, private helpers add none, and blocked data/traces identify the full suspended source call path deterministically.
+
+## 5. Native and WebAssembly Runners
+
+- [ ] 5.1 Prototype and pin the LLVM private step-entry, continuation-header, and iterative driver ABI against the target-neutral descriptors without changing synchronous runner ABIs.
+- [ ] 5.2 Implement LLVM transfer, complete, resume, typed-failure propagation, frame payload cleanup, and reclaim paths with no recursive driver calls, tail-call dependency, exception unwinding, or `setjmp`/`longjmp`.
+- [ ] 5.3 Prototype and pin the Wasm private step-entry, linear-memory frame header, dispatch identity, and iterative driver protocol without changing synchronous runner ABIs.
+- [ ] 5.4 Implement Wasm transfer, complete, resume, typed-failure propagation, frame payload cleanup, and reclaim paths with no recursive host calls, JavaScript promise, tail-call dependency, host `RangeError`, or `unreachable` on valid suspended execution.
+- [ ] 5.5 Add three-engine parity tests for scalar non-tail self-recursion, mutual recursion, state retained after `run`, success, typed failure, allocator exhaustion, allocation/release counts, and cleanup order.
+
+## 6. Composition and Ownership Conformance
+
+- [ ] 6.1 Add `Effect.map` conformance tests where suspension precedes mapping and verify the mapper and its captures resume and clean exactly once without changing the source combinator.
+- [ ] 6.2 Add `Effect.flatMap` conformance tests where the callback selects a suspended Effect and verify unioned failure/requirement rows, callback ownership, and cleanup.
+- [ ] 6.3 Add suspended outcome-reification, recovery, retry, and provision tests, including provider acquisition and exclusive-provider loan lifetimes across resumption.
+- [ ] 6.4 Add tracked-owner tests for deep success and injected typed failure, asserting inner-to-outer exactly-once source cleanup, followed by exactly-once private continuation reclamation.
+- [ ] 6.5 Add trap/defect tests that preserve the no-source-unwind contract and distinguish any orderly private frame reclamation from source Drop observations.
+
+## 7. Pay-for-Use and Acceptance
+
+- [ ] 7.1 Strengthen the synchronous Effect cost suite with positive controls and concrete suspendability/MIR assertions: no suspendable instances, suspension operations, continuation descriptors, driver entries, or changes to pinned `RunStaticEffect` verdicts and direct-call shape.
+- [ ] 7.2 Inspect parsed LLVM IR/bitcode and linked symbols for a pinned non-suspending corpus, proving absence of continuation allocation, driver, resume dispatch, complete-versus-transfer branch, and synchronous entry-shape drift.
+- [ ] 7.3 Inspect decoded Wasm sections, imports, functions, tables, and instructions for the same corpus, proving absence of continuation allocation, driver, resume dispatch, complete-versus-transfer branch, and synchronous entry-shape drift.
+- [ ] 7.4 Add release-candidate acceptance for the correct scalar non-tail result at depth 1,000,000 on native release and 100,000 on direct Wasm, plus raised-limit evaluator parity and default deterministic `CallDepth` blockage.
+- [ ] 7.5 Run `pnpm typecheck`, `pnpm exec biome check .`, `pnpm test`, `pnpm check`, `pnpm release:candidate`, and `openspec validate add-effect-suspension-boundary --strict`; report any pre-existing failure exactly before handoff.

--- a/packages/compiler/test/SynchronousEffectCost.test.ts
+++ b/packages/compiler/test/SynchronousEffectCost.test.ts
@@ -8,9 +8,22 @@ interface Structure {
   readonly calls: number
   readonly branches: number
   readonly allocations: number
+  readonly allocationSites: ReadonlyArray<string>
   readonly indirectCalls: number
   readonly suspensionTerms: number
   readonly effectTerms: number
+}
+
+interface EntryStructure extends Structure {
+  readonly abi?: {
+    readonly parameters: ReadonlyArray<string>
+    readonly results: ReadonlyArray<string>
+  }
+}
+
+interface TagCount {
+  readonly tag: string
+  readonly count: number
 }
 
 interface RunnerClassification {
@@ -53,19 +66,32 @@ interface CostCase {
   }
   readonly runners: ReadonlyArray<RunnerClassification>
   readonly pipeTokens: { readonly hir: number; readonly mir: number }
+  readonly mirOperationTags: ReadonlyArray<TagCount>
+  readonly suspensionOperationTags: ReadonlyArray<TagCount>
   readonly mir: Structure
   readonly optimizedLlvm: Structure
-  readonly optimizedLlvmEntry: Structure
+  readonly optimizedLlvmEntry: EntryStructure
   readonly assembly: Structure
   readonly assemblyEntry: Structure
   readonly wasm: Structure & { readonly binaryBytes: number }
-  readonly wasmEntry: Structure
+  readonly wasmEntry: EntryStructure
   readonly unnormalizedWasm: Structure & { readonly binaryBytes: number }
-  readonly unnormalizedWasmEntry: Structure
+  readonly unnormalizedWasmEntry: EntryStructure
+  readonly symbols: {
+    readonly native: ReadonlyArray<string>
+    readonly wasm: ReadonlyArray<string>
+  }
+  readonly linkage: {
+    readonly nativeRuntime: ReadonlyArray<string>
+    readonly nativeDeclarations: ReadonlyArray<string>
+    readonly wasmImports: ReadonlyArray<string>
+    readonly unnormalizedWasmImports: ReadonlyArray<string>
+  }
+  readonly suspensionLinkage: ReadonlyArray<string>
 }
 
 interface CostReport {
-  readonly schema: 1
+  readonly schema: 2
   readonly clang: string
   readonly node: string
   readonly cases: ReadonlyArray<CostCase>
@@ -83,7 +109,7 @@ it('captures synchronous Effect costs deterministically in fresh processes', () 
   assert.strictEqual(first.stdout, second.stdout)
 
   const report = JSON.parse(first.stdout) as CostReport
-  assert.strictEqual(report.schema, 1)
+  assert.strictEqual(report.schema, 2)
   assert.match(report.clang, /clang version/)
   assert.strictEqual(report.cases.length, 18)
   assert.deepEqual(
@@ -108,6 +134,13 @@ it('captures synchronous Effect costs deterministically in fresh processes', () 
     assert.strictEqual(sample.behavior.unnormalizedWasm, sample.expected, sample.id)
     assert.strictEqual(sample.pipeTokens.hir, 0, sample.id)
     assert.strictEqual(sample.pipeTokens.mir, 0, sample.id)
+    // This is derived from the MIR object graph, so a suspension operation cannot hide behind an
+    // encoder spelling change. The fixture's centralized reserved vocabulary classifies new tags.
+    assert.isAbove(sample.mirOperationTags.length, 0, sample.id)
+    assert.deepEqual(sample.suspensionOperationTags, [], sample.id)
+    // These values come from backend symbol tables, native-runtime requirements, LLVM
+    // declarations, and Wasm imports. An unreferenced but linked suspension component is covered.
+    assert.deepEqual(sample.suspensionLinkage, [], sample.id)
     assert.strictEqual(sample.mir.suspensionTerms, 0, sample.id)
     assert.strictEqual(sample.optimizedLlvm.suspensionTerms, 0, sample.id)
     assert.strictEqual(sample.optimizedLlvmEntry.suspensionTerms, 0, sample.id)
@@ -117,6 +150,14 @@ it('captures synchronous Effect costs deterministically in fresh processes', () 
     assert.strictEqual(sample.wasmEntry.suspensionTerms, 0, sample.id)
     assert.strictEqual(sample.unnormalizedWasm.suspensionTerms, 0, sample.id)
     assert.strictEqual(sample.unnormalizedWasmEntry.suspensionTerms, 0, sample.id)
+    // A synchronous entry has no indirect dispatcher. Direct calls remain valid for ordinary
+    // user code and Effect runners.
+    assert.strictEqual(sample.optimizedLlvmEntry.indirectCalls, 0, sample.id)
+    assert.strictEqual(sample.wasmEntry.indirectCalls, 0, sample.id)
+    assert.strictEqual(sample.unnormalizedWasmEntry.indirectCalls, 0, sample.id)
+    assert.isDefined(sample.optimizedLlvmEntry.abi, sample.id)
+    assert.isDefined(sample.wasmEntry.abi, sample.id)
+    assert.isDefined(sample.unnormalizedWasmEntry.abi, sample.id)
     assert.isAbove(sample.wasm.binaryBytes, 0, sample.id)
     assert.isAbove(sample.unnormalizedWasm.binaryBytes, 0, sample.id)
     if (sample.applicability === 'DirectStaticRun') {
@@ -173,7 +214,30 @@ it('captures synchronous Effect costs deterministically in fresh processes', () 
     assert.isDefined(baseline, pair)
     assert.isDefined(effect, pair)
     if (baseline === undefined || effect === undefined) continue
-    assert.isAtLeast(effect.optimizedLlvm.allocations, 0, pair)
-    assert.isAtLeast(effect.wasm.allocations, 0, pair)
+    // Compare semantic entry properties with an imperative program that performs the same work.
+    // This avoids platform-dependent instruction snapshots while proving that merely using a
+    // non-suspending Effect adds no allocation path or mandatory complete-vs-pending branch.
+    assert.isAtMost(
+      effect.optimizedLlvmEntry.allocations,
+      baseline.optimizedLlvmEntry.allocations,
+      pair,
+    )
+    assert.isAtMost(effect.wasmEntry.allocations, baseline.wasmEntry.allocations, pair)
+    assert.isAtMost(
+      effect.unnormalizedWasmEntry.allocations,
+      baseline.unnormalizedWasmEntry.allocations,
+      pair,
+    )
+    assert.isAtMost(effect.optimizedLlvmEntry.branches, baseline.optimizedLlvmEntry.branches, pair)
+    assert.isAtMost(effect.wasmEntry.branches, baseline.wasmEntry.branches, pair)
+    assert.isAtMost(
+      effect.unnormalizedWasmEntry.branches,
+      baseline.unnormalizedWasmEntry.branches,
+      pair,
+    )
+    // The exported entry keeps the same parameter/result ABI; no pending result is exposed.
+    assert.deepEqual(effect.optimizedLlvmEntry.abi, baseline.optimizedLlvmEntry.abi, pair)
+    assert.deepEqual(effect.wasmEntry.abi, baseline.wasmEntry.abi, pair)
+    assert.deepEqual(effect.unnormalizedWasmEntry.abi, baseline.unnormalizedWasmEntry.abi, pair)
   }
 }, 180_000)

--- a/packages/compiler/test/characterization/effect-suspend-stack/README.md
+++ b/packages/compiler/test/characterization/effect-suspend-stack/README.md
@@ -1,0 +1,51 @@
+# Effect suspension stack characterization
+
+This fixture records the pre-`Effect.suspend` recursion boundary independently for four shapes:
+
+- `scalar-non-tail`: scalar non-tail recursive Effect execution;
+- `box-build`: recursive Effect construction followed by iterative consuming teardown;
+- `box-walk`: iterative construction, recursive borrowed traversal, then iterative consuming teardown;
+- `box-drop`: iterative construction followed by ordinary recursive `Box.drop` cleanup.
+
+The iterative teardown used by `box-build` and `box-walk` consumes every link through `Box.into`,
+so every allocation is released normally without adding recursive `Box.drop` to those measured
+paths. The fixture does not suppress cleanup or intentionally leak storage.
+
+Run it after building the compiler:
+
+```sh
+pnpm --filter @silk-effect/compiler build
+node packages/compiler/test/characterization/effect-suspend-stack/characterize.mjs \
+  --engine wasm --case scalar-non-tail --depth 8000
+```
+
+`--engine` accepts `native`, `wasm`, or `evaluator`. `--case` accepts `scalar-non-tail`,
+`box-build`, `box-walk`, or `box-drop`. Add `--expect completed`, `--expect
+host-stack-exhaustion`, or another reported outcome kind to make one invocation an assertion.
+
+Each invocation prints one JSON record containing the engine, case, depth, outcome, elapsed time,
+and host versions. Stack thresholds are host properties: compare shapes within one pinned host and
+record the host metadata instead of treating one machine's depth as universal.
+
+## Local phase-attribution sample
+
+Measured on arm64 Darwin with Node 26.5.0 and Homebrew clang 22.1.8:
+
+| engine | case | depth | outcome |
+|---|---|---:|---|
+| Wasm | scalar non-tail | 1,000 | completed |
+| Wasm | scalar non-tail | 8,000 | host stack exhaustion (`RangeError`) |
+| Wasm | Box build | 1,000 | host stack exhaustion (`RangeError`) |
+| Wasm | Box walk | 1,000 | completed |
+| Wasm | Box drop | 1,000 | completed |
+| Wasm | Box walk | 4,000 | host stack exhaustion (`RangeError`) |
+| Wasm | Box drop | 4,000 | host stack exhaustion (`RangeError`) |
+| native release | Box build | 1,000 | completed |
+| native release | Box walk | 1,000 | completed |
+| native release | Box drop | 1,000 | completed |
+
+This sample attributes the earliest local Wasm failure to recursive Effect construction, while
+also confirming that ordinary recursive walk and recursive Drop have independent later limits.
+The Linux/Node 22 `unreachable` reported at a walk depth near 1,000 did not reproduce on this host;
+it remains a separate environment-sensitive defect rather than an `Effect.suspend` acceptance
+criterion.

--- a/packages/compiler/test/characterization/effect-suspend-stack/characterize.mjs
+++ b/packages/compiler/test/characterization/effect-suspend-stack/characterize.mjs
@@ -1,0 +1,259 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../../../dist/Analysis.js'
+import * as Driver from '../../../dist/Driver.js'
+import * as SourceFile from '../../../dist/SourceFile.js'
+import * as SourceResolver from '../../../dist/SourceResolver.js'
+
+const encoder = new TextEncoder()
+
+const argument = (name) => {
+  const index = process.argv.indexOf(name)
+  return index < 0 ? undefined : process.argv.at(index + 1)
+}
+
+const engine = argument('--engine')
+const shape = argument('--case')
+const depthText = argument('--depth')
+const expected = argument('--expect')
+
+if (engine !== 'native' && engine !== 'wasm' && engine !== 'evaluator') {
+  throw new Error('--engine must be native, wasm, or evaluator')
+}
+if (!['scalar-non-tail', 'box-build', 'box-walk', 'box-drop'].includes(shape)) {
+  throw new Error('--case must be scalar-non-tail, box-build, box-walk, or box-drop')
+}
+const depth = Number(depthText)
+if (!Number.isSafeInteger(depth) || depth <= 0 || depth > 2_000_000_000) {
+  throw new Error('--depth must be a positive i32')
+}
+
+const scalarSource = `effect fn count(value: i32) -> i32 {
+  if value == 0 { return 0 }
+  let inner = run count(value - 1)
+  return inner + 1
+}
+
+pub fn main() -> i32 {
+  let answer = run count(${depth})
+  if answer == ${depth} { return 42 }
+  return 1
+}`
+
+const boxSource = `import silk.box {
+  Box,
+  make as boxMake,
+  get as boxGet,
+  into as boxInto
+}
+
+pub struct End {}
+
+pub struct Link {
+  next: Box<Chain>
+}
+
+pub struct Chain {
+  step: End | Link
+  value: i32
+}
+
+effect fn recursiveBuild(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  if depth == 0 { return Chain { step: End {}, value: 0 } }
+  let inner = run recursiveBuild(depth - 1)
+  let boxed = run boxMake<Chain>(move inner)
+  return Chain { step: Link { next: move boxed }, value: 1 }
+}
+
+effect fn iterativeBuild(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  let mut current = Chain { step: End {}, value: 0 }
+  let mut index = 0
+  while index < depth {
+    let boxed = run boxMake<Chain>(move current)
+    current = Chain { step: Link { next: move boxed }, value: 1 }
+    index = index + 1
+  }
+  return move current
+}
+
+// Characterization-only teardown: consume one link at a time so build and walk measurements do
+// not accidentally exercise recursive Box.drop. Every allocation still releases normally.
+fn iterativeDrop(chain: Chain) -> () {
+  let mut current = move chain
+  let mut complete = false
+  while complete == false {
+    complete = consumeStep(&mut current)
+  }
+  return ()
+}
+
+fn consumeStep(current: &mut Chain) -> bool {
+  let step = Intrinsic.replace(current.step, End {})
+  return match move step {
+    End nothing => true
+    Link { next } => continueWith(move current, move next)
+  }
+}
+
+fn continueWith(current: &mut Chain, next: Box<Chain>) -> bool {
+  let mut replacement = boxInto<Chain>(move next)
+  let replacementStep = Intrinsic.replace(replacement.step, End {})
+  let previousStep = Intrinsic.replace(current.step, move replacementStep)
+  drop previousStep
+  current.value = replacement.value
+  drop replacement
+  return false
+}
+
+fn walk(self: &Chain) -> i32 {
+  return self.value + match &self.step {
+    End nothing => 0
+    Link { next } => walkBox(boxGet<Chain>(&next))
+  }
+}
+
+fn walkBox(view: &[Chain]) -> i32 {
+  return match &view[usize.ZERO] {
+    Chain { step, value } => value + match &step {
+      End nothing => 0
+      Link { next } => walkBox(boxGet<Chain>(&next))
+    }
+  }
+}
+
+effect fn buildOnly() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run recursiveBuild(${depth}) |> Effect.provideMut(&mut allocator)
+  iterativeDrop(move built)
+  return 42
+}
+
+effect fn walkOnly() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run iterativeBuild(${depth}) |> Effect.provideMut(&mut allocator)
+  let answer = walk(&built)
+  iterativeDrop(move built)
+  if answer == ${depth} { return 42 }
+  return 1
+}
+
+effect fn dropOnly() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run iterativeBuild(${depth}) |> Effect.provideMut(&mut allocator)
+  drop built
+  return 42
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 2 }
+
+pub fn main() -> i32 {
+  return run Effect.catch(${shape === 'box-build' ? 'buildOnly()' : shape === 'box-walk' ? 'walkOnly()' : 'dropOnly()'}, recover)
+}`
+
+const source = shape === 'scalar-non-tail' ? scalarSource : boxSource
+const sourceId = `characterization/effect-suspend-stack/${shape}-${engine}-${depth}`
+const temporary = mkdtempSync(join(tmpdir(), 'silk-effect-suspend-stack-'))
+
+const classifyWasm = (cause) => {
+  if (cause instanceof RangeError) return 'host-stack-exhaustion'
+  if (cause instanceof WebAssembly.RuntimeError) return 'wasm-trap'
+  return 'host-error'
+}
+
+try {
+  const startedAt = performance.now()
+  let outcome
+  if (engine === 'evaluator') {
+    const snapshot = await Effect.runPromise(
+      Analysis.ofSourceRealized(sourceId, encoder.encode(source), 'aarch64-apple-darwin'),
+    )
+    const diagnostics = Analysis.diagnostics(snapshot)
+    if (diagnostics.length > 0) {
+      throw new Error(`Silk diagnostics: ${JSON.stringify(diagnostics)}`)
+    }
+    const evaluated = Analysis.evaluate(snapshot, {
+      maxSteps: Math.max(1_000_000, depth * 10_000),
+      maxCallDepth: Math.max(1_024, depth + 16),
+    })
+    outcome =
+      evaluated._tag === 'Completed'
+        ? Object.freeze({ kind: 'completed', result: evaluated.result.value })
+        : Object.freeze({
+            kind: evaluated._tag === 'Blocked' ? 'evaluation-blocked' : 'evaluation-failure',
+            outcome: evaluated,
+          })
+  } else if (engine === 'wasm') {
+    const snapshot = await Effect.runPromise(
+      Analysis.ofSourceRealized(sourceId, encoder.encode(source), 'wasm32-unknown-unknown'),
+    )
+    const diagnostics = Analysis.diagnostics(snapshot)
+    if (diagnostics.length > 0) {
+      throw new Error(`Silk diagnostics: ${JSON.stringify(diagnostics)}`)
+    }
+    const artifact = await Effect.runPromise(Analysis.codegenWasm(snapshot, { mode: 'release' }))
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(artifact.bytes.slice()), {})
+    const main = instance.exports.silk_main
+    if (typeof main !== 'function') throw new Error('missing Wasm silk_main export')
+    try {
+      const result = main()
+      outcome = Object.freeze({ kind: 'completed', result })
+    } catch (cause) {
+      outcome = Object.freeze({
+        kind: classifyWasm(cause),
+        error: cause instanceof Error ? `${cause.name}: ${cause.message}` : String(cause),
+      })
+    }
+  } else {
+    const destination = join(temporary, `${shape}-${depth}`)
+    const compiled = await Effect.runPromise(
+      Driver.compile({
+        compilation: { root: SourceFile.make(sourceId, encoder.encode(source)) },
+        toolchain: Object.freeze({
+          _tag: 'Toolchain',
+          clang: process.env.SILK_EFFECT_STACK_CLANG ?? '/usr/bin/clang',
+        }),
+        profile: 'release',
+        destination,
+      }).pipe(Effect.provide(SourceResolver.empty)),
+    )
+    if (compiled._tag !== 'Compiled') {
+      throw new Error(`native compilation failed: ${JSON.stringify(compiled)}`)
+    }
+    const run = spawnSync(compiled.path, [], { encoding: 'utf8', timeout: 60_000 })
+    outcome = Object.freeze({
+      kind:
+        run.status === 42
+          ? 'completed'
+          : run.signal === 'SIGSEGV'
+            ? 'host-stack-exhaustion'
+            : run.error?.code === 'ETIMEDOUT'
+              ? 'timeout'
+              : run.signal === null
+                ? 'unexpected-exit'
+                : 'host-signal',
+      status: run.status,
+      signal: run.signal,
+      stderr: run.stderr,
+    })
+  }
+
+  const report = Object.freeze({
+    schema: 1,
+    engine,
+    case: shape,
+    depth,
+    outcome,
+    elapsedMs: Math.round(performance.now() - startedAt),
+    host: Object.freeze({ platform: process.platform, arch: process.arch, node: process.version }),
+  })
+  process.stdout.write(`${JSON.stringify(report)}\n`)
+  if (expected !== undefined && outcome.kind !== expected) {
+    process.stderr.write(`expected ${expected}, received ${outcome.kind}\n`)
+    process.exitCode = 1
+  }
+} finally {
+  rmSync(temporary, { recursive: true, force: true })
+}

--- a/packages/compiler/test/fixtures/synchronous-effect-cost.mjs
+++ b/packages/compiler/test/fixtures/synchronous-effect-cost.mjs
@@ -11,6 +11,21 @@ import * as Mir from '../../dist/Mir.js'
 const encoder = new TextEncoder()
 const hash = (value) => createHash('sha256').update(value).digest('hex')
 const occurrences = (text, pattern) => [...text.matchAll(pattern)].length
+const suspensionVocabulary = Object.freeze([
+  'suspend',
+  'suspended',
+  'continuation',
+  'scheduler',
+  'fiber',
+  'dispatch',
+  'resume',
+  'trampoline',
+  'pending',
+  'atomic',
+])
+const suspensionTerm = new RegExp(`(?:${suspensionVocabulary.join('|')})`, 'i')
+const containsSuspensionTerm = (value) =>
+  suspensionTerm.test(value.replaceAll(/\bsuspended=false\b/gi, ''))
 const normalize = (text) =>
   text
     .replaceAll(/cost\/[a-z0-9-]+\/(?:native|wasm)/g, 'cost/<case>/<target>')
@@ -253,19 +268,22 @@ const clangText = (bitcode, id, arguments_) => {
 }
 
 const summarize = (text, includeHash = true) => {
-  const suspensionMatches = [
+  const suspensionMatches = text
+    .split('\n')
+    .filter(containsSuspensionTerm)
+    .map((line) => line.trim())
+  const allocationSites = [
     ...text.matchAll(
-      /\bsuspended=true\b|\bsuspend(?:ed)?[_ .-]?(?:effect|operation|step)\b|\b(?:scheduler|fiber|effect[_ .-]?continuation|runtime[_ .-]?continuation)\b/gi,
+      /\b(?:call\s+[^\n@]*@((?:malloc|calloc|realloc|aligned_alloc))|memory\.grow)\b/gi,
     ),
-  ].map((match) =>
-    text.slice(Math.max(0, (match.index ?? 0) - 48), (match.index ?? 0) + match[0].length + 48),
-  )
+  ].map((match) => match[1]?.toLowerCase() ?? 'memory.grow')
   return Object.freeze({
     bytes: Buffer.byteLength(text),
     ...(includeHash ? { hash: hash(text) } : {}),
     calls: occurrences(text, /\bcall\b/g),
     branches: occurrences(text, /\b(?:br|if|switch)\b/g),
-    allocations: occurrences(text, /\b(?:malloc|calloc|realloc|free|memory\.grow)\b/gi),
+    allocations: allocationSites.length,
+    allocationSites: Object.freeze(allocationSites),
     indirectCalls: occurrences(text, /\bcall\b[^\n@]*%[A-Za-z0-9_.]+/g),
     suspensionTerms: suspensionMatches.length,
     suspensionMatches,
@@ -289,6 +307,20 @@ const llvmEntry = (text) => {
   if (start < 0 || body < 0) return ''
   const end = text.indexOf('\n}', body)
   return end < 0 ? '' : text.slice(start, end + 2)
+}
+
+const llvmEntryAbi = (text) => {
+  const signature = /^define\s+(.+?)\s+@silk_main\(([^)]*)\)/m.exec(text)
+  if (signature === null) return undefined
+  const result = /(?:^|\s)(void|i\d+|float|double|ptr|\{[^}]+\})$/.exec(signature[1])?.[1]
+  if (result === undefined) return undefined
+  const parameters = signature[2].trim()
+  return Object.freeze({
+    parameters: Object.freeze(
+      parameters === '' ? [] : parameters.split(',').map((value) => value.trim()),
+    ),
+    results: Object.freeze(result === 'void' ? [] : [result]),
+  })
 }
 
 const assemblyEntry = (text) => {
@@ -337,6 +369,28 @@ const wasmEntry = (text) => {
   const imported = forms.filter((form) => /^\(import\b/.test(form) && /\(func\b/.test(form)).length
   return forms.filter((form) => /^\(func\b/.test(form)).at(index - imported) ?? ''
 }
+
+const wasmEntryAbi = (text) => {
+  const forms = topLevelWasmForms(text)
+  const entry = wasmEntry(text)
+  const typeIndex = Number(/^\(func\s+\(type\s+(\d+)\)/.exec(entry)?.[1])
+  if (!Number.isInteger(typeIndex)) return undefined
+  const type = forms.filter((form) => /^\(type\b/.test(form)).at(typeIndex)
+  if (type === undefined) return undefined
+  const values = (kind) =>
+    Object.freeze(
+      [...type.matchAll(new RegExp(`\\(${kind}((?:\\s+[a-z][0-9]+)*)\\)`, 'g'))].flatMap((match) =>
+        match[1].trim().split(/\s+/).filter(Boolean),
+      ),
+    )
+  return Object.freeze({ parameters: values('param'), results: values('result') })
+}
+
+const llvmDeclarations = (text) =>
+  Object.freeze([...text.matchAll(/^declare\s+[^@\n]*@([^\s(]+)/gm)].map((match) => match[1]))
+
+const wasmImports = (text) =>
+  Object.freeze(topLevelWasmForms(text).filter((form) => /^\(import\b/.test(form)))
 
 const wasmBehavior = (artifact, id) => {
   const instance = new WebAssembly.Instance(new WebAssembly.Module(artifact.bytes.slice()), {})
@@ -599,7 +653,9 @@ try {
         (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl#'),
       ).length
       const verdicts = Analysis.effectNormalizationOf(wasm)
-      const runners = runnerClassifications(Analysis.loweredMir(wasm))
+      const loweredWasm = Analysis.loweredMir(wasm)
+      const runners = runnerClassifications(loweredWasm)
+      const mirOperationTags = countTags(loweredWasm.functions.flatMap(Mir.operations))
       const applicability = directStaticCases.has(sample.id)
         ? 'DirectStaticRun'
         : constructorOnlyCases.has(sample.id)
@@ -641,25 +697,51 @@ try {
             hir: occurrences(hir, /\|>/g),
             mir: occurrences(mir, /\|>/g),
           }),
+          mirOperationTags,
+          suspensionOperationTags: Object.freeze(
+            mirOperationTags.filter(({ tag }) => containsSuspensionTerm(tag)),
+          ),
           hir: summarize(hir),
           mir: summarize(mir),
           debugLlvm: summarize(debugLlvm),
           releaseLlvm: summarize(releaseLlvm),
           optimizedLlvm: summarize(optimizedLlvm, false),
-          optimizedLlvmEntry: summarize(llvmEntry(optimizedLlvm), false),
+          optimizedLlvmEntry: Object.freeze({
+            ...summarize(llvmEntry(optimizedLlvm), false),
+            abi: llvmEntryAbi(optimizedLlvm),
+          }),
           assembly: summarizeAssembly(assembly),
           assemblyEntry: summarizeAssembly(assemblyEntry(assembly)),
           wasm: Object.freeze({ ...summarize(wat), binaryBytes: wasmArtifact.bytes.length }),
-          wasmEntry: summarize(wasmEntry(wat)),
+          wasmEntry: Object.freeze({ ...summarize(wasmEntry(wat)), abi: wasmEntryAbi(wat) }),
           unnormalizedWasm: Object.freeze({
             ...summarize(unnormalizedWat),
             binaryBytes: unnormalizedWasmArtifact.bytes.length,
           }),
-          unnormalizedWasmEntry: summarize(wasmEntry(unnormalizedWat)),
+          unnormalizedWasmEntry: Object.freeze({
+            ...summarize(wasmEntry(unnormalizedWat)),
+            abi: wasmEntryAbi(unnormalizedWat),
+          }),
           symbols: Object.freeze({
             native: release.symbols.map((entry) => entry.declaration.name),
             wasm: wasmArtifact.symbols.map((entry) => entry.declaration.name),
           }),
+          linkage: Object.freeze({
+            nativeRuntime: release.nativeRuntimeSymbols,
+            nativeDeclarations: llvmDeclarations(optimizedLlvm),
+            wasmImports: wasmImports(wat),
+            unnormalizedWasmImports: wasmImports(unnormalizedWat),
+          }),
+          suspensionLinkage: Object.freeze(
+            [
+              ...release.nativeRuntimeSymbols,
+              ...llvmDeclarations(optimizedLlvm),
+              ...wasmImports(wat),
+              ...wasmImports(unnormalizedWat),
+              ...release.symbols.map((entry) => entry.declaration.name),
+              ...wasmArtifact.symbols.map((entry) => entry.declaration.name),
+            ].filter(containsSuspensionTerm),
+          ),
         }),
       )
     } catch (cause) {
@@ -671,7 +753,7 @@ try {
   if (version.status !== 0) throw new Error(`${clang} --version failed: ${version.stderr}`)
   process.stdout.write(
     JSON.stringify({
-      schema: 1,
+      schema: 2,
       clang: version.stdout.split('\n').at(0),
       node: process.version,
       cases,


### PR DESCRIPTION
## What changed

- adds the complete OpenSpec proposal for the explicit `Effect.suspend` boundary;
- commits a three-engine characterization fixture that isolates scalar recursion and `Box` build,
  walk, and drop phases;
- strengthens the synchronous Effect cost suite with structural MIR, linkage, allocation-path,
  pending-branch, indirect-dispatch, and entry-ABI checks;
- records the local phase matrix and keeps ordinary traversal/Drop failures outside #24.

This is the design and characterization gate for #24. It deliberately does **not** implement
`Effect.suspend`; OpenSpec task 1.4 remains unchecked pending explicit approval.

## Design decisions for review

- `Effect.suspend` is ordinary Silk over one minimal sealed intrinsic.
- Its explicit contract adds `OutOfMemory ? &mut Allocator`.
- One owned continuation allocation is made per suspended logical frame.
- The allocator provider loan ends before the deferred child begins.
- Suspended parents continue to count toward evaluator `CallDepth`.
- Native and Wasm use private iterative runners; synchronous programs retain their existing shape.

## Characterization results

On arm64 Darwin / Node 26.5.0, recursive Wasm `Box` build reaches host stack exhaustion at depth
1,000; isolated walk and ordinary recursive Drop complete there and each reaches host stack
exhaustion by depth 4,000. The Linux/Node 22 premature `unreachable` did not reproduce locally.

Follow-ups: #132, #133, #134.

## Verification

Passed:

- `pnpm typecheck`
- `pnpm exec biome check .`
- focused SynchronousEffectCost and CompilerArtifactArchitecture tests (3/3)
- `openspec validate add-effect-suspension-boundary --strict`
- native, Wasm, and raised-limit evaluator characterization commands

Repository-wide `pnpm test` and `pnpm check` reach an unrelated stable failure in
`packages/compiler-cli/test/Workflow.test.ts:383`: “keeps watching after a compilation that
reports a diagnostic” observes exit 1 after the repair instead of 0. The exact test fails again when
run alone; this branch does not modify compiler-cli or watcher code.