### PR TITLE
type-system: let a user-defined type conform to an interface

### DIFF
--- a/openspec/changes/admit-user-interface-witnesses/design.md
+++ b/openspec/changes/admit-user-interface-witnesses/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Interfaces are monomorphization-time only: they create no effect requirement, no provider slot, and
+no runtime dispatch. That property is preserved here in full. The change is about which mapping
+targets a conformance may name, and what specialization does with the one it names — not about what
+representation reaches the engines.
+
+Two facts about the existing language decide almost everything below.
+
+1. **An interface operation never consumes its operands.** Ownership checks a builtin call's
+   arguments non-consumingly (`Ownership.checkExpression`, the `BuiltinCall` case), which is why
+   `slice[i] < slice[j]` is accepted inside a body bounded by `Order`.
+2. **No nominal type is `Copy`.** `Ownership.categoryOf` classifies every nominal as `MoveOnly`, so
+   a user struct is move-only whether or not it owns a resource.
+
+Together these rule out the obvious design — a witness whose signature is literally the contract's,
+taking operands by value. Such a witness could only be called by moving the operands out of places
+the operator merely reads, which ownership already forbids, and which for a resource-owning element
+would mean the callee dropping a value it does not own.
+
+## Goals / Non-Goals
+
+Goals:
+
+- One user nominal type may conform to one interface by mapping each operation to one of its own
+  functions.
+- The witness is checked for complete coverage exactly as an `Intrinsic.*` one is; the #103 coverage
+  check applies unchanged.
+- A generic bounded by the interface specializes at the user type and the call reaches the mapped
+  function.
+- `Integer` and every existing `Intrinsic.*` witness keep working, source untouched.
+
+Non-Goals: blanket or conditional conformances, more than one interface per conformance, any runtime
+representation change or dynamic dispatch, and #118's call surface for operations no operator spells.
+
+## Decisions
+
+### A witness target is one intrinsic or one function of the provider's own actor
+
+The mapping keeps its two-segment shape. `Intrinsic.<operation>` selects the sealed operation as
+before. `<Provider>.<function>` names a function declared in the provider type's own module, the
+same actor-qualified spelling a service conformance already uses (`impl FileSystem for OsFileSystem
+{ readFile: OsFileSystem.readFile }`). No third form is admitted, so a conformance can never name a
+function belonging to some other type.
+
+### A source witness observes its operands through a shared borrow
+
+For a contract operation `fn op(a: T, b: T) -> R`, the mapped function is declared
+`fn name(a: &T, b: &T) -> R` — every contract parameter received by shared borrow, the result by
+value. This is forced, not chosen: the operator that reaches the witness does not consume its
+operands, and no nominal provider is `Copy`, so a by-value parameter could not be supplied without
+either a move the ownership checker rejects or a duplicate the callee would later drop.
+
+The contract itself keeps declaring value operands, because that is what the intrinsic witnesses
+take and `Order`/`Integer` must keep working unchanged. The borrow is the source witness's calling
+convention, not a change to what the interface declares.
+
+Beyond the operand form, the source witness is checked exactly as the intrinsic one: same arity,
+same substituted parameter and result types, ordinary function kind, no type parameters, no failure
+row, and no requirement row.
+
+### Specialization redirects the operator; it does not reinterpret the contract
+
+An operator inside a generic body cannot know its operand type, so it still elaborates against the
+compiler-known operation of a stand-in actor. It now also records the bound interface operation it
+spells — capability, provider parameter, and operation name — on the `BuiltinCall` it produces.
+
+At specialization the recorded provider is substituted. When the resulting type has a conformance
+mapping that operation to one of its own functions, lowering emits a shared borrow of each operand
+local and an ordinary static call; instance discovery walks the same conformance so the witness is
+reachable, since no ordinary call names it. When the mapping names an intrinsic — every scalar —
+nothing is recorded to redirect to and the compiler-known operation lowers as it always has.
+
+### A borrow-only place read observes without claiming
+
+Lowering a redirected operator over a move-only element reads the operand place into a temporary and
+borrows it. MIR forbids reading a non-`Copy` value out of a place without a paired consume, and
+rightly so — but it already licenses one exception: a read whose value feeds a shared `Match` and
+nothing else. The same license is extended to a read whose value is never accessed as an owner and
+is borrowed shared. Such a value cannot be moved, dropped, or written through, so it is observable
+only through a shared reference and no release can notice it.
+
+The alternative — projecting a loan through a slice element selector, so the witness receives a
+pointer to the element itself rather than to a temporary — needs runtime index arithmetic in three
+backends and a source syntax the language deliberately rejects today ("a slice borrow requires a
+direct stable array binding or slice parameter"). It buys nothing here: a comparison reads, and a
+read of a copy it cannot move out of is indistinguishable from a read of the original.
+
+## Risks / Trade-offs
+
+The temporary is a shallow copy of the operand for the duration of the call. It is sound because the
+witness can only read through `&`, but it does mean a witness cannot observe operand identity — two
+distinct elements that are bitwise equal are indistinguishable to it. No interface operation in
+scope here can observe identity, and #118 is where any operation that wanted to would be defined.
+
+## Migration
+
+None. No existing source changes: every shipped conformance names an intrinsic and keeps doing so.

--- a/openspec/changes/admit-user-interface-witnesses/proposal.md
+++ b/openspec/changes/admit-user-interface-witnesses/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+An interface conformance was admitted only when its mapping target was a two-segment `Intrinsic.*`
+path; every other target was rejected with `is incompatible with`. The consequence is larger than
+the error message suggests: **no user-defined type could conform to any interface at all.** Every
+type that could witness `Order`, `Integer`, or any future interface was one of the built-in
+scalars.
+
+An interface whose only possible implementors are the twelve scalars is not really an interface.
+`Order` could only order scalars, so — since every scalar is `Copy` and its equality is identity —
+**sort stability was unobservable and a move-only element type could not exist**. `HashKey` (#34)
+could only ever key a map by a scalar.
+
+The damage lands in the test suites. PR #126 (`Vector.sort`) could not write two of its own
+acceptance criteria — "equal elements keep their input order" and "a sort over a move-only element
+type with no leak" — because no conforming element type could witness either. The implementation
+met both, and nothing proved it. That is a gap that reads as coverage until someone checks, which
+is the same shape as PR #84's decorative move-only assertions that hid the #86 Wasm bug.
+
+## What Changes
+
+- Admit a second witness target: a two-segment path naming one function of the provider's own
+  actor, checked against the same substituted contract the `Intrinsic.*` target is checked against.
+- Define the source witness's operand form. An interface operation never consumes its operands — a
+  builtin operator does not, and a generic body is checked with its parameter non-`Copy` — so a
+  source witness receives each contract operand by shared borrow and returns the contract result by
+  value. A by-value operand would consume what the operator only reads and is rejected.
+- Redirect specialization: a bound operator whose specialized operand type has a source-declared
+  witness lowers to a call to that function, and instance discovery follows the conformance to it.
+  A scalar argument keeps selecting its compiler-known operation, unchanged.
+- License the operand read the redirected call needs: a place read whose value is never accessed as
+  an owner and is only borrowed shared observes a non-`Copy` place without claiming it, exactly as
+  the existing shared match projection does.
+- Write PR #126's two unmet criteria, now that they are writable: sort stability over a user type
+  with distinguishable-but-equal elements, and a sort over a move-only element type asserting
+  acquires equal releases.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `bootstrap-declaration-index`: record what may serve as an interface witness target — one sealed
+  intrinsic or one function of the provider's own actor — and the operand form each takes.
+- `bootstrap-type-generics`: specialize a bounded parameter at a user type and reach that type's
+  mapped function, while a scalar keeps reaching its compiler-known operation.
+- `bootstrap-owned-sequence`: ordering is witnessed by user types, so stability is observable and a
+  move-only element type can be ordered.
+
+## Impact
+
+The change affects conformance validation in the declaration index, the interface operation an
+operator records during elaboration, instance discovery, lowering, and one MIR validation license.
+It adds no diagnostic code, no runtime representation, no dynamic dispatch, and no instance-key
+shape: the redirected operator becomes an ordinary static call to an ordinary Silk function.
+`Integer` and every existing `Intrinsic.*` witness keep working with their source untouched.
+
+It does not add blanket or conditional conformances (`impl<T: A> B for T`), more than one interface
+per conformance, or a call surface for an interface operation whose name no operator spells (#118).

--- a/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-declaration-index/spec.md
+++ b/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-declaration-index/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: An interface witness names one intrinsic or one function of its own provider
+
+An interface conformance SHALL map each of the interface's operations to a two-segment path naming
+either one sealed `Intrinsic` operation or one function declared by the provider type's own actor.
+No other target SHALL be admitted, so a conformance can never name a function belonging to another
+type. A mapping whose provider-qualified name matches no declaration SHALL be reported as a mapped
+operation that does not exist.
+
+Both targets SHALL be checked against the same contract, substituted by the conformance's interface
+type arguments: the same arity, the same operand and result types, an ordinary function kind, and no
+failure or requirement row. They differ only in operand form. A sealed operation SHALL take the
+contract's operand types as declared. A source witness SHALL receive each contract operand by shared
+borrow and return the contract result by value, because an interface operation never consumes what
+it reads and no nominal provider is `Copy`; a source witness declaring a by-value operand, extra
+type parameters, a failure row, or a requirement row SHALL be rejected as incompatible with the
+operation it maps.
+
+The completeness rule is unchanged by the target's form: a conformance SHALL still map every
+operation the interface declares and no operation it does not.
+
+#### Scenario: Admit a user type's own function as a witness
+
+- **WHEN** `impl Order<Cell> for Cell { lessThan: Cell.cellLess }` names `fn cellLess(left: &Cell, right: &Cell) -> bool`
+- **THEN** the conformance is admitted and recorded as the witness for `Cell`
+
+#### Scenario: Reject a by-value operand
+
+- **WHEN** the mapped function is declared `fn cellLess(left: Cell, right: Cell) -> bool`
+- **THEN** the conformance is rejected as incompatible with the operation it maps
+
+#### Scenario: Reject a mapping to a function that does not exist
+
+- **WHEN** a conformance maps an operation to `Cell.absent` and the provider's actor declares no such function
+- **THEN** the conformance reports that the mapped operation does not exist
+
+#### Scenario: Keep every shipped intrinsic witness admissible
+
+- **WHEN** the standard library maps `Order` and `Integer` to `Intrinsic.*` operations for each scalar
+- **THEN** every one of those conformances is admitted exactly as before, with its source unchanged
+
+#### Scenario: Require complete coverage whatever the target
+
+- **WHEN** a user type's conformance to a two-operation interface maps only one operation
+- **THEN** the conformance is rejected naming the unmapped operation, as it is for an intrinsic witness

--- a/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-owned-sequence/spec.md
+++ b/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-owned-sequence/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Vector ordering is stable and deterministic
+
+`Vector<T>` SHALL support ordering its elements in place for any element type carrying an `Order`
+witness, whether that witness selects a compiler-known comparison or one of the element type's own
+functions. The order SHALL be total and stable: two elements that compare equal SHALL keep their
+input order relative to one another, and this SHALL hold for an element type whose equal elements
+stay distinguishable, so stability is observable rather than merely asserted. The order SHALL be
+deterministic — the same input SHALL always produce the same output, and the evaluator, LLVM, and
+Wasm SHALL agree on that output — because every comparison and every exchange is decided by run
+boundaries alone and never by an address, a capacity, or an engine detail. Ordering SHALL move each
+element at most once per exchange, so no element is duplicated, leaked, or dropped twice, and SHALL
+NOT require the element type to be `Copy` to move an element; comparing two elements SHALL NOT
+consume either, so an element type that owns a resource can be ordered. Ordering allocates a scratch
+buffer and therefore SHALL carry the typed `OutOfMemory` failure and the allocator requirement.
+
+`Vector<T>` SHALL support searching a sorted vector for an element through the same `Order` witness,
+returning an optional index that is present only when a matching element exists. The search SHALL
+return the lowest matching index when several elements compare equal, so repeated searches over one
+vector answer identically.
+
+#### Scenario: Order an unsorted vector
+
+- **WHEN** a program orders a vector whose elements are not in order
+- **THEN** every element afterward compares no greater than the element following it, and the length and every element value are unchanged
+
+#### Scenario: Equal elements keep their input order
+
+- **WHEN** a vector holding several elements that compare equal is ordered
+- **THEN** those elements keep their input order relative to one another, and ordering the result again leaves it unchanged
+
+#### Scenario: Observe stability through a user element type
+
+- **WHEN** a vector of a user type that compares on one field and carries another the comparison never reads is ordered
+- **THEN** elements with equal comparison fields appear in their input order, distinguished by the field the comparison ignored
+
+#### Scenario: Order a move-only element type
+
+- **WHEN** a vector whose element type owns an allocation, and is therefore never `Copy`, is ordered and later released
+- **THEN** the elements are ordered by their witness and every allocation acquired is released exactly once
+
+#### Scenario: Ordering an empty or one-element vector
+
+- **WHEN** a program orders a vector holding no element or exactly one element
+- **THEN** the vector is unchanged and no comparison is required
+
+#### Scenario: Three engines agree on one order
+
+- **WHEN** the same program orders the same input on the evaluator, on LLVM, and on Wasm
+- **THEN** the three engines observe the same element at every index
+
+#### Scenario: Ordering releases every allocation it acquires
+
+- **WHEN** a program orders a vector and the vector is later released
+- **THEN** every allocation the ordering acquired is released exactly once, and each element is destroyed exactly once
+
+#### Scenario: Search a sorted vector
+
+- **WHEN** a program searches a sorted vector for an element it holds and for one it does not
+- **THEN** the present element yields its index and the missing element yields an absent value

--- a/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-type-generics/spec.md
+++ b/openspec/changes/admit-user-interface-witnesses/specs/bootstrap-type-generics/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: A bounded parameter specializes at a user type and reaches its witness
+
+Specialization SHALL admit a user-defined nominal type as the argument for a parameter bounded by an
+interface whenever that type's conformance covers the bound's whole contract, on the same terms as a
+built-in scalar. An operator on a bound-typed operand SHALL reach the operation the argument's
+conformance maps: the sealed operation when the mapping names an intrinsic, and an ordinary static
+call to the provider's own function when it names one, with each operand passed by shared borrow.
+The redirected call SHALL be reachable from instance discovery even though no ordinary call names
+it, SHALL remain fully static — no requirement row, no provider slot, and no runtime dispatch — and
+SHALL NOT consume either operand.
+
+An operand read that serves only such a call SHALL be permitted to observe a non-`Copy` place: a
+place read whose value is never accessed as an owner and is borrowed shared claims nothing, so it
+can be neither moved, dropped, nor written through.
+
+#### Scenario: Specialize a two-operation bound at a user struct
+
+- **WHEN** a user struct maps both operations of an interface declaring `add` and `lessThan`, and a generic bounded by it is specialized at that struct
+- **THEN** the specialization is admitted and each operator reaches the struct's own mapped function
+
+#### Scenario: Keep a scalar argument on its compiler-known operation
+
+- **WHEN** the same generic is specialized at `i32`, whose conformance maps the operation to an intrinsic
+- **THEN** the operator lowers to the compiler-known operation with no call to source
+
+#### Scenario: Order a move-only element type
+
+- **WHEN** a bound-typed operand is an element type that owns an allocation and is therefore never `Copy`
+- **THEN** the comparison borrows the element rather than moving it, and the element is neither duplicated nor released twice
+
+#### Scenario: Reject an incomplete witness at the specialization
+
+- **WHEN** a user type's conformance maps only some of the bound's operations and a call specializes at it
+- **THEN** the call is rejected naming each operation the type does not implement

--- a/openspec/changes/admit-user-interface-witnesses/tasks.md
+++ b/openspec/changes/admit-user-interface-witnesses/tasks.md
@@ -1,0 +1,35 @@
+## 1. Witness Admissibility
+
+- [x] 1.1 Accept a `<Provider>.<function>` mapping target in the interface conformance branch of the
+      declaration index, resolving the function in the provider type's own module.
+- [x] 1.2 Check the source witness against the substituted contract: same arity, each operand a
+      shared borrow of the contract's operand type, the contract's result by value, ordinary
+      function kind, no type parameters, no failure row, and no requirement row.
+- [x] 1.3 Report a mapping whose provider-qualified name matches no declaration as a mapped
+      operation that does not exist, and keep the `Intrinsic.*` branch's checks unchanged.
+- [x] 1.4 Add `interfaceWitnessImplementation`, selecting the provider function one conformance maps
+      an operation to and returning nothing for an intrinsic target.
+
+## 2. Specialization And Dispatch
+
+- [x] 2.1 Record the bound interface operation an operator spells — capability, provider parameter,
+      and operation name — on the operator fact and on the `BuiltinCall` it produces.
+- [x] 2.2 Follow the conformance during instance discovery so a source witness is reachable even
+      though no ordinary call names it.
+- [x] 2.3 Lower a redirected operator to a shared borrow of each operand local and one ordinary
+      static call, leaving an intrinsic-mapped operator on its compiler-known operation.
+- [x] 2.4 License a place read that is never accessed as an owner and is borrowed shared to observe
+      a non-`Copy` place, as the shared match projection already is.
+
+## 3. Acceptance
+
+- [x] 3.1 Add tests declaring a two-operation interface, witnessing it with a user struct, and
+      specializing a generic bounded by it at that struct so both operations are reached.
+- [x] 3.2 Add tests rejecting an incomplete conformance by operation name, a by-value operand, a
+      disagreeing result, and a mapping to a function the provider does not declare.
+- [x] 3.3 Add a test specializing one bound at both a scalar and a user type in one program.
+- [x] 3.4 Write PR #126's first unmet criterion: sort stability over a user element type whose equal
+      elements stay distinguishable.
+- [x] 3.5 Write PR #126's second unmet criterion: a sort over a move-only element type asserting the
+      acquire and release counts agree.
+- [x] 3.6 Keep `Integer`, `Order`, and every shipped `Intrinsic.*` witness passing unchanged.

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -3457,11 +3457,88 @@ export const complete = (self: Index, resolver: TypeResolver): Index => {
           continue
         }
         if (invalid) continue
+        const interfaceProviderModule = Type.isNominal(provider)
+          ? modules.find((candidate) => candidate.module === provider.module)
+          : undefined
         for (const contract of sourceInterface.operations) {
           if (contract.name._tag !== 'Present') continue
           const mapping = mapped.get(contract.name.spelling)
           if (mapping === undefined) continue
           const target = mapping.target
+          const contractName = contract.name.spelling
+          const contractShape =
+            contract.functionKind === 'Ordinary' &&
+            contract.failureRow.failures.length === 0 &&
+            contract.requirementRow.requirements.length === 0
+          const reject = (): void => {
+            diagnostics.push(
+              Diagnostic.invalidConformance(
+                `${target._tag === 'TypePath' ? target.spelling : '_'} is incompatible with ${capability.name}.${contractName}`,
+                mapping.syntax.span,
+              ),
+            )
+          }
+          // A witness names either one sealed intrinsic or one function of the provider's own
+          // actor. The two targets are checked against the same substituted contract; only the
+          // operand form differs, because a source witness observes each operand through a shared
+          // borrow while an intrinsic consumes the scalar the operand denotes.
+          if (
+            Type.isNominal(provider) &&
+            target._tag === 'TypePath' &&
+            target.segments.length === 2 &&
+            target.segments.at(0)?.spelling === provider.name &&
+            target.segments.at(0)?.spelling !== 'Intrinsic'
+          ) {
+            const targetName = target.segments.at(1)?.spelling
+            const implementation = interfaceProviderModule?.declarations.find(
+              (declaration) =>
+                targetName !== undefined &&
+                declaration.name._tag === 'Present' &&
+                declaration.name.spelling === targetName,
+            )
+            if (implementation === undefined) {
+              diagnostics.push(
+                Diagnostic.invalidConformance(
+                  `mapped operation ${provider.name}.${targetName ?? '_'} does not exist`,
+                  mapping.syntax.span,
+                ),
+              )
+              continue
+            }
+            const validParameters =
+              implementation.parameters.length === contract.parameters.length &&
+              contract.parameters.every((parameter, ordinal) => {
+                const actual = implementation.parameters.at(ordinal)?.declaredType
+                return (
+                  parameter.declaredType._tag === 'Resolved' &&
+                  actual?._tag === 'Resolved' &&
+                  Type.isReference(actual.type) &&
+                  actual.type.access === 'Shared' &&
+                  Type.equals(
+                    Type.substitute(parameter.declaredType.type, substitution),
+                    actual.type.target,
+                  )
+                )
+              })
+            const validResult =
+              implementation.returnType._tag === 'Resolved' &&
+              contract.returnType._tag === 'Resolved' &&
+              Type.equals(
+                Type.substitute(contract.returnType.type, substitution),
+                implementation.returnType.type,
+              )
+            if (
+              !contractShape ||
+              !validParameters ||
+              !validResult ||
+              implementation.functionKind !== 'Ordinary' ||
+              implementation.typeParameters.length > 0 ||
+              implementation.failureRow.failures.length > 0 ||
+              implementation.requirementRow.requirements.length > 0
+            )
+              reject()
+            continue
+          }
           const operation =
             target._tag === 'TypePath' &&
             target.segments.length === 2 &&
@@ -3489,18 +3566,11 @@ export const complete = (self: Index, resolver: TypeResolver): Index => {
           if (
             operation === undefined ||
             operation.unsafe ||
-            contract.functionKind !== 'Ordinary' ||
+            !contractShape ||
             !validParameters ||
-            !validResult ||
-            contract.failureRow.failures.length > 0 ||
-            contract.requirementRow.requirements.length > 0
+            !validResult
           )
-            diagnostics.push(
-              Diagnostic.invalidConformance(
-                `${target._tag === 'TypePath' ? target.spelling : '_'} is incompatible with ${capability.name}.${contract.name.spelling}`,
-                mapping.syntax.span,
-              ),
-            )
+            reject()
         }
         continue
       }
@@ -4094,6 +4164,42 @@ export const unmappedInterfaceOperations = (
         : [],
     ),
   )
+}
+
+/**
+ * Selects the provider's own function that its interface conformance maps one operation to.
+ *
+ * Nothing is returned when the mapping names a sealed intrinsic instead, which is the whole answer
+ * for every scalar witness: specialization keeps lowering those operators to the compiler-known
+ * operation and only a source-declared target redirects the call to ordinary Silk.
+ */
+export const interfaceWitnessImplementation = (
+  self: Index,
+  provider: Type.Type,
+  capability: Type.Nominal,
+  operation: string,
+): CanonicalId | undefined => {
+  if (!Type.isNominal(provider)) return undefined
+  const mapping = interfaceConformance(self, provider, capability)?.operations.find(
+    (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === operation,
+  )
+  const target = mapping?.target
+  if (
+    target?._tag !== 'TypePath' ||
+    target.segments.length !== 2 ||
+    target.segments.at(0)?.spelling !== provider.name
+  )
+    return undefined
+  const targetName = target.segments.at(1)?.spelling
+  const declaration = self.modules
+    .find((module) => module.module === provider.module)
+    ?.declarations.find(
+      (candidate) =>
+        targetName !== undefined &&
+        candidate.name._tag === 'Present' &&
+        candidate.name.spelling === targetName,
+    )
+  return declaration?.canonical._tag === 'Canonical' ? declaration.canonical.id : undefined
 }
 
 /** Selects the unique compiler-shipped or source-declared witness for one provider. */

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -558,8 +558,23 @@ export interface OperatorExpressionFact {
   readonly arguments: ReadonlyArray<ArgumentFact>
   readonly mappings: ReadonlyArray<BuiltinArgumentMappingFact>
   readonly contract: CallContractFact
+  readonly interfaceOperation?: InterfaceOperationFact
   readonly type: ExpressionTypeFact
   readonly syntax: SyntaxTree.Node
+}
+
+/**
+ * The bound contract one operator resolves through inside a generic body.
+ *
+ * The operator still elaborates against the compiler-known operation of a stand-in actor, because
+ * the operand type is not known until specialization. This records which interface operation the
+ * operator spells so specialization can redirect the call to a source witness; a scalar argument
+ * keeps the compiler-known operation and never consults it.
+ */
+export interface InterfaceOperationFact {
+  readonly capability: Type.Nominal
+  readonly provider: Type.Parameter
+  readonly operation: string
 }
 
 /** One declaration or builtin named as a callable value without invocation. */
@@ -4738,21 +4753,33 @@ const analyzeOperatorExpression = (
     )
   }
   const selectedFirstType = argumentsResult.facts.at(0)?.type
-  const genericInterface =
+  const boundOperand =
     selectedFirstType?._tag === 'Available' && Type.isParameter(selectedFirstType.type)
-      ? declaration.typeParameters.some((parameter) => {
+      ? selectedFirstType.type
+      : undefined
+  const interfaceOperation =
+    boundOperand === undefined
+      ? undefined
+      : declaration.typeParameters.flatMap((parameter): ReadonlyArray<InterfaceOperationFact> => {
           // Every operation the bound declares is callable on a bound-typed operand, so an operator
           // stays generic exactly when the bound's contract names the operation it spells.
           const bound = parameter.bound
-          if (
-            !Type.equals(parameter.type, selectedFirstType.type) ||
-            bound?._tag !== 'ResolvedBound'
-          )
-            return false
+          if (!Type.equals(parameter.type, boundOperand) || bound?._tag !== 'ResolvedBound')
+            return []
           const operationName = `${operator.slice(0, 1).toLowerCase()}${operator.slice(1)}`
           return bound.operations.includes(operationName)
-        })
-      : false
+            ? [
+                Object.freeze({
+                  capability: Type.nominal(bound.capability.module, bound.capability.name, [
+                    boundOperand,
+                  ]),
+                  provider: boundOperand,
+                  operation: operationName,
+                }),
+              ]
+            : []
+        })[0]
+  const genericInterface = interfaceOperation !== undefined
   const selectedActor: Operator.Actor =
     selectedFirstType?._tag === 'Available' && Type.isString(selectedFirstType.type)
       ? 'string'
@@ -4809,6 +4836,7 @@ const analyzeOperatorExpression = (
       arguments: argumentsResult.facts,
       mappings: builtinArgumentMappings(reference, argumentsResult.facts),
       contract: contract.fact,
+      ...(interfaceOperation === undefined ? {} : { interfaceOperation }),
       type: expressionType,
       syntax: node,
     }),
@@ -7882,6 +7910,9 @@ const hirExpression = (fact: ExpressionFact, borrow?: Hir.BorrowId): Hir.Express
       _tag: 'BuiltinCall',
       operation: fact.reference.operation,
       intrinsic: fact.reference.intrinsic,
+      ...(fact._tag === 'Operator' && fact.interfaceOperation !== undefined
+        ? { interfaceOperation: fact.interfaceOperation }
+        : {}),
       typeArguments: Object.freeze(
         fact._tag === 'Call'
           ? fact.typeArguments.flatMap((argument) =>

--- a/packages/compiler/src/Hir.ts
+++ b/packages/compiler/src/Hir.ts
@@ -536,6 +536,16 @@ export type Expression =
       readonly _tag: 'BuiltinCall'
       readonly operation: BuiltinOperation
       readonly intrinsic: Intrinsic.OperationId
+      /**
+       * The bound interface operation an operator inside a generic body spells. Specialization
+       * redirects the call to the provider's own function when the conformance maps one, and
+       * otherwise keeps the compiler-known operation this node already names.
+       */
+      readonly interfaceOperation?: {
+        readonly capability: Type.Nominal
+        readonly provider: Type.Parameter
+        readonly operation: string
+      }
       readonly typeArguments: ReadonlyArray<Type.Type>
       readonly arguments: ReadonlyArray<Expression>
       readonly loanEnds: ReadonlyArray<BorrowId>

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -582,6 +582,51 @@ const slotDropHookTargets = (
   return fn.statements.flatMap((statement) => Hir.statementExpressions(statement).flatMap(walk))
 }
 
+/**
+ * Collects the provider functions a specialized body's bound operators dispatch to.
+ *
+ * A source witness is reachable through the operator that spells its operation and through no
+ * ordinary call, so discovery has to read the conformance itself; a scalar argument maps the same
+ * operator to a sealed intrinsic and contributes no target.
+ */
+const interfaceWitnessTargets = (
+  fn: Hir.HirFunction,
+  index: DeclarationIndex.Index,
+  substitution: Type.Substitution,
+): ReadonlyArray<CallTarget> => {
+  const walk = (expression: Hir.Expression): ReadonlyArray<CallTarget> => {
+    const bound = expression._tag === 'BuiltinCall' ? expression.interfaceOperation : undefined
+    const capability =
+      bound === undefined ? undefined : Type.substitute(bound.capability, substitution)
+    const target =
+      bound === undefined || capability === undefined || !Type.isNominal(capability)
+        ? undefined
+        : DeclarationIndex.interfaceWitnessImplementation(
+            index,
+            Type.substitute(bound.provider, substitution),
+            capability,
+            bound.operation,
+          )
+    const own =
+      target === undefined
+        ? []
+        : [Object.freeze({ declaration: target, typeArguments: Object.freeze([]) })]
+    if (expression._tag === 'Match') {
+      return [
+        ...own,
+        ...walk(expression.scrutinee),
+        ...expression.arms.flatMap((arm) =>
+          arm.reachable
+            ? [...(arm.guard === undefined ? [] : walk(arm.guard)), ...walk(arm.result)]
+            : [],
+        ),
+      ]
+    }
+    return [...own, ...Hir.expressionChildren(expression).flatMap(walk)]
+  }
+  return fn.statements.flatMap((statement) => Hir.statementExpressions(statement).flatMap(walk))
+}
+
 const callableBindings = (fn: Hir.HirFunction): ReadonlyMap<number, Hir.Expression> => {
   const bindings = new Map<number, Hir.Expression>()
   const expression = (value: Hir.Expression): void => {
@@ -1355,6 +1400,7 @@ export const discover = (
     const cleanupIdentities = new Set(cleanupTargets.map(identityOfCall))
     for (const call of [
       ...bodyCallTargets(fn),
+      ...interfaceWitnessTargets(fn, index, substitution),
       ...requirementBindingCallTargets(fn, substitution, index),
       ...directCalls.map((call) => ({
         declaration: call.target.declaration,

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -1043,6 +1043,91 @@ const lowerEffectExecution = (
   return lowerRunEffectValue(fn, lowered.result, loweredType, success, span, availableRequirements)
 }
 
+/**
+ * Redirects one bound operator to the provider's own function when specialization lands on a type
+ * whose conformance maps the operation to source rather than to a sealed intrinsic.
+ *
+ * An interface operation never consumes its operands — a builtin operator does not, and a generic
+ * body is checked with the element type non-`Copy` — so the witness observes each operand through a
+ * shared borrow of the local the operand already lowered to. The borrow lives only across the call,
+ * and its identity cannot collide with an argument borrow at the same span because a bound operand
+ * has the bound's own type and is therefore never itself a borrow expression.
+ */
+const lowerInterfaceWitnessCall = (
+  fn: FunctionLowering,
+  expression: Extract<Hir.Expression, { readonly _tag: 'BuiltinCall' }>,
+  argumentLocals: ReadonlyArray<Mir.LocalId>,
+): Mir.LocalId | undefined => {
+  const bound = expression.interfaceOperation
+  if (bound === undefined) return undefined
+  const provider = fn.semantic(bound.provider)
+  const capability = fn.semantic(bound.capability)
+  if (!Type.isNominal(capability)) return undefined
+  const target = DeclarationIndex.interfaceWitnessImplementation(
+    fn.index,
+    provider,
+    capability,
+    bound.operation,
+  )
+  const providerType = fn.type(provider)
+  const resultType = fn.type(expression.type)
+  const referenceType = fn.type(Type.reference('Shared', provider))
+  if (
+    target === undefined ||
+    providerType === undefined ||
+    resultType === undefined ||
+    referenceType?._tag !== 'Reference'
+  )
+    return undefined
+  const borrows = argumentLocals.map((argument, ordinal) => {
+    const borrow = Object.freeze({
+      _tag: 'BorrowId' as const,
+      function: fn.owner.function.declaration.id,
+      callSpan: expression.span,
+      ordinal,
+    })
+    const destination = fn.alloc(referenceType)
+    fn.emit(
+      Object.freeze({
+        _tag: 'BeginLoan',
+        borrow,
+        destination,
+        root: argument,
+        selectors: Object.freeze([]),
+        sourceType: providerType,
+        type: referenceType,
+        access: 'Shared',
+        reborrow: false,
+        suspendsParent: false,
+        provenance: generated(expression.span),
+      }),
+    )
+    return Object.freeze({ borrow, local: destination })
+  })
+  const destination = fn.alloc(resultType)
+  fn.emit(
+    Object.freeze({
+      _tag: 'Call',
+      destination,
+      target,
+      typeArguments: Object.freeze([]),
+      arguments: Object.freeze(borrows.map((entry) => entry.local)),
+      type: resultType,
+      provenance: generated(expression.span),
+    }),
+  )
+  for (const entry of borrows)
+    fn.emit(
+      Object.freeze({
+        _tag: 'EndLoan',
+        borrow: entry.borrow,
+        slice: entry.local,
+        provenance: generated(expression.span),
+      }),
+    )
+  return destination
+}
+
 function lowerExpression(
   fn: FunctionLowering,
   expression: Hir.Expression,
@@ -2554,6 +2639,8 @@ function lowerExpressionInner(
         if (slot !== undefined && inherited.length > 0) fn.slotLoans.delete(slot.ordinal)
         return Object.freeze({ result })
       }
+      const witnessCall = lowerInterfaceWitnessCall(fn, expression, argumentLocals)
+      if (witnessCall !== undefined) return finishBuiltin(witnessCall)
       if (expression.operation === 'LayoutOf') {
         const raw = expression.typeArguments.at(0)
         const element = raw === undefined ? undefined : fn.semantic(raw)

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -3371,13 +3371,33 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                 candidate.scrutinee.ordinal === operation.destination.ordinal &&
                 (candidate.access === 'Shared' || candidate.access === 'Exclusive'),
             )
+          // A read whose value is never accessed as an owner and is only borrowed shared observes
+          // the place without claiming it: it cannot be moved, dropped, or written through, so a
+          // non-Copy element reaches an interface witness without being duplicated in any sense a
+          // later release could notice. This is the same license the shared match projection has.
+          const sharedBorrowProjection =
+            operation._tag === 'ReadPlace' &&
+            operation.consume !== true &&
+            operations.every(
+              (candidate) =>
+                !accessedOwnerLocals(candidate).some(
+                  (local) => local.ordinal === operation.destination.ordinal,
+                ),
+            ) &&
+            operations.some(
+              (candidate) =>
+                candidate._tag === 'BeginLoan' &&
+                candidate.access === 'Shared' &&
+                candidate.root.ordinal === operation.destination.ordinal,
+            )
           if (
             selected === undefined ||
             !SilkType.equals(selected, semanticType(operation.type)) ||
             (operation._tag === 'ReadPlace' &&
               !isStructurallyCopy(self.layout, selected) &&
               operation.consume !== true &&
-              !sharedMatchProjection)
+              !sharedMatchProjection &&
+              !sharedBorrowProjection)
           ) {
             violations.push(
               Object.freeze({

--- a/packages/compiler/test/UserInterfaceWitness.test.ts
+++ b/packages/compiler/test/UserInterfaceWitness.test.ts
@@ -1,0 +1,273 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const analyzed = (name: string, source: string) => Analysis.ofSourceRealized(name, ascii(source))
+
+const messages = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.message)
+
+const evaluatedValue = (name: string, source: string) =>
+  Effect.gen(function* () {
+    const snapshot = yield* analyzed(name, source)
+    assert.deepEqual(messages(snapshot), [])
+    const outcome = Analysis.evaluate(snapshot)
+    assert.strictEqual(
+      outcome._tag,
+      'Completed',
+      JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value)),
+    )
+    return outcome._tag === 'Completed' ? outcome.result.value : undefined
+  })
+
+/**
+ * One user-declared interface with two operator-spelled operations, one user struct witnessing
+ * both, and one generic body bounded by the interface. A witness observes each operand through a
+ * shared borrow, because an interface operation never consumes what it compares or combines.
+ */
+const twoOperations = `interface Blend<T> {
+  fn add(left: T, right: T) -> T
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+fn cellAdd(left: &Cell, right: &Cell) -> Cell {
+  return Cell { weight: left.weight + right.weight }
+}
+
+fn cellLess(left: &Cell, right: &Cell) -> bool {
+  return left.weight < right.weight
+}
+
+impl Blend<Cell> for Cell {
+  add: Cell.cellAdd
+  lessThan: Cell.cellLess
+}
+
+/// Reaches both mapped operations: the comparison decides the branch and the sum is the result.
+fn merged<T: Blend>(left: T, right: T) -> T {
+  if left < right {
+    return left + right
+  }
+  return right + left
+}
+`
+
+it.effect('specializes a two-operation bound at a user struct and calls both operations', () =>
+  Effect.gen(function* () {
+    // 3 < 8 takes the first branch, and the mapped `add` folds the two weights into 11.
+    const value = yield* evaluatedValue(
+      'user-witness/two-operations',
+      `${twoOperations}
+pub fn main() -> i32 {
+  let blended = merged<Cell>(Cell { weight: 3 }, Cell { weight: 8 })
+  let reversed = merged<Cell>(Cell { weight: 8 }, Cell { weight: 3 })
+  return blended.weight * 100 + reversed.weight
+}`,
+    )
+    assert.strictEqual(value, 1111)
+  }),
+)
+
+it.effect('rejects a conformance that leaves one operation unmapped, naming it', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* analyzed(
+      'user-witness/missing-operation',
+      `interface Blend<T> {
+  fn add(left: T, right: T) -> T
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+fn cellLess(left: &Cell, right: &Cell) -> bool {
+  return left.weight < right.weight
+}
+
+impl Blend<Cell> for Cell {
+  lessThan: Cell.cellLess
+}
+
+pub fn main() -> i32 { return 0 }`,
+    )
+    assert.deepEqual(messages(snapshot), ['Invalid conformance: missing add'])
+  }),
+)
+
+it.effect('rejects a bounded specialization at a type whose conformance is incomplete', () =>
+  Effect.gen(function* () {
+    // The coverage check reaches the call site too: a half-mapped witness cannot satisfy a bound.
+    const snapshot = yield* analyzed(
+      'user-witness/incomplete-specialization',
+      `interface Blend<T> {
+  fn add(left: T, right: T) -> T
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+fn cellLess(left: &Cell, right: &Cell) -> bool {
+  return left.weight < right.weight
+}
+
+impl Blend<Cell> for Cell {
+  lessThan: Cell.cellLess
+}
+
+fn ordered<T: Blend>(left: T, right: T) -> bool {
+  return left < right
+}
+
+pub fn main() -> i32 {
+  if ordered<Cell>(Cell { weight: 1 }, Cell { weight: 2 }) { return 1 }
+  return 0
+}`,
+    )
+    assert.include(
+      messages(snapshot),
+      'Invalid conformance: user-witness/incomplete-specialization.Cell does not implement Blend.add',
+    )
+  }),
+)
+
+it.effect('rejects a witness whose operand is taken by value rather than by shared borrow', () =>
+  Effect.gen(function* () {
+    // A by-value operand would consume what the operator only reads, so it cannot witness.
+    const snapshot = yield* analyzed(
+      'user-witness/by-value-operand',
+      `interface Ordered<T> {
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+fn cellLess(left: Cell, right: Cell) -> bool {
+  return left.weight < right.weight
+}
+
+impl Ordered<Cell> for Cell {
+  lessThan: Cell.cellLess
+}
+
+pub fn main() -> i32 { return 0 }`,
+    )
+    assert.deepEqual(messages(snapshot), [
+      'Invalid conformance: Cell.cellLess is incompatible with Ordered.lessThan',
+    ])
+  }),
+)
+
+it.effect('rejects a witness whose result disagrees with the contract', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* analyzed(
+      'user-witness/wrong-result',
+      `interface Ordered<T> {
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+fn cellLess(left: &Cell, right: &Cell) -> i32 {
+  return left.weight - right.weight
+}
+
+impl Ordered<Cell> for Cell {
+  lessThan: Cell.cellLess
+}
+
+pub fn main() -> i32 { return 0 }`,
+    )
+    assert.deepEqual(messages(snapshot), [
+      'Invalid conformance: Cell.cellLess is incompatible with Ordered.lessThan',
+    ])
+  }),
+)
+
+it.effect('rejects a mapping that names a function the provider actor does not declare', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* analyzed(
+      'user-witness/absent-function',
+      `interface Ordered<T> {
+  fn lessThan(left: T, right: T) -> bool
+}
+
+struct Cell {
+  weight: i32
+}
+
+impl Ordered<Cell> for Cell {
+  lessThan: Cell.absent
+}
+
+pub fn main() -> i32 { return 0 }`,
+    )
+    assert.deepEqual(messages(snapshot), [
+      'Invalid conformance: mapped operation Cell.absent does not exist',
+    ])
+  }),
+)
+
+it.effect('keeps the standard library Order and Integer witnesses selecting their intrinsics', () =>
+  Effect.gen(function* () {
+    // The user witness path must not disturb the scalar one: both interfaces still specialize
+    // through `Intrinsic.*` for every scalar the standard library maps.
+    const value = yield* evaluatedValue(
+      'user-witness/intrinsic-unchanged',
+      `import silk.order { less }
+import silk.numeric { add }
+pub fn main() -> i32 {
+  let mut score = 0
+  if less<i32>(1, 2) { score = score + 1 }
+  if less<u8>(2, 1) { score = score + 10 }
+  return score + add<i32>(20, 21)
+}`,
+    )
+    assert.strictEqual(value, 42)
+  }),
+)
+
+it.effect('lets a user witness and an intrinsic witness serve the same interface', () =>
+  Effect.gen(function* () {
+    // One generic body, two specializations: `i32` keeps the compiler-known comparison and `Cell`
+    // reaches ordinary Silk, so the two witness kinds coexist under one bound.
+    const value = yield* evaluatedValue(
+      'user-witness/mixed-witnesses',
+      `import silk.order { Order, less }
+
+struct Cell {
+  weight: i32
+}
+
+fn cellLess(left: &Cell, right: &Cell) -> bool {
+  return left.weight < right.weight
+}
+
+impl Order<Cell> for Cell {
+  lessThan: Cell.cellLess
+}
+
+pub fn main() -> i32 {
+  let mut score = 0
+  if less<i32>(1, 2) { score = score + 1 }
+  if less<Cell>(Cell { weight: 5 }, Cell { weight: 4 }) { score = score + 10 }
+  if less<Cell>(Cell { weight: 4 }, Cell { weight: 5 }) { score = score + 100 }
+  return score
+}`,
+    )
+    assert.strictEqual(value, 101)
+  }),
+)

--- a/packages/compiler/test/VectorSort.test.ts
+++ b/packages/compiler/test/VectorSort.test.ts
@@ -300,3 +300,119 @@ it.effect(
     }),
   60_000,
 )
+
+/**
+ * Stability is only observable when two elements can compare equal yet stay distinguishable. Every
+ * conforming type used to be a scalar, whose equality is identity, so this program could not be
+ * written until a user type could witness `Order`. `Item` compares on `key` alone and carries a
+ * `tag` the comparison never reads, so the arrangement of the equal elements is visible in the
+ * result.
+ */
+const stableUserOrder = `import silk.order { Order }
+import silk.vector { Vector, make, append, asSlice, sort, length }
+
+struct Item {
+  key: i32
+  tag: i32
+}
+
+fn itemLess(left: &Item, right: &Item) -> bool {
+  return left.key < right.key
+}
+
+impl Order<Item> for Item { lessThan: Item.itemLess }
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut items = make<Item>()
+  let a = run append<Item>(&mut items, Item { key: 1, tag: 1 }) |> Effect.provideMut(&mut allocator)
+  let b = run append<Item>(&mut items, Item { key: 0, tag: 2 }) |> Effect.provideMut(&mut allocator)
+  let c = run append<Item>(&mut items, Item { key: 1, tag: 3 }) |> Effect.provideMut(&mut allocator)
+  let d = run append<Item>(&mut items, Item { key: 0, tag: 4 }) |> Effect.provideMut(&mut allocator)
+  let ordered = run sort<Item>(&mut items) |> Effect.provideMut(&mut allocator)
+  let view = asSlice<Item>(&items)
+  let mut folded = 0
+  let mut index = usize.ZERO
+  while index < length<Item>(&items) {
+    folded = folded * 10 + view[index].tag
+    index = index + usize.ONE
+  }
+  return folded
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 99 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect('keeps equal elements of a user type in their input order', () =>
+  Effect.gen(function* () {
+    // Tags 1..4 carry keys [1, 0, 1, 0]. A stable order yields keys [0, 0, 1, 1] with tags 2, 4,
+    // 1, 3 — the two equal-key pairs each in input order. Any unstable placement folds otherwise.
+    const value = yield* evaluatedValue('vector-sort/stable-user-order', stableUserOrder)
+    assert.strictEqual(value, 2413)
+  }),
+)
+
+/**
+ * A sort over an element type that owns an allocation and is therefore never `Copy`. Nothing in
+ * the comparison, the index permutation, or the final bulk move may duplicate or lose one, so the
+ * acquire and release counts have to agree exactly.
+ */
+const moveOnlyElements = `import silk.order { Order }
+import silk.vector { Vector, make, append, asSlice, sort, length }
+
+struct Tracked {
+  key: i32
+  payload: Vector<i32>
+}
+
+fn trackedLess(left: &Tracked, right: &Tracked) -> bool {
+  return left.key < right.key
+}
+
+impl Order<Tracked> for Tracked { lessThan: Tracked.trackedLess }
+
+effect fn hold(key: i32) -> Tracked ! OutOfMemory ? &mut Allocator {
+  let mut payload = make<i32>()
+  let filled = run append<i32>(&mut payload, key)
+  return Tracked { key: key, payload: move payload }
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut items = make<Tracked>()
+  let first = run hold(3) |> Effect.provideMut(&mut allocator)
+  let a = run append<Tracked>(&mut items, move first) |> Effect.provideMut(&mut allocator)
+  let second = run hold(1) |> Effect.provideMut(&mut allocator)
+  let b = run append<Tracked>(&mut items, move second) |> Effect.provideMut(&mut allocator)
+  let third = run hold(2) |> Effect.provideMut(&mut allocator)
+  let c = run append<Tracked>(&mut items, move third) |> Effect.provideMut(&mut allocator)
+  let ordered = run sort<Tracked>(&mut items) |> Effect.provideMut(&mut allocator)
+  let view = asSlice<Tracked>(&items)
+  let mut folded = 0
+  let mut index = usize.ZERO
+  while index < length<Tracked>(&items) {
+    folded = folded * 10 + view[index].key
+    index = index + usize.ONE
+  }
+  return folded
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 99 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect('sorts a move-only element type and releases every allocation it acquires', () =>
+  Effect.gen(function* () {
+    const outcome = yield* evaluate('vector-sort/move-only-elements', moveOnlyElements)
+    if (outcome._tag !== 'Completed') return
+    // Keys [3, 1, 2] order to [1, 2, 3]: each element travelled without being duplicated or lost.
+    assert.strictEqual(outcome.result.value, 123)
+    const acquires = outcome.trace.filter((event) => event._tag === 'AllocationAcquire')
+    const releases = outcome.trace.filter((event) => event._tag === 'AllocationRelease')
+    // Each element owns one allocation of its own, so a duplicated element would leak one and a
+    // lost element would release one twice. The counts agree only when neither happened.
+    assert.isAbove(acquires.length, 0)
+    assert.strictEqual(releases.length, acquires.length)
+  }),
+)


### PR DESCRIPTION
Closes #129

`DeclarationIndex.ts` accepted an interface witness only when the mapping target was a two-segment `Intrinsic.*` path, so every type that could conform to any interface was a built-in scalar and no user-defined type could conform at all. Because every scalar is `Copy` and its equality is identity, that made sort stability unobservable and a move-only element type impossible — which is why PR #126 could not write two of its own acceptance criteria.

## What changed

**Witness admissibility.** A conformance may now map an operation to `Provider.function`, naming one function of the provider type's own actor — the same actor-qualified spelling a service conformance already uses (`impl FileSystem for OsFileSystem { readFile: OsFileSystem.readFile }`). It is checked against the same substituted contract as an `Intrinsic.*` target: same arity, same operand and result types, ordinary function kind, no type parameters, no failure row, no requirement row. #103's complete-coverage check applies unchanged, and a mapping naming a function that does not exist now says so rather than reporting a signature mismatch.

**Operand form.** A source witness receives each contract operand by shared borrow and returns the contract result by value: `fn cellLess(left: &Cell, right: &Cell) -> bool` witnesses `fn lessThan(left: T, right: T) -> bool`. This is forced, not chosen. An interface operation never consumes its operands (ownership checks a builtin call's arguments non-consumingly, which is why `slice[i] < slice[j]` is accepted in an `Order`-bounded body), and `Ownership.categoryOf` classifies every nominal as `MoveOnly`, so a by-value operand could only be supplied by a move the ownership checker already rejects. The interface declaration itself is untouched, so the intrinsic witnesses keep taking values.

**Dispatch.** An operator in a generic body still elaborates against a stand-in actor's compiler-known operation, but now records the bound interface operation it spells on its `BuiltinCall`. At specialization, an operand type whose conformance maps that operation to source lowers to a shared borrow of each operand and one ordinary static call; instance discovery walks the conformance so the witness is reachable, since no ordinary call names it. A scalar records nothing to redirect to and lowers exactly as before. No requirement row, no provider slot, no runtime dispatch, no representation change.

**One MIR license.** Lowering a redirected operator over a move-only element reads the operand place into a temporary and borrows it. MIR already licenses one such borrow-like read — a value feeding a shared `Match` and nothing else. The same license is extended to a read whose value is never accessed as an owner and is borrowed shared: it can be neither moved, dropped, nor written through, so no release can notice it.

## Acceptance criteria

- [x] A user struct conforms to a two-operation interface and a generic bounded by it specializes at that struct and calls both operations
- [x] A user struct whose conformance omits an operation is rejected, naming the operation — at the conformance and again at the specialization
- [x] **PR #126's two unmet criteria are written**: sort stability over a user type with distinguishable-but-equal elements, and a sort over a move-only element type asserting acquires equal releases
- [x] `Integer` and every existing `Intrinsic.*` witness still pass unchanged, with their source untouched

## Out of scope, as specified

Blanket and conditional conformances, more than one interface per conformance, any runtime representation change, and #118's call surface for operations no operator spells. #118 composes with this and is worked in parallel.

## Spec

`openspec/changes/admit-user-interface-witnesses/` records what may serve as a witness target and the operand form each takes (`bootstrap-declaration-index`), what specialization does with it (`bootstrap-type-generics`), and that ordering is now witnessed by user types so stability is observable and a move-only element type can be ordered (`bootstrap-owned-sequence`, modified).

## Tests

Tests: baseline 0 failures, after 0 failures, +10 new tests.

The two known-ignore local failures are unchanged and unrelated: `compiler-cli` FormatCommand/FormatWorkflow (3, chmod vs root) and `packages/wasm` `Extended.test.ts` "threads address types". `packages/compiler` goes 1330 → 1340 passing, 0 failing.

Verified the new tests fail before the change: 5 of the 10 fail on `main`'s compiler sources — both sort criteria, the two-operation specialization, the mixed scalar/user witness program, and the absent-function diagnostic. The other 5 pin rejections that must not regress.

Also run: `pnpm exec biome check .`, `pnpm typecheck`, `pnpm test:scripts`, `pnpm release:candidate`, and `pnpm --filter @silk-effect/compiler documentation:generate` (no output change — the work adds no diagnostic code, reusing `invalidConformance`).