### PR TITLE
fix(backend): reload memory-backed roots at cleanup and outcome joins

### DIFF
--- a/packages/compiler/src/Backend.ts
+++ b/packages/compiler/src/Backend.ts
@@ -1346,6 +1346,41 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
               }),
             )
           }
+
+          /**
+           * Re-reads every memory-backed root from its storage into the local value cache.
+           *
+           * The cache holds SSA values, and an SSA value is only readable in blocks the block
+           * defining it dominates. Running this on entry to a block whose predecessors diverge
+           * re-establishes that: nothing cached from one predecessor survives into the join, and
+           * what replaces it is a load placed in the join itself. Storage is authoritative
+           * because every write to one of these roots stores through it, so the reloaded value
+           * is also the current one — a cleanup arm that mutated the root is observed, not
+           * discarded.
+           */
+          const reloadMutableRoots = Effect.fnUntraced(function* (tag: string) {
+            for (const root of [...mutableRoots].sort((left, right) => left - right)) {
+              const storage = mutableStorage.get(root)
+              if (storage === undefined) continue
+              const loaded: Array<Value.Input> = []
+              const logicalType = entry.fn.localTypes.at(root)
+              if (logicalType === undefined) throw new RangeError('Mutable root lost its type')
+              for (const [lane, pointer] of storage.entries()) {
+                const callingLane = valueLanesFor(logicalType).at(lane)
+                if (callingLane === undefined) throw new RangeError('Mutable root lost a lane')
+                loaded.push(
+                  yield* FunctionBody.load(
+                    body,
+                    laneType(callingLane),
+                    pointer,
+                    `mut${root}_${lane}_load_${tag}`,
+                  ),
+                )
+              }
+              locals.set(root, Object.freeze(loaded))
+            }
+          })
+
           const storeAddressRootValues = Effect.fnUntraced(function* (
             root: number,
             values: ReadonlyArray<Value.Input>,
@@ -2363,6 +2398,12 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
                     )
                     yield* FunctionBody.branch(body, followingBlock)
                     yield* LlvmBlock.setInsertionPoint(body, followingBlock)
+                    // The arm just emitted is only one of this join's two predecessors, so
+                    // anything it left in the value cache is unreadable here — a Drop hook
+                    // reloads its receiver after calling out, and those loads live in the arm.
+                    // Reloading re-roots the cache in this block, which is both valid SSA and
+                    // the value the arm may have just mutated.
+                    yield* reloadMutableRoots(`${tag}_u${caseEntry.ordinal}_next`)
                     continue
                   }
                   for (const [pathOrdinal, path] of paths.entries()) {
@@ -2406,28 +2447,7 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
             const blockHandle = blocks.get(block.id.ordinal)
             if (blockHandle === undefined) continue
             if (blockOrdinal > 0) yield* LlvmBlock.setInsertionPoint(body, blockHandle)
-            if (blockOrdinal > 0) {
-              for (const root of [...mutableRoots].sort((left, right) => left - right)) {
-                const storage = mutableStorage.get(root)
-                if (storage === undefined) continue
-                const loaded: Array<Value.Input> = []
-                const logicalType = entry.fn.localTypes.at(root)
-                if (logicalType === undefined) throw new RangeError('Mutable root lost its type')
-                for (const [lane, pointer] of storage.entries()) {
-                  const callingLane = valueLanesFor(logicalType).at(lane)
-                  if (callingLane === undefined) throw new RangeError('Mutable root lost a lane')
-                  loaded.push(
-                    yield* FunctionBody.load(
-                      body,
-                      laneType(callingLane),
-                      pointer,
-                      `mut${root}_${lane}_load_b${block.id.ordinal}`,
-                    ),
-                  )
-                }
-                locals.set(root, Object.freeze(loaded))
-              }
-            }
+            if (blockOrdinal > 0) yield* reloadMutableRoots(`b${block.id.ordinal}`)
             for (const operation of block.operations) {
               switch (operation._tag) {
                 case 'BindMatch': {
@@ -6152,6 +6172,9 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
                     )
                   }
                   yield* LlvmBlock.setInsertionPoint(body, followingBlock)
+                  // Both arms of this outcome dispatch reach here, so neither arm's cached
+                  // values are readable in the join. Reloading re-roots them at this block.
+                  yield* reloadMutableRoots(`effect_run${operation.destination.ordinal}_following`)
                   const storage = mutableStorage.get(operation.destination.ordinal)
                   if (storage === undefined)
                     throw new RangeError('Effect run destination is not materialized')
@@ -6318,6 +6341,11 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
                         ),
                   )
                   yield* LlvmBlock.setInsertionPoint(body, followingBlock)
+                  // Both arms of this outcome dispatch reach here, so neither arm's cached
+                  // values are readable in the join. Reloading re-roots them at this block.
+                  yield* reloadMutableRoots(
+                    `effect_value${operation.destination.ordinal}_following`,
+                  )
                   const storage = mutableStorage.get(operation.destination.ordinal)
                   if (storage === undefined)
                     throw new RangeError('Effect value run destination is not materialized')
@@ -6443,6 +6471,11 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
                     yield* FunctionBody.branch(body, followingBlock)
                   }
                   yield* LlvmBlock.setInsertionPoint(body, followingBlock)
+                  // Both arms of this outcome dispatch reach here, so neither arm's cached
+                  // values are readable in the join. Reloading re-roots them at this block.
+                  yield* reloadMutableRoots(
+                    `effect_result${operation.destination.ordinal}_following`,
+                  )
                   const storage = mutableStorage.get(operation.destination.ordinal)
                   if (storage === undefined)
                     throw new RangeError('Effect result destination is not materialized')
@@ -6557,6 +6590,12 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
                     yield* FunctionBody.branch(body, trapBlock)
                   }
                   yield* LlvmBlock.setInsertionPoint(body, following)
+                  // The success arm and every failure-tag arm reach here, so no arm's cached
+                  // values are readable in the join — and the failure arms run cleanup, which
+                  // reloads. Reloading re-roots the cache at this block.
+                  yield* reloadMutableRoots(
+                    `effect_entry${operation.destination.ordinal}_following`,
+                  )
                   const storage = mutableStorage.get(operation.destination.ordinal)
                   const pointer = storage?.at(0)
                   if (pointer === undefined)

--- a/packages/compiler/test/TemporaryDirectoryAcceptance.test.ts
+++ b/packages/compiler/test/TemporaryDirectoryAcceptance.test.ts
@@ -129,6 +129,52 @@ effect fn program() -> i32 ! FileError | OutOfMemory {
 ${epilogue}`
 
 /**
+ * Several populated scopes, each released while the others are still owned. This is the shape that
+ * trapped at `-O0` while #130's crash was being narrowed: one owner's cleanup is a conditional arm,
+ * and the values the arm reloads are read again at the arm's join. Both a populated tree and a live
+ * neighbour are needed — two bare scopes released in sequence do not reach it.
+ */
+const nativeManySource = `${prelude}
+
+effect fn program() -> i32 ! FileError | OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let mut fs = run osMake("${nativeRoot}") |> Effect.provideMut(&mut allocator)
+  let parent = run pathMake("/many") |> Effect.provideMut(&mut allocator)
+  let prepared = run Intrinsic.bindRequirement(
+    Intrinsic.bindRequirement(createDirectoriesRecursively(&parent), &mut fs),
+    &mut allocator
+  )
+  let payload = [u8.toU8(1), u8.toU8(2), u8.toU8(3)]
+${[0, 1, 2]
+  .map(
+    (index) => `  let scope${index} = run Intrinsic.bindRequirement(
+    Intrinsic.bindRequirement(temporaryDirectory(&parent, "silk-many${index}-"), &mut fs),
+    &mut allocator
+  )
+  let nested${index} = run pathJoin(&scope${index}.path, "nested") |> Effect.provideMut(&mut allocator)
+  let madeNested${index} = run Intrinsic.bindRequirement(
+    Intrinsic.bindRequirement(createDirectoriesRecursively(&nested${index}), &mut fs),
+    &mut allocator
+  )
+  let file${index} = run pathJoin(&nested${index}, "payload.bin") |> Effect.provideMut(&mut allocator)
+  let wrote${index} = run Intrinsic.bindRequirement(FileSystem.writeFile(&file${index}, &payload), &mut fs)
+  if run Intrinsic.bindRequirement(exists(&scope${index}.path), &mut fs) {} else { return ${index + 1} }`,
+  )
+  .join('\n')}
+${[0, 1, 2]
+  .map(
+    (index) => `  let released${index} = run Intrinsic.bindRequirement(
+    Intrinsic.bindRequirement(release(move scope${index}), &mut fs),
+    &mut allocator
+  )`,
+  )
+  .join('\n')}
+  return 42
+}
+
+${epilogue}`
+
+/**
  * The provider protocol on the evaluator: the provider chooses the name, so the created name comes
  * back through the output buffer, and a buffer too small creates nothing and reports the capacity
  * it needs. The retry counter is what proves the second half.
@@ -176,14 +222,10 @@ it.effect(
           root: SourceFile.make('temporary-directory/native', ascii(nativeSource)),
         },
         toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-        // Debug, not release. `removeDirectoryRecursively` is correct on both, but clang 18.1
-        // crashes in its own Register Coalescer pass while compiling that function's IR at -O2
-        // ("PLEASE submit a bug report to llvm/llvm-project"). The crash reproduces with the same
-        // function written in an ordinary user module, so it is a backend defect rather than
-        // anything this module can express differently — three separate formulations of the walk
-        // hit it. Native codegen and a real filesystem are still exercised here; only the
-        // optimizer level differs. Raise this to 'release' once the toolchain is fixed.
-        profile: 'debug',
+        // Release, so this also stands as the regression test for #130: the backend used to let
+        // a cleanup arm's reloaded lanes escape into the arm's join block, which is invalid SSA,
+        // and Clang crashed on it at -O2 instead of diagnosing it.
+        profile: 'release',
         destination: join(destinationRoot, 'native'),
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
@@ -218,8 +260,8 @@ it.effect(
           root: SourceFile.make('temporary-directory/native-tree', ascii(nativeTreeSource)),
         },
         toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-        // Debug for the same toolchain reason as above.
-        profile: 'debug',
+        // Release for the same reason as above — this is the walk #130 crashed on.
+        profile: 'release',
         destination: join(destinationRoot, 'native-tree'),
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
@@ -230,6 +272,40 @@ it.effect(
       assert.isFalse(existsSync(join(nativeRoot, 'tree')))
     }),
   120_000,
+)
+
+it.effect(
+  'releases each of several populated scopes while the rest are still owned',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'temporary-directory/native-many',
+        ascii(nativeManySource),
+      )
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+      const compiled = yield* Driver.compile({
+        compilation: {
+          root: SourceFile.make('temporary-directory/native-many', ascii(nativeManySource)),
+        },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'native-many'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      // Before #130 was fixed this trapped (SIGILL) even at -O0: a cleanup arm's reloaded lanes
+      // escaped into the arm's join block, so the join read an undefined union tag and fell
+      // through to the invalid-tag trap. The status, not just the absence of a crash, is what
+      // says the releases actually ran.
+      assert.strictEqual(
+        run.status,
+        42,
+        JSON.stringify({ signal: run.signal, stderr: run.stderr, stdout: run.stdout }),
+      )
+      assert.deepEqual(readdirSync(join(nativeRoot, 'many')), [])
+    }),
+  180_000,
 )
 
 it.effect(


### PR DESCRIPTION
Closes #130

## It was not a Clang bug

The backend was emitting **invalid SSA**, and Clang was crashing on it rather than diagnosing it.

```
$ opt -passes=verify program.bc
Instruction does not dominate all uses!
  %25949 = load i32, ptr %25948, align 4
  store i32 %25949, ptr %26175, align 4
  ... 50 of these, all in @silk_..._removeDirectoryRecursively_...
```

Ubuntu's Clang is built with assertions off, so it does **not** run the verifier on `-x ir` input. The module went straight to codegen and took the backend down with it.

## Answers to the issue's three open questions

**1. Which Clang versions.** Both that were reachable. 18.1.3 crashes in Register Coalescer; 19.1.1 crashes in `correlated-propagation`. Different passes, same SIGSEGV. A minimum-version constraint would not have helped — invalid IR is undefined behaviour, so no Clang is obliged to survive it, and pinning would have hidden a real miscompile.

**2. Which IR construct.** Named-IR attribution puts it exactly here:

```
effect_value85_failure:                  ; the arm
  %reload4_0_294 = load i32, ptr %addr4  ; Drop hook reloads its receiver
  ...
  br label %propagation_release80_u1_next

propagation_release80_u1_next:           ; the join — also reached from the branch
  store i32 %reload4_0_294, ptr %...     ; reads a value the arm defined
```

A `Drop` hook mutates its receiver, so the cleanup emitter reloads it from storage after the call. Those loads land in the *arm*. The emitter then moves to the arm's join and keeps reading the same cached SSA values — but the join is reached from the branch too, so the arm does not dominate it.

**3. Was the emitted IR unremarkable.** No. It was invalid. Nothing to report upstream.

## The fix

The per-block reload that already keeps these roots out of registers across MIR block edges is extracted as `reloadMutableRoots` and now also runs at the joins the emitter creates *inside* a single MIR block: the union-cleanup arm's join, and the four outcome-dispatch joins (`effect_run` / `effect_value` / `effect_result` / `effect_entry`). Storage is authoritative — every write to these roots stores through it — so the reload restores what an arm mutated rather than discarding it.

Trap-guarded continuations (`arith_trap`, `raw_trap`, the `_ok` blocks) are untouched: the other arm does not fall through, so the branch block dominates them.

## The `-O0` trap is the same bug, not a separate one

The issue asked whether the `-O0` trap the #31 worker saw deserved its own issue. It does not — same defect, different manifestation.

I could not reproduce it with bare scopes released in sequence (clean up to 12 owners). It needs a **populated** tree *and* a live neighbour. With both, it reproduces at 3 owners:

| owners | before | after |
|---|---|---|
| 3, populated, `-O0` | **SIGILL** | exit 42 |
| 6, populated, `-O0` | **SIGILL** | exit 42 |
| 3 / 6, populated, `-O2` | Clang SIGSEGV | exit 42 |

`SIGILL` is our own `@llvm.trap()`: at `-O0` the invalid IR compiles, the join reads an undefined union tag, no case matches, and dispatch falls through to the invalid-tag trap. Same root cause, fixed by the same change. No new issue filed.

## Tests

Baseline 0 real failures, after 0 real failures, +1 new test.

- Restored both of PR #128's pins to `profile: 'release'`.
- Added *"releases each of several populated scopes while the rest are still owned"* — the `-O0` shape, which nothing covered.
- **All three fail without this change** (verified by stashing the fix) and pass with it.
- `packages/compiler`: 166 files, 1330 tests, all passing.
- Full workspace failures are the documented-ignorable set only: `compiler-cli` FormatCommand/FormatWorkflow (chmod vs root), `packages/wasm` Extended "threads address types", and one `lsp` Server test that passes in isolation.
- Verifier clean: `opt -passes=verify` reports 0 violations on the emitted module, down from 50.

## One unrelated thing found on the way

`IrText.render` output does not round-trip — it emits duplicate value names, and `store i32 null` where the type is not a pointer, so `llvm-as` rejects it. Harmless today (bitcode is what gets compiled, and the goldens compare text to text), but it is why the dominance check here had to run on the bitcode rather than on the renderer's output. Happy to file it separately if useful.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZSXssmWmdZTzSB51GeSAC)_