### PR TITLE
type-system: give a bound's non-operator operations a call surface

### DIFF
--- a/openspec/changes/give-bound-operations-a-call-surface/design.md
+++ b/openspec/changes/give-bound-operations-a-call-surface/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`accept-multi-operation-interface-bounds` left one gap deliberately and recorded why: an interface
+is not an actor, so `Bound.operation(value)` resolves to a public function of the module declaring
+the interface rather than to the bound's operation. It also recorded the constraint any answer must
+satisfy — unlike an operator, a bound operation must consult the witness's selected operation at
+specialization rather than reuse the width-neutral scalar lowering an operator already has.
+
+The spelling is settled: `Bound.operation(args)`, qualified through the bound's own name, parallel
+to a service operation. What follows is how that spelling resolves and how it reaches the engines.
+
+## Goals / Non-Goals
+
+Goals:
+
+- Every operation a bound declares is callable in the generic body, at the contract the interface
+  declares for it, checked once over the canonical parameter.
+- The call reaches the witness's implementation for the specialized type argument.
+- A collision with a module-level function of the same name resolves by a stated rule, and a
+  receiver that answers to no single parameter is reported.
+
+Non-Goals: `HashKey` and `Order` themselves, witness admissibility (#129), a bound operation as a
+first-class value, type arguments on a bound operation, and any runtime representation change.
+
+## Decisions
+
+### The bound takes the spelling, and only the names it declares
+
+Resolution of a two-segment receiver already asks what the qualifier names. When it names an
+interface, the new question comes first: does the declaration being elaborated bound one of its
+type parameters by that interface, and does that bound's recorded contract declare this member? Only
+both answers together take the spelling. A member the bound does not declare, and a body with no
+such bound, fall through to exactly the resolution they had before — which is what keeps
+`Integer.add(40, 2)` resolving to `silk/numeric`'s public `add` outside a bounded body, and keeps
+every other member of an interface's module reachable inside one.
+
+Inside a bounded body the bound wins. `Integer.add(left, right)` in a body bounded by `Integer`
+names the bound's operation, not the module function it shadows. This is the resolution the whole
+change exists to produce: qualifying through the bound's name and getting the declaring module's
+function instead is the defect being fixed, so preferring the module function there would leave the
+bound's operation with no spelling at all. The module function stays reachable through its module.
+
+The match is on the bound's recorded canonical capability, not on the spelling the bound was
+written with, so an interface imported under an alias is the same bound under either name.
+
+### A receiver that names two parameters is reported, not guessed
+
+One declaration may bound two of its parameters by one interface. The receiver is the bound's name,
+so `Bound.operation(...)` then names no single parameter, and each parameter has its own witness.
+The call is reported — `SEM0097`, naming the parameters it is ambiguous across — rather than
+resolved to the first parameter. Nothing here forecloses a receiver that names the parameter
+instead; it forecloses only guessing.
+
+### The contract is the interface's own, over the bounded parameter
+
+The interface writes its contract over its own type parameter. A bound applies that interface to one
+parameter of the bounded declaration, so the operation's contract in the body is the declared one
+with the interface's parameter substituted — `mix(left: T, right: T) -> T` over the bound's `T`,
+`ranksBelow(left: T, right: T) -> bool` keeping its `bool`. That is the same contract the conformance
+check already holds every witness to, which is what lets the body be checked once, over the
+canonical parameter, before any concrete argument exists.
+
+A bound operation carries no type arguments of its own: the only type the call varies over is the
+bounded parameter, and that one is supplied by the specialization of the declaration the body
+belongs to.
+
+### The call records the question; specialization answers it
+
+An operator on a bound-typed operand carries its compiler-known operation from elaboration because
+the specialized operand type alone selects the instruction: `Add` over `u8` and `Add` over `i32` are
+one width-neutral lowering. A bound operation has no such property. Two providers of one interface
+may map one operation to two unrelated instructions — `Mixer.mix` is `Intrinsic.i32WrappingAdd` for
+`i32` and `Intrinsic.u8SaturatingAdd` for `u8` — and neither is the other's width-neutral form.
+
+So the HIR node records the question rather than an answer: which operation, of which interface,
+over which bounded parameter. `BoundOperationCall` carries no operation code and no intrinsic
+identity. Lowering, which is where the substitution exists, reads the conformance the specialization
+admitted, takes the compiler-known operation it maps, and continues as the ordinary builtin call it
+now is. Two instances of one body therefore lower to two instructions from one node.
+
+Recording the question rather than an answer is also what keeps the node honest under #129: when
+witness admissibility widens, the node does not change — only what lowering finds at the end of the
+conformance does.
+
+### The reachable-intrinsic report reads the same witness
+
+Target availability is answered from the intrinsics reachable instances retain. A bound operation
+names no intrinsic until its type argument is known, so its identity is read per instance, through
+that instance's substitution, from the same conformance lowering will read. Two instances of one
+body contribute two identities, which is exactly what the availability report has to see.

--- a/openspec/changes/give-bound-operations-a-call-surface/proposal.md
+++ b/openspec/changes/give-bound-operations-a-call-surface/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+A bound may declare any number of operations, and every one of them is checked for coverage before
+a type argument is admitted. Only some of them are callable. An operation whose name an operator
+spells — `add`, `subtract`, `lessThan`, `equals` — is reached through that operator; an operation
+whose name no operator spells is reachable from nowhere. `Bound.operation(value)` parses today, but
+it resolves to a public function of the module declaring the interface, which is why
+`Integer.add(40, 2)` resolves at all.
+
+That gap blocks `HashKey` (#34), whose whole contract is `hash`. A generic bounded by `HashKey`
+could reach the equivalence half through `equals` and could not reach the hash half at all.
+
+## What Changes
+
+- Give a bound's operations a call surface spelled `Bound.operation(args)`, qualified through the
+  bound's own name, parallel to a service operation.
+- Prefer the bound over the interface's declaring module when the receiver names a bound of the
+  declaration being elaborated and the member is a name that bound's contract declares. Every other
+  member of that module keeps resolving where it resolved before, and a body with no such bound is
+  untouched.
+- Report a receiver that names an interface bounding two of one declaration's parameters, where no
+  single parameter answers the call.
+- Select the operation's implementation from the witness at specialization rather than from the
+  width-neutral scalar lowering an operator already carries, so two providers of one interface may
+  answer one operation with two unrelated instructions.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bootstrap-type-generics`: make every operation a bound declares callable in a generic body
+  through the bound's own name, resolve that spelling to the bound rather than to a same-named
+  public function of the interface's declaring module, and select the concrete operation from the
+  witness the specialization admitted.
+
+## Impact
+
+The change affects call resolution and elaboration, one new HIR expression, lowering, and the
+reachable-intrinsic report. Bounds stay monomorphization-time only: the call creates no effect
+requirement, no provider slot, and no runtime dispatch, and it reaches the engines as the same
+compiler-known operation an operator would have reached them as. Operator-spelled operations are
+unchanged, and `Integer` keeps working with its source untouched.
+
+It does not add `HashKey` or `Order`, does not widen which witnesses are admissible (#129), does
+not make a bound operation a first-class value, and does not give a bound operation type arguments
+of its own.

--- a/openspec/changes/give-bound-operations-a-call-surface/specs/bootstrap-type-generics/spec.md
+++ b/openspec/changes/give-bound-operations-a-call-surface/specs/bootstrap-type-generics/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: A bound's operations are callable through the bound's own name
+
+A generic body SHALL be able to call every operation its parameter's bound declares, spelled
+`Bound.operation(args)`, whether or not an operator spells that operation's name. The call SHALL
+take the contract the interface declares for that operation with the interface's own type parameter
+replaced by the bounded parameter, SHALL be checked once over that parameter before any concrete
+argument exists, and MUST NOT accept type arguments of its own.
+
+#### Scenario: Call an operation no operator spells
+
+- **WHEN** a body bounded by an interface declaring `mix(left: T, right: T) -> T` evaluates `Mixer.mix(left, right)`
+- **THEN** the call is checked over the bounded parameter and evaluates through the type argument's witness
+
+#### Scenario: Keep a bound operation at its declared result
+
+- **WHEN** a bound declares `ranksBelow(left: T, right: T) -> bool` and the body calls it
+- **THEN** the call results in `bool` rather than the bounded parameter
+
+#### Scenario: Refuse an operation the bound does not declare
+
+- **WHEN** a body names an operation the bound's interface never declares
+- **THEN** the receiver reports that the interface has no such operation
+
+### Requirement: A bound receiver resolves to the bound before the interface's module
+
+A receiver naming an interface SHALL resolve to that interface's operation whenever the declaration
+being elaborated bounds one of its type parameters by that interface and the bound's recorded
+contract declares the named member; the bound SHALL be matched by the interface's canonical
+identity rather than by the spelling the bound was written with. Every other member of that
+interface's module, and every body no such bound belongs to, SHALL keep resolving to the public
+function of the declaring module exactly as before. A receiver naming an interface that bounds more
+than one of the declaration's type parameters answers to no single parameter and SHALL be reported
+rather than resolved to either.
+
+#### Scenario: Prefer the bound over a same-named module function
+
+- **WHEN** a body bounded by `Integer` calls `Integer.add(value, value)` and `silk/numeric` also declares a public `add`
+- **THEN** the call selects the bound's operation over the bounded parameter, not the module function
+
+#### Scenario: Keep the module function where no bound claims the name
+
+- **WHEN** an unbounded body calls `Integer.add(40, 2)`
+- **THEN** the call resolves to `silk/numeric`'s public `add` exactly as it did before
+
+#### Scenario: Report a receiver naming two bounded parameters
+
+- **WHEN** one declaration bounds two type parameters by one interface and the body calls that interface's operation
+- **THEN** the call is reported as ambiguous across those type parameters and resolves to neither
+
+### Requirement: A bound operation selects its implementation from the witness
+
+Lowering a bound operation call SHALL read the conformance the specialization admitted for the
+concrete type argument and use the compiler-known operation that conformance maps for the named
+operation, rather than any operation fixed before the type argument was known. Two specializations
+of one body whose witnesses map one operation to different compiler-known operations SHALL lower to
+those different operations, and every such reachable operation SHALL be reported to target
+availability under the specialization that reaches it.
+
+#### Scenario: Reach two witnesses from one body
+
+- **WHEN** one bound operation is mapped to a wrapping operation for `i32` and a saturating operation for `u8`, and one generic body is specialized at both
+- **THEN** each specialization lowers to the operation its own witness maps, and neither reuses the other's
+
+#### Scenario: Keep operator-spelled operations unchanged
+
+- **WHEN** a body reaches a bound operation through the operator that spells it
+- **THEN** the operator keeps the width-neutral lowering it already had and consults no conformance

--- a/openspec/changes/give-bound-operations-a-call-surface/tasks.md
+++ b/openspec/changes/give-bound-operations-a-call-surface/tasks.md
@@ -1,0 +1,34 @@
+## 1. Resolution
+
+- [x] 1.1 Add a `ResolvedBoundOperation` call reference carrying the capability over the bounded
+      parameter, the operation name, the interface's declaration of it, and the contract that
+      operation declares over that parameter.
+- [x] 1.2 Resolve a two-segment receiver naming an interface against the bounds of the declaration
+      being elaborated, matching on the bound's recorded canonical capability, and take the spelling
+      only for a member the bound's contract declares.
+- [x] 1.3 Report a receiver naming an interface that bounds more than one of the declaration's type
+      parameters, naming the parameters it is ambiguous across (`SEM0097`).
+- [x] 1.4 Check the call against the interface's contract exactly as a compiler-known operation's is
+      checked, and reject explicit type arguments on it.
+
+## 2. Specialization
+
+- [x] 2.1 Add `interfaceOperationIntrinsic`, selecting the compiler-known operation one provider's
+      interface conformance maps for one operation.
+- [x] 2.2 Add a `BoundOperationCall` HIR expression recording the capability, the bounded parameter,
+      and the operation name, with no operation code and no intrinsic identity.
+- [x] 2.3 Lower it by reading the witness the specialization admitted and continuing as the builtin
+      call that witness names.
+- [x] 2.4 Read the same witness when collecting reachable intrinsics, so target availability sees
+      each specialization's own operation.
+
+## 3. Acceptance
+
+- [x] 3.1 Add a test declaring an interface with a non-operator-spelled operation, bounding a
+      generic by it, calling that operation, and evaluating end to end.
+- [x] 3.2 Add a test showing one body reaching two different witnesses for two different type
+      arguments, with instructions that are not each other's width-neutral form.
+- [x] 3.3 Add a test for a bound operation whose declared result is not the bounded parameter.
+- [x] 3.4 Add tests for the collision case: the bound preferred inside a bounded body, the module
+      function kept outside one, and the two-parameter receiver reported.
+- [x] 3.5 Keep the operator-spelled operations and `Integer` passing unchanged.

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -4096,6 +4096,35 @@ export const unmappedInterfaceOperations = (
   )
 }
 
+/**
+ * Selects the compiler-known operation one provider's interface conformance maps an operation to.
+ *
+ * An operator on a bound-typed operand needs no witness: its lowering is width-neutral, and the
+ * specialized operand type alone selects the concrete instruction. An operation no operator spells
+ * has no such lowering, so its call reads the witness the specialization selected — two providers
+ * of one interface may map one operation to two unrelated instructions, and only the conformance
+ * says which. A provider with no single conformance, or a mapping that is not a two-segment
+ * `Intrinsic` path, selects nothing.
+ */
+export const interfaceOperationIntrinsic = (
+  self: Index,
+  provider: Type.Type,
+  capability: Type.Nominal,
+  operation: string,
+): Intrinsic.Operation | undefined => {
+  const mapping = interfaceConformance(self, provider, capability)?.operations.find(
+    (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === operation,
+  )
+  const target = mapping?.target
+  if (
+    target?._tag !== 'TypePath' ||
+    target.segments.length !== 2 ||
+    target.segments.at(0)?.spelling !== 'Intrinsic'
+  )
+    return undefined
+  return Intrinsic.findOperation('Intrinsic', target.segments.at(1)?.spelling ?? '')
+}
+
 /** Selects the unique compiler-shipped or source-declared witness for one provider. */
 export const witness = (
   self: Index,

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -192,6 +192,8 @@ export const invalidStringViewTypeCode = 'SEM0094' as const
 export const invalidFloatLiteralCode = 'SEM0095' as const
 /** Stable code for an effect site or a move inside the conditional right operand of `&&` or `||`. */
 export const impureShortCircuitOperandCode = 'SEM0096' as const
+/** Stable code for a bound operation call whose receiver names more than one bounded parameter. */
+export const ambiguousBoundOperationCode = 'SEM0097' as const
 
 /** Stable code for a use of a binding after its consuming move. */
 export const useAfterMoveCode = 'OWN0001' as const
@@ -322,6 +324,7 @@ export type Code =
   | typeof invalidStringViewTypeCode
   | typeof invalidFloatLiteralCode
   | typeof impureShortCircuitOperandCode
+  | typeof ambiguousBoundOperationCode
   | typeof useAfterMoveCode
   | typeof partialMoveCode
   | typeof explicitMoveRequiredCode
@@ -400,6 +403,11 @@ export type Reason =
   | { readonly _tag: 'UnknownOwnedCallableReturn' }
   | { readonly _tag: 'MissingUnsafeBoundary'; readonly operation: string }
   | { readonly _tag: 'InvalidConformance'; readonly detail: string }
+  | {
+      readonly _tag: 'AmbiguousBoundOperation'
+      readonly spelling: string
+      readonly parameters: ReadonlyArray<string>
+    }
   | { readonly _tag: 'InvalidServiceDeclaration'; readonly detail: string }
   | { readonly _tag: 'InvalidReturnedBorrowSignature' }
   | { readonly _tag: 'InvalidReturnedBorrowOrigin' }
@@ -2229,6 +2237,32 @@ export const invalidConformance = (detail: string, span: SourceSpan.SourceSpan):
     severity: 'error',
     message: `Invalid conformance: ${detail}`,
     reason: Object.freeze({ _tag: 'InvalidConformance', detail }),
+    span,
+  })
+
+/**
+ * Creates the diagnostic for a bound operation reachable through more than one bounded parameter.
+ *
+ * The receiver of a bound operation call is the bound's own name, so one declaration bounding two
+ * of its parameters by the same interface leaves the call naming no single parameter. The operation
+ * is real and the bound is satisfied; what is missing is which parameter's witness answers it.
+ */
+export const ambiguousBoundOperation = (
+  spelling: string,
+  parameters: ReadonlyArray<string>,
+  span: SourceSpan.SourceSpan,
+): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'semantic',
+    code: ambiguousBoundOperationCode,
+    severity: 'error',
+    message: `${spelling} is ambiguous across bounded type parameters ${parameters.join(', ')}`,
+    reason: Object.freeze({
+      _tag: 'AmbiguousBoundOperation',
+      spelling,
+      parameters: Object.freeze([...parameters]),
+    }),
     span,
   })
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -168,6 +168,23 @@ export type CallReferenceFact =
       readonly service: DeclarationIndex.ServiceFact
       readonly operation: DeclarationIndex.ServiceOperationFact
     }
+  /**
+   * One operation of a type parameter's bound, reached through the bound's own name. The contract
+   * is the interface's own declaration over the bounded parameter, checked once before any concrete
+   * argument exists; which implementation runs is the witness's answer at specialization, not one
+   * this reference records.
+   */
+  | {
+      readonly _tag: 'ResolvedBoundOperation'
+      readonly spelling: string
+      readonly token: Token.Token
+      readonly capability: Type.Nominal
+      readonly provider: Type.Parameter
+      readonly operation: string
+      readonly declaration: DeclarationIndex.ServiceOperationFact
+      readonly parameters: ReadonlyArray<SemanticType>
+      readonly result: SemanticType
+    }
   | {
       readonly _tag: 'Missing'
       readonly spelling: string
@@ -3226,7 +3243,13 @@ const sourceCallableTypeParameters = (
 const callArityDiagnostic = (
   reference: Extract<
     CallReferenceFact,
-    { readonly _tag: 'Resolved' | 'ResolvedBuiltin' | 'ResolvedServiceOperation' }
+    {
+      readonly _tag:
+        | 'Resolved'
+        | 'ResolvedBuiltin'
+        | 'ResolvedServiceOperation'
+        | 'ResolvedBoundOperation'
+    }
   >,
   expectedCount: number,
   actualCount: number,
@@ -3243,9 +3266,15 @@ const callArityDiagnostic = (
           actor: reference.actor,
           operation: reference.operation,
         })
-      : reference._tag === 'Resolved'
-        ? reference.declaration.id
-        : reference.operation.id,
+      : reference._tag === 'ResolvedBoundOperation'
+        ? Object.freeze({
+            _tag: 'BuiltinTarget',
+            actor: reference.capability.name,
+            operation: reference.operation,
+          })
+        : reference._tag === 'Resolved'
+          ? reference.declaration.id
+          : reference.operation.id,
     expectedCount,
     actualCount,
     span,
@@ -3269,7 +3298,9 @@ const analyzeCallContract = (
       diagnostics: Object.freeze([]),
     })
   }
-  if (reference._tag === 'ResolvedBuiltin') {
+  // A bound operation's contract is a fixed parameter and result list over the bounded parameter,
+  // exactly like a compiler-known operation's, so both are checked the same way.
+  if (reference._tag === 'ResolvedBuiltin' || reference._tag === 'ResolvedBoundOperation') {
     const unavailableArgument = argumentsList.find((argument) => argument.type._tag !== 'Available')
     if (unavailableArgument !== undefined) {
       return Object.freeze({
@@ -3685,6 +3716,121 @@ const serviceOperation = (
       operation.name._tag === 'Present' &&
       operation.name.spelling === spelling_,
   )
+
+/**
+ * The contract one interface operation declares over a bounded parameter.
+ *
+ * The interface writes its contract over its own type parameter; a bound applies that interface to
+ * one parameter of the bounded declaration, so the operation's contract over that parameter is the
+ * declared one with the interface's parameter substituted. It is the same contract the conformance
+ * check already holds every witness to, which is what lets the body be checked once, over the
+ * canonical parameter, before any concrete argument exists.
+ */
+const interfaceOperationContract = (
+  interface_: DeclarationIndex.InterfaceFact,
+  member: string,
+  parameter: Type.Parameter,
+):
+  | {
+      readonly declaration: DeclarationIndex.ServiceOperationFact
+      readonly parameters: ReadonlyArray<SemanticType>
+      readonly result: SemanticType
+    }
+  | undefined => {
+  const operation = interface_.operations.find(
+    (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === member,
+  )
+  if (
+    operation === undefined ||
+    operation.functionKind !== 'Ordinary' ||
+    operation.typeParameters.length > 0 ||
+    operation.returnType._tag !== 'Resolved'
+  )
+    return undefined
+  const substitution = Type.substitution(
+    interface_.typeParameters.map((declared) => declared.type),
+    Object.freeze([parameter]),
+  )
+  if (substitution === undefined) return undefined
+  const parameters = operation.parameters.flatMap((declared) =>
+    declared.declaredType._tag === 'Resolved'
+      ? [Type.substitute(declared.declaredType.type, substitution)]
+      : [],
+  )
+  if (parameters.length !== operation.parameters.length) return undefined
+  return Object.freeze({
+    declaration: operation,
+    parameters: Object.freeze(parameters),
+    result: Type.substitute(operation.returnType.type, substitution),
+  })
+}
+
+/**
+ * Resolves one `Bound.operation(...)` receiver against the bounds of the declaration being
+ * elaborated.
+ *
+ * A bound's operation is spelled through the bound's own name, so inside a body bounded by an
+ * interface that name selects the bound's operation rather than a same-named public function of the
+ * module declaring the interface. The preference is deliberately narrow: only a name the bound's
+ * recorded contract actually declares is taken, so every other member of that module keeps
+ * resolving exactly where it resolved before, and a body with no such bound is untouched.
+ *
+ * One declaration may bound two of its parameters by one interface. The receiver then names no
+ * single parameter, and the call is reported rather than resolved to either.
+ */
+const boundOperationReference = (
+  declaration: DeclarationFact,
+  interface_: DeclarationIndex.InterfaceFact,
+  qualifier: string,
+  member: string,
+  memberToken: Token.Token,
+):
+  | {
+      readonly _tag: 'BoundOperation'
+      readonly reference: Extract<CallReferenceFact, { readonly _tag: 'ResolvedBoundOperation' }>
+    }
+  | { readonly _tag: 'AmbiguousBound'; readonly parameters: ReadonlyArray<string> }
+  | undefined => {
+  if (interface_.canonical._tag !== 'Canonical') return undefined
+  const capability = interface_.canonical.id
+  const bounded = declaration.typeParameters.filter((parameter) => {
+    const bound = parameter.bound
+    return (
+      bound?._tag === 'ResolvedBound' &&
+      bound.capability.module === capability.module &&
+      bound.capability.name === capability.name &&
+      bound.operations.includes(member)
+    )
+  })
+  if (bounded.length === 0) return undefined
+  if (bounded.length > 1)
+    return Object.freeze({
+      _tag: 'AmbiguousBound',
+      parameters: Object.freeze(
+        bounded.map((parameter) =>
+          parameter.name._tag === 'Present' ? parameter.name.spelling : Type.encode(parameter.type),
+        ),
+      ),
+    })
+  const parameter = bounded.at(0)
+  if (parameter === undefined) return undefined
+  const contract = interfaceOperationContract(interface_, member, parameter.type)
+  if (contract === undefined) return undefined
+  return Object.freeze({
+    _tag: 'BoundOperation',
+    reference: Object.freeze({
+      _tag: 'ResolvedBoundOperation' as const,
+      spelling: `${qualifier}.${member}`,
+      token: memberToken,
+      capability: Type.nominal(capability.module, capability.name, [parameter.type]),
+      provider: parameter.type,
+      operation: member,
+      declaration: contract.declaration,
+      parameters: contract.parameters,
+      result: contract.result,
+    }),
+  })
+}
 
 const resolvedFunctionReference = (
   source: SourceFile.SourceFile,
@@ -5866,6 +6012,40 @@ function analyzeExpression(
     }
     if (
       qualifierLookup._tag === 'Resolved' &&
+      qualifierLookup.declaration._tag === 'InterfaceDeclaration'
+    ) {
+      const bound = boundOperationReference(
+        declaration,
+        qualifierLookup.declaration,
+        qualifier,
+        member,
+        memberToken,
+      )
+      if (bound?._tag === 'AmbiguousBound') {
+        const ambiguous = Diagnostic.ambiguousBoundOperation(
+          `${qualifier}.${member}`,
+          bound.parameters,
+          memberToken.span,
+        )
+        return finishDeclarationCall(
+          node,
+          Object.freeze({
+            _tag: 'Missing',
+            spelling: `${qualifier}.${member}`,
+            token: memberToken,
+            cause: Diagnostic.identity(ambiguous),
+          }),
+          argumentsResult,
+          callTypeArguments,
+          ambiguous,
+          resolution.index,
+        )
+      }
+      if (bound !== undefined)
+        return finishBoundOperationCall(node, bound.reference, argumentsResult, callTypeArguments)
+    }
+    if (
+      qualifierLookup._tag === 'Resolved' &&
       (qualifierLookup.declaration._tag === 'StructDeclaration' ||
         qualifierLookup.declaration._tag === 'InterfaceDeclaration') &&
       qualifierLookup.declaration.canonical._tag === 'Canonical'
@@ -6245,6 +6425,58 @@ const finishDeclarationCall = (
       ...callTypeArguments.diagnostics,
       ...callContract.diagnostics,
       ...constraintDiagnostics,
+    ]),
+    type: expressionType._tag === 'Available' ? expressionType.type : undefined,
+  })
+}
+
+/**
+ * Finishes one call to an operation the enclosing declaration's bound declares.
+ *
+ * The contract is the interface's own, over the bounded parameter, so the call checks exactly like
+ * a compiler-known operation's. It carries no type arguments of its own: the only type the call
+ * varies over is the bounded parameter, and that one is supplied by the specialization of the
+ * declaration this body belongs to.
+ */
+const finishBoundOperationCall = (
+  node: SyntaxTree.Node,
+  reference: Extract<CallReferenceFact, { readonly _tag: 'ResolvedBoundOperation' }>,
+  argumentsResult: ArgumentsResult,
+  callTypeArguments: CallTypeArgumentsResult,
+): ExpressionResult => {
+  const typeArgumentDiagnostic =
+    callTypeArguments.explicit && callTypeArguments.facts.length > 0
+      ? Diagnostic.typeArgumentArity(
+          reference.spelling,
+          0,
+          callTypeArguments.facts.length,
+          node.span,
+        )
+      : undefined
+  const callContract = analyzeCallContract(node, reference, argumentsResult.facts)
+  const expressionType =
+    hasAvailableCallSyntax(node) &&
+    typeArgumentDiagnostic === undefined &&
+    callContract.fact._tag === 'Compatible'
+      ? availableExpressionType(reference.result)
+      : unavailableExpressionType
+  return Object.freeze({
+    fact: Object.freeze({
+      _tag: 'Call',
+      reference,
+      path: referencePath(node),
+      typeArguments: callTypeArguments.facts,
+      arguments: argumentsResult.facts,
+      mappings: callContract.mappings,
+      contract: callContract.fact,
+      type: expressionType,
+      syntax: node,
+    }),
+    diagnostics: Object.freeze([
+      ...(typeArgumentDiagnostic === undefined ? [] : [typeArgumentDiagnostic]),
+      ...argumentsResult.diagnostics,
+      ...callTypeArguments.diagnostics,
+      ...callContract.diagnostics,
     ]),
     type: expressionType._tag === 'Available' ? expressionType.type : undefined,
   })
@@ -7760,6 +7992,53 @@ const hirExpression = (fact: ExpressionFact, borrow?: Hir.BorrowId): Hir.Express
           ? 'LeftThenCallable'
           : 'CalleeThenArguments',
       realization: fact.callee._tag === 'CallableSection' ? 'DirectErasedSection' : 'Environment',
+      type: fact.type.type,
+      span: fact.syntax.span,
+    })
+  }
+  if (
+    fact.reference._tag === 'ResolvedBoundOperation' &&
+    fact.contract._tag === 'Compatible' &&
+    fact.type._tag === 'Available'
+  ) {
+    const borrowIds = Object.freeze(
+      fact.arguments.flatMap(
+        (argument, ordinal): ReadonlyArray<Hir.BorrowId> =>
+          argument.expression._tag === 'Borrow' &&
+          argument.expression.formation._tag !== 'Unavailable'
+            ? [
+                Object.freeze({
+                  _tag: 'BorrowId' as const,
+                  function: argument.id.function,
+                  callSpan: argument.id.callSpan,
+                  ordinal,
+                }),
+              ]
+            : [],
+      ),
+    )
+    return Object.freeze({
+      _tag: 'BoundOperationCall',
+      capability: fact.reference.capability,
+      provider: fact.reference.provider,
+      operation: fact.reference.operation,
+      arguments: Object.freeze(
+        fact.arguments.map((argument, ordinal) =>
+          hirExpression(
+            argument.expression,
+            argument.expression._tag === 'Borrow' &&
+              argument.expression.formation._tag !== 'Unavailable'
+              ? Object.freeze({
+                  _tag: 'BorrowId',
+                  function: argument.id.function,
+                  callSpan: argument.id.callSpan,
+                  ordinal,
+                })
+              : undefined,
+          ),
+        ),
+      ),
+      loanEnds: borrowIds,
       type: fact.type.type,
       span: fact.syntax.span,
     })

--- a/packages/compiler/src/Hir.ts
+++ b/packages/compiler/src/Hir.ts
@@ -543,6 +543,24 @@ export type Expression =
       readonly type: DeclarationIndex.SemanticType
       readonly span: SourceSpan.SourceSpan
     }
+  /**
+   * One call to an operation a type parameter's bound declares, spelled through the bound's own
+   * name. It records the question rather than an answer: which operation of which interface, over
+   * which bounded parameter. An operator carries its compiler-known operation from elaboration
+   * because the specialized operand type alone selects the instruction; an operation no operator
+   * spells has no such lowering, so the concrete instruction is the one the witness selected for
+   * the specialized type argument, and only lowering — where the substitution exists — knows it.
+   */
+  | {
+      readonly _tag: 'BoundOperationCall'
+      readonly capability: Type.Nominal
+      readonly provider: Type.Type
+      readonly operation: string
+      readonly arguments: ReadonlyArray<Expression>
+      readonly loanEnds: ReadonlyArray<BorrowId>
+      readonly type: DeclarationIndex.SemanticType
+      readonly span: SourceSpan.SourceSpan
+    }
   | {
       readonly _tag: 'Unavailable'
       readonly span: SourceSpan.SourceSpan
@@ -719,6 +737,7 @@ export const expressionChildren = (expression: Expression): ReadonlyArray<Expres
       case 'EffectConstruct':
       case 'ServiceEffectConstruct':
       case 'BuiltinCall':
+      case 'BoundOperationCall':
         return expression.arguments
       case 'CallableSection':
         return expression.captures.map((capture) => capture.value)
@@ -785,6 +804,7 @@ export const hasUnavailable = (self: HirFunction): boolean => {
       case 'EffectConstruct':
       case 'ServiceEffectConstruct':
       case 'BuiltinCall':
+      case 'BoundOperationCall':
         return expression.arguments.some(walk)
       case 'CallableSection':
         return expression.captures.some((capture) => walk(capture.value))
@@ -855,7 +875,8 @@ export const firstUnavailable = (
       case 'Call':
       case 'EffectConstruct':
       case 'ServiceEffectConstruct':
-      case 'BuiltinCall': {
+      case 'BuiltinCall':
+      case 'BoundOperationCall': {
         for (const argument of expression.arguments) {
           const found = walk(argument)
           if (found !== undefined) return found
@@ -1038,7 +1059,11 @@ export const verify = (self: Module): ReadonlyArray<VerificationIssue> => {
         issues.push(Object.freeze({ _tag: 'InvalidSliceOperation', span: expression.span }))
       }
     }
-    if (expression._tag === 'Call' || expression._tag === 'BuiltinCall') {
+    if (
+      expression._tag === 'Call' ||
+      expression._tag === 'BuiltinCall' ||
+      expression._tag === 'BoundOperationCall'
+    ) {
       const begins = expression.arguments
         .flatMap(expressionTree)
         .filter(
@@ -1046,12 +1071,15 @@ export const verify = (self: Module): ReadonlyArray<VerificationIssue> => {
             candidate,
           ): candidate is Extract<Expression, { readonly _tag: 'SliceBorrow' | 'ValueBorrow' }> =>
             (candidate._tag === 'SliceBorrow' || candidate._tag === 'ValueBorrow') &&
-            (expression._tag === 'BuiltinCall' ||
+            (expression._tag !== 'Call' ||
               (candidate.borrow.callSpan.start === expression.span.start &&
                 candidate.borrow.callSpan.end === expression.span.end)),
         )
         .map((candidate) => borrowText(candidate.borrow))
-      const ends = [...expression.loanEnds, ...expression.heldLoans].map(borrowText)
+      const ends = [
+        ...expression.loanEnds,
+        ...(expression._tag === 'BoundOperationCall' ? [] : expression.heldLoans),
+      ].map(borrowText)
       if (
         begins.length !== ends.length ||
         begins.some((begin, ordinal) => begin !== ends.at(ordinal)) ||
@@ -1410,6 +1438,11 @@ const encodeExpression = (expression: Expression, depth: number): string => {
         ...expression.arguments.map((argument) => encodeExpression(argument, depth + 1)),
       ].join('\n')
     }
+    case 'BoundOperationCall':
+      return [
+        `${indent}bound ${Type.encode(expression.capability)}.${expression.operation} over ${Type.encode(expression.provider)} : ${Type.encode(expression.type)} ${spanText(expression.span)}`,
+        ...expression.arguments.map((argument) => encodeExpression(argument, depth + 1)),
+      ].join('\n')
     case 'Unavailable':
       return `${indent}unavailable ${spanText(expression.span)}`
   }

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -262,20 +262,43 @@ const compareIntrinsicCalls = (left: IntrinsicCall, right: IntrinsicCall): numbe
   left.span.start - right.span.start ||
   left.span.end - right.span.end
 
-/** Collects the canonical intrinsic identities retained by reachable function instances. */
-const reachableIntrinsics = (instances: ReadonlyArray<Instance>): ReadonlyArray<IntrinsicCall> => {
+/**
+ * Collects the canonical intrinsic identities retained by reachable function instances.
+ *
+ * A bound operation names no intrinsic until its type argument is known, so its identity is read
+ * from the witness this instance's substitution selects. Two instances of one body therefore
+ * contribute two identities, which is exactly what target availability has to see.
+ */
+const reachableIntrinsics = (
+  instances: ReadonlyArray<Instance>,
+  index: DeclarationIndex.Index,
+): ReadonlyArray<IntrinsicCall> => {
   const calls = new Map<string, IntrinsicCall>()
   for (const instance of instances) {
     for (const statement of instance.function.statements) {
       for (const root of Hir.statementExpressions(statement)) {
         for (const expression of Hir.expressionTree(root)) {
+          const selected =
+            expression._tag === 'BoundOperationCall'
+              ? (() => {
+                  const capability = Type.substitute(expression.capability, instance.substitution)
+                  return Type.isNominal(capability)
+                    ? DeclarationIndex.interfaceOperationIntrinsic(
+                        index,
+                        Type.substitute(expression.provider, instance.substitution),
+                        capability,
+                        expression.operation,
+                      )?.id
+                    : undefined
+                })()
+              : undefined
           const operation =
             expression._tag === 'BuiltinCall'
               ? expression.intrinsic
               : (expression._tag === 'FunctionItem' || expression._tag === 'CallableSection') &&
                   expression.target._tag === 'BuiltinCallableTarget'
                 ? expression.target.intrinsic
-                : undefined
+                : selected
           if (operation === undefined) continue
           const span = expression.span
           const key = `${Intrinsic.operationText(operation)}\u0000${span.sourceId}\u0000${span.start}\u0000${span.end}`
@@ -480,7 +503,7 @@ const callTargets = (expression: Hir.Expression): ReadonlyArray<CallTarget> => {
   if (expression._tag === 'ArrayConstruct') {
     return expression.elements.flatMap((element) => callTargets(element))
   }
-  if (expression._tag === 'BuiltinCall') {
+  if (expression._tag === 'BuiltinCall' || expression._tag === 'BoundOperationCall') {
     return expression.arguments.flatMap((argument) => callTargets(argument))
   }
   if (expression._tag === 'FunctionItem') return []
@@ -1419,7 +1442,7 @@ export const discover = (
     instances,
     callables: Object.freeze([...recordedCallables.values()]),
     calls: Object.freeze([...recordedCalls.values()]),
-    intrinsics: reachableIntrinsics(instances),
+    intrinsics: reachableIntrinsics(instances, index),
     violations: Object.freeze(violations),
   })
 }

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -1079,7 +1079,8 @@ const addExpressionTypes = (
     expression._tag === 'Call' ||
     expression._tag === 'EffectConstruct' ||
     expression._tag === 'ServiceEffectConstruct' ||
-    expression._tag === 'BuiltinCall'
+    expression._tag === 'BuiltinCall' ||
+    expression._tag === 'BoundOperationCall'
   ) {
     for (const argument of expression.arguments) addExpressionTypes(types, argument, substitution)
   }

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -2517,6 +2517,38 @@ function lowerExpressionInner(
       }
       return { result: destination }
     }
+    case 'BoundOperationCall': {
+      // The bound named the operation; the specialization names the witness. Only here is the type
+      // argument known, so only here can the conformance say which compiler-known operation the
+      // call runs — two providers of one interface may answer one operation with two unrelated
+      // instructions, and an operator's width-neutral lowering cannot stand in for that.
+      const capability = fn.semantic(expression.capability)
+      const provider = fn.semantic(expression.provider)
+      if (!Type.isNominal(capability)) return undefined
+      const selected = DeclarationIndex.interfaceOperationIntrinsic(
+        fn.index,
+        provider,
+        capability,
+        expression.operation,
+      )
+      if (selected?.rule._tag !== 'BuiltinRule') return undefined
+      // The call the witness names, at this call's own span: the enclosing `lowerExpression` ends
+      // this span's returned-view loans once, after the operation it selected has been lowered.
+      return lowerExpressionInner(
+        fn,
+        Object.freeze({
+          _tag: 'BuiltinCall',
+          operation: selected.rule.operation,
+          intrinsic: selected.id,
+          typeArguments: Object.freeze([]),
+          arguments: expression.arguments,
+          loanEnds: expression.loanEnds,
+          heldLoans: Object.freeze([]),
+          type: expression.type,
+          span: expression.span,
+        }),
+      )
+    }
     case 'BuiltinCall': {
       const argumentLocals: Array<Mir.LocalId> = []
       for (const argument of expression.arguments) {

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -619,7 +619,8 @@ const checkExpression = (
       }
       return
     }
-    case 'BuiltinCall': {
+    case 'BuiltinCall':
+    case 'BoundOperationCall': {
       for (const argument of expression.arguments)
         checkExpression(state, live, argument, false, guard, escaping)
       return

--- a/packages/compiler/src/SemanticOccurrence.ts
+++ b/packages/compiler/src/SemanticOccurrence.ts
@@ -486,6 +486,23 @@ const callResolution = (
           : available(Object.freeze({ _tag: 'IntrinsicOperationIdentity', id: operation.id })),
     })
   }
+  if (reference._tag === 'ResolvedBoundOperation') {
+    // A bound operation is declared once, by the interface, and answered per specialization by a
+    // witness. The declaration is what a reader navigates to, so that is what the occurrence names.
+    const declaration = locationOfServiceOperation(reference.declaration)
+    return Object.freeze({
+      resolution:
+        reference.declaration.state._tag === 'Unique'
+          ? available(
+              Object.freeze({
+                _tag: 'ServiceOperationIdentity',
+                id: reference.declaration.state.id,
+              }),
+            )
+          : Object.freeze({ _tag: 'Unavailable' }),
+      ...(declaration === undefined ? {} : { declaration }),
+    })
+  }
   if (reference._tag === 'ResolvedServiceOperation') {
     const declaration = locationOfServiceOperation(reference.operation)
     return Object.freeze({
@@ -542,7 +559,9 @@ const collectCallReference = (
   push(
     pending,
     selected?.span,
-    reference._tag === 'ResolvedBuiltin' || reference._tag === 'ResolvedServiceOperation'
+    reference._tag === 'ResolvedBuiltin' ||
+      reference._tag === 'ResolvedServiceOperation' ||
+      reference._tag === 'ResolvedBoundOperation'
       ? 'Operation'
       : 'Value',
     resolved.resolution,

--- a/packages/compiler/test/InterfaceBounds.test.ts
+++ b/packages/compiler/test/InterfaceBounds.test.ts
@@ -145,6 +145,119 @@ pub fn main() -> i32 { return combine(40, 2) }`)
   }),
 )
 
+/**
+ * A bound operation no operator spells. `mix` is reachable only through the bound's own name, and
+ * the two witnesses answer it with two unrelated instructions — wrapping for `i32`, saturating for
+ * `u8` — so the call must read the witness the specialization selected rather than reuse an
+ * operator's width-neutral lowering.
+ */
+const nonOperatorOperation = `pub interface Mixer<T> {
+  fn mix(left: T, right: T) -> T
+}
+impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
+impl Mixer<u8> for u8 { mix: Intrinsic.u8SaturatingAdd }
+pub fn blend<T: Mixer>(left: T, right: T) -> T { return Mixer.mix(left, right) }
+pub fn main() -> i32 { return blend(40, 2) }`
+
+it.effect('calls a bound operation no operator spells', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(nonOperatorOperation)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('reaches a different witness for each specialized type argument', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`pub interface Mixer<T> {
+  fn mix(left: T, right: T) -> T
+}
+impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
+impl Mixer<u8> for u8 { mix: Intrinsic.u8SaturatingAdd }
+pub fn blend<T: Mixer>(left: T, right: T) -> T { return Mixer.mix(left, right) }
+pub fn main() -> i32 {
+  // u8 saturates at 255; i32 wraps from its maximum to its minimum. One shared body, two
+  // instructions, and neither is the other's width-neutral form.
+  let saturated = blend<u8>(200, 100)
+  let wrapped = blend<i32>(2147483647, 1)
+  if saturated != 255 { return 1 }
+  if wrapped != -2147483648 { return 2 }
+  return 42
+}`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('keeps a bound operation at the result its interface declares', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`pub interface Ranked<T> {
+  fn ranksBelow(left: T, right: T) -> bool
+}
+impl Ranked<i32> for i32 { ranksBelow: Intrinsic.i32LessThan }
+pub fn pick<T: Ranked>(left: T, right: T) -> T {
+  if Ranked.ranksBelow(left, right) { return move right }
+  return move left
+}
+pub fn main() -> i32 { return pick(2, 42) }`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+/**
+ * `Integer.add` names both the bound's operation and a public function of `silk/numeric`. Inside a
+ * body bounded by `Integer` the bound takes the spelling; the module function stays reachable
+ * everywhere else, including through its own module namespace.
+ */
+it.effect('prefers the bound operation over a same-named module function', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`import silk.numeric { Integer }
+pub fn twice<T: Integer>(value: T) -> T { return Integer.add(value, value) }
+pub fn main() -> i32 { return twice(21) }`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('keeps the module function reachable where no bound claims the name', () =>
+  Effect.gen(function* () {
+    const { self, outcome } = yield* evaluate(`import silk.numeric { Integer }
+pub fn main() -> i32 { return Integer.add(40, 2) }`)
+    assert.deepEqual(Analysis.diagnostics(self), [])
+    assert.strictEqual(outcome._tag, 'Completed', describe(outcome))
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('reports a bound operation reachable through two bounded parameters', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(`pub interface Mixer<T> {
+  fn mix(left: T, right: T) -> T
+}
+impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
+pub fn blend<A: Mixer, B: Mixer>(left: A, right: B) -> A { return Mixer.mix(left, left) }
+pub fn main() -> i32 { return blend<i32, i32>(40, 2) }`)
+    assert.include(messages(self), 'Mixer.mix is ambiguous across bounded type parameters A, B')
+  }),
+)
+
+it.effect('reports a bound operation the interface never declares', () =>
+  Effect.gen(function* () {
+    const self = yield* snapshot(`pub interface Mixer<T> {
+  fn mix(left: T, right: T) -> T
+}
+impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
+pub fn blend<T: Mixer>(left: T, right: T) -> T { return Mixer.stir(left, right) }
+pub fn main() -> i32 { return blend(40, 2) }`)
+    assert.include(messages(self), 'Mixer has no operation stir')
+  }),
+)
+
 it.effect('records the resolved bound contract on the declaration it belongs to', () =>
   Effect.gen(function* () {
     const self = yield* snapshot(twoOperations)

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -16,11 +16,11 @@ $ pnpm --filter @silk-effect/compiler documentation:generate
 | `LEX` | Lexical | 7 |
 | `PAR` | Parser | 4 |
 | `MOD` | Module | 4 |
-| `SEM` | Semantic | 95 |
+| `SEM` | Semantic | 96 |
 | `OWN` | Ownership | 12 |
 | `LAY` | Layout | 1 |
 
-There are 123 codes in total.
+There are 124 codes in total.
 
 ## Lexical (`LEX`)
 
@@ -151,6 +151,7 @@ There are 123 codes in total.
 | `SEM0094` | Stable code for wrapping the already-borrowed string view in another reference or slice. |  |
 | `SEM0095` | Stable code for a float literal spelling no floating-point value can represent. | `Invalid float literal: <spelling>` |
 | `SEM0096` | Stable code for an effect site or a move inside the conditional right operand of `&&` or `\|\|`. | `The right operand of <operator> must be pure, found <detail>` |
+| `SEM0097` | Stable code for a bound operation call whose receiver names more than one bounded parameter. | `<spelling> is ambiguous across bounded type parameters <join>` |
 
 ## Ownership (`OWN`)
 

--- a/packages/language/docs/reference.md
+++ b/packages/language/docs/reference.md
@@ -312,6 +312,30 @@ pub fn main() -> i32 {
 The `T: Integer` bound on `add` is what makes `left + right` legal inside its body: a generic body
 may use only the operations its bounds promise.
 
+An operation whose name an operator spells is reached through that operator. Every other operation
+is reached by qualifying through the bound's own name, `Bound.operation(args)`, the same shape a
+service operation takes:
+
+```silk
+pub interface Mixer<T> {
+  fn mix(left: T, right: T) -> T
+}
+
+impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
+impl Mixer<u8> for u8 { mix: Intrinsic.u8SaturatingAdd }
+
+pub fn blend<T: Mixer>(left: T, right: T) -> T { return Mixer.mix(left, right) }
+```
+
+One body, two specializations, two instructions: `blend<i32>` wraps and `blend<u8>` saturates,
+because each reads the operation its own witness maps. The call is still specialization-time only —
+no dispatch, no provider slot, no row.
+
+Inside a body bounded by an interface, that name selects the bound's operation even when the
+interface's module also declares a public function of the same name; the module function stays
+reachable through its module everywhere else. A declaration that bounds two of its type parameters
+by one interface leaves the receiver naming neither, and the call is reported with `SEM0097`.
+
 ### 2.6 Services
 
 A `service` declares runtime capability contracts — operation signatures only, with no fields, no


### PR DESCRIPTION
Closes #118

## What

An operation whose name an operator spells was callable through that operator; one whose name no operator spells was reachable from nowhere. `Bound.operation(value)` parsed, but resolved to a public function of the module declaring the interface — which is why `Integer.add(40, 2)` resolves today.

The spelling is settled: **`Bound.operation(args)`**, qualified through the bound's own name, parallel to a service operation ([decision recorded on the issue](https://github.com/julia-script/silk-effect/issues/118#issuecomment-5283424914)).

```silk
pub interface Mixer<T> {
  fn mix(left: T, right: T) -> T
}

impl Mixer<i32> for i32 { mix: Intrinsic.i32WrappingAdd }
impl Mixer<u8> for u8 { mix: Intrinsic.u8SaturatingAdd }

pub fn blend<T: Mixer>(left: T, right: T) -> T { return Mixer.mix(left, right) }
```

One body, two specializations, two instructions: `blend<i32>` wraps, `blend<u8>` saturates.

## How

**Resolution.** A two-segment receiver naming an interface is resolved against the bounds of the declaration being elaborated. When one of its type parameters is bound by that interface *and* the bound's recorded contract declares the member, the bound takes the spelling. The preference is deliberately narrow: a member no bound declares, and a body with no such bound, resolve exactly where they did before. The match is on the bound's canonical capability, not on the spelling it was written with, so an aliased import is the same bound. A receiver naming an interface that bounds two of one declaration's parameters answers to no single parameter and is reported — `SEM0097`, naming the parameters it is ambiguous across.

**Contract.** The interface's own contract with its type parameter replaced by the bounded one, checked once over the canonical parameter, before any concrete argument exists. `mix(left: T, right: T) -> T` over the bound's `T`; `ranksBelow(left: T, right: T) -> bool` keeps its `bool`. No type arguments of its own.

**Specialization.** This is the constraint PR #107's `design.md` recorded. An operator carries its compiler-known operation from elaboration because the specialized operand type alone selects the instruction — `Add` over `u8` and over `i32` are one width-neutral lowering. A bound operation has no such property: two providers may map one operation to two unrelated instructions. So the new `BoundOperationCall` HIR node records the *question* — which operation, of which interface, over which bounded parameter — and carries no operation code and no intrinsic identity. Lowering, the phase that holds the substitution, reads the conformance the specialization admitted, takes the compiler-known operation it maps, and continues as the ordinary builtin call it now is. The reachable-intrinsic report reads the same witness, per instance, so target availability sees each specialization's own operation.

Recording the question rather than an answer is also what keeps the node stable under #129: when witness admissibility widens, the node does not change — only what lowering finds at the end of the conformance does.

## Criteria

- [x] The spelling is chosen and recorded on the issue before implementation.
- [x] A test declares an interface with a non-operator-spelled operation, bounds a generic by it, calls that operation, and evaluates end to end.
- [x] A test shows the call reaches two different witnesses for two different type arguments — wrapping for `i32`, saturating for `u8`, neither the other's width-neutral form.
- [x] Tests cover requirement 3's collision case: the bound preferred inside a bounded body, `Integer.add(40, 2)` unchanged outside one, and the two-parameter receiver reported.
- [x] `Integer` and the #103 tests pass unchanged, with `numeric.silk` untouched.
- [x] The spec records the call form through openspec (`give-bound-operations-a-call-surface`).

## Out of scope

`HashKey` (#34) and `Order` (#36) themselves; witness admissibility (#129), so the tests necessarily use scalar witnesses; a bound operation as a first-class value.

## Tests

`Tests: baseline 1 failure (LexerPressure timeout under parallel load, passes alone), after 0 failures, +8 new tests` — 1329 → 1337 in `packages/compiler`. The five behavioural additions were verified to fail before the change; the two guard tests (`Integer.add` outside a bounded body, an operation the interface never declares) pass before and after by design.

Also run: `turbo run typecheck` clean, `pnpm test:scripts` 8/8, `lsp` 78/78, `llvm` 59/59, `documentation` 4/4, `language` 28/28. Pre-existing local failures unrelated to this change and identical at baseline: `packages/wasm` `Extended.test.ts` "threads address types", `compiler-cli` `FormatCommand`/`FormatWorkflow` (chmod vs root).

New diagnostic code `SEM0097` — `packages/language/docs/diagnostics.md` regenerated via `documentation:generate`, and the language reference documents the call form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNNUW72WRYcjUbZewZya4a

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNNUW72WRYcjUbZewZya4a)_