### PR TITLE
test(compiler): pin occurrence lookup against a linear scan, not a clock

### DIFF
--- a/packages/compiler/test/OccurrencePerformance.test.ts
+++ b/packages/compiler/test/OccurrencePerformance.test.ts
@@ -1,6 +1,7 @@
 import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
+import type * as SemanticOccurrence from '../src/SemanticOccurrence.js'
 import * as SourceFile from '../src/SourceFile.js'
 import * as SourceResolver from '../src/SourceResolver.js'
 
@@ -13,7 +14,49 @@ const moduleSource = (module: number, declarations: number): string =>
       `pub fn value${module}_${ordinal}(input: i32) -> i32 { return i32.add(input, ${ordinal}) }`,
   ).join('\n')
 
-it.effect('keeps representative multi-module occurrence storage and lookup within budget', () =>
+/**
+ * Answers one lookup by scanning every occurrence of the module, with the same
+ * smallest-span-then-lowest-ordinal selection the index performs. This is the
+ * linear cost the index exists to avoid, measured on the same probes, machine
+ * and process, so the comparison holds regardless of absolute machine speed.
+ */
+const scanOccurrenceAt = (
+  index: SemanticOccurrence.ModuleIndex,
+  offset: number,
+): SemanticOccurrence.SemanticOccurrence | undefined => {
+  let selected: SemanticOccurrence.SemanticOccurrence | undefined
+  for (const candidate of index.occurrences) {
+    if (candidate.span.start > offset || offset >= candidate.span.end) continue
+    if (
+      selected === undefined ||
+      candidate.span.end - candidate.span.start < selected.span.end - selected.span.start ||
+      (candidate.span.end - candidate.span.start === selected.span.end - selected.span.start &&
+        candidate.ordinal < selected.ordinal)
+    )
+      selected = candidate
+  }
+  return selected
+}
+
+const elapsedOf = (work: () => void): number => {
+  const started = performance.now()
+  work()
+  return performance.now() - started
+}
+
+/**
+ * Indexed lookup must stay this many times cheaper than the linear scan over
+ * the same probes. The fixture holds over a thousand occurrences per module,
+ * where the index measures roughly eight times cheaper; requiring four leaves
+ * scheduling noise room to distort the reading without weakening what is
+ * pinned, since replacing the search with a scan collapses the ratio to one.
+ */
+const requiredSpeedup = 4
+
+/** Timed rounds, excluding the warm-up round that also calibrates repetition. */
+const rounds = 5
+
+it.effect('keeps multi-module occurrence storage compact and lookup sub-linear', () =>
   Effect.gen(function* () {
     const moduleCount = 6
     const declarationsPerModule = 40
@@ -51,16 +94,66 @@ it.effect('keeps representative multi-module occurrence storage and lookup withi
       ),
     )
 
-    const probes = indexes.flatMap((index) =>
-      index.occurrences.map(
-        (occurrence) => [occurrence.span.sourceId, occurrence.span.start] as const,
-      ),
+    const probes = [...snapshot.semanticOccurrences.modules].flatMap(([module, index]) =>
+      index.occurrences.map((occurrence) => ({ module, index, offset: occurrence.span.start })),
     )
-    const started = performance.now()
-    for (let pass = 0; pass < 5; pass += 1)
-      for (const [module, offset] of probes)
-        assert.isDefined(Analysis.semanticOccurrenceAt(snapshot, module, offset))
-    const elapsed = performance.now() - started
-    assert.isBelow(elapsed, 1_000)
+
+    const disagreements = probes
+      .filter((probe) => {
+        const indexed = Analysis.semanticOccurrenceAt(snapshot, probe.module, probe.offset)
+        const scanned = scanOccurrenceAt(probe.index, probe.offset)
+        return (
+          indexed === undefined ||
+          scanned === undefined ||
+          indexed.ordinal !== scanned.ordinal ||
+          indexed.span.start !== scanned.span.start ||
+          indexed.span.end !== scanned.span.end
+        )
+      })
+      .map((probe) => `${probe.module}@${probe.offset}`)
+    assert.deepEqual(disagreements, [])
+
+    let observed = 0
+    const indexedPass = (): void => {
+      for (const probe of probes)
+        if (Analysis.semanticOccurrenceAt(snapshot, probe.module, probe.offset) !== undefined)
+          observed += 1
+    }
+    const scanPass = (): void => {
+      for (const probe of probes)
+        if (scanOccurrenceAt(probe.index, probe.offset) !== undefined) observed += 1
+    }
+
+    // One warm-up round pays each path's compilation and sizes how often the
+    // cheaper indexed pass repeats per timed round, so both rounds span a
+    // comparable stretch of wall clock. A descheduled millisecond then costs
+    // each side a similar fraction instead of swamping the shorter reading.
+    const indexedWarm = elapsedOf(indexedPass)
+    const scanWarm = elapsedOf(scanPass)
+    const indexedRepeats = Math.min(
+      32,
+      Math.max(1, Math.round(scanWarm / Math.max(indexedWarm, Number.EPSILON))),
+    )
+
+    // Rounds alternate and are compared on their fastest reading: descheduling
+    // only ever inflates an elapsed time, so the minimum across rounds is the
+    // reading least polluted by whatever else a shared runner is doing.
+    let indexedFastest = Number.POSITIVE_INFINITY
+    let scanFastest = Number.POSITIVE_INFINITY
+    for (let round = 0; round < rounds; round += 1) {
+      const indexedElapsed =
+        elapsedOf(() => {
+          for (let repeat = 0; repeat < indexedRepeats; repeat += 1) indexedPass()
+        }) / indexedRepeats
+      indexedFastest = Math.min(indexedFastest, indexedElapsed)
+      scanFastest = Math.min(scanFastest, elapsedOf(scanPass))
+    }
+    assert.isAbove(observed, 0)
+    assert.isAbove(scanFastest, 0)
+    assert.isBelow(
+      indexedFastest * requiredSpeedup,
+      scanFastest,
+      `indexed lookup ${indexedFastest.toFixed(2)}ms is not ${requiredSpeedup}x cheaper than the ${scanFastest.toFixed(2)}ms linear scan over ${occurrenceCount} occurrences`,
+    )
   }),
 )


### PR DESCRIPTION
Closes #143.

## The change

`packages/compiler/test/OccurrencePerformance.test.ts` gated `validate` on `assert.isBelow(elapsed, 1_000)` against a measurement taking ~410ms locally. That 2.4x headroom is what a shared runner ate on PR #141, on a diff that cannot touch the timed region at all.

Per requirement 2 the budget is not raised — it is removed. The guard is now comparative: the same probes are answered twice, once through `Analysis.semanticOccurrenceAt` and once through a linear scan over the same module index, in the same process on the same machine, and the indexed path must stay **4x cheaper**. That pins the sub-linear property the millisecond count was standing in for, and the ratio is unchanged by how fast the machine is.

Noise handling:

- **Alternating rounds, compared on their fastest reading.** Descheduling only ever inflates an elapsed time, so the minimum across rounds is the reading least polluted by whatever else the runner is doing.
- **A warm-up round sizes how often the cheaper indexed pass repeats per timed round**, so both rounds span comparable wall clock and a stolen millisecond costs each side a similar fraction rather than swamping the shorter measurement. It self-calibrates, so it stays balanced on a machine with different constant factors — and collapses to 1 repeat under a regression, keeping the failing run quick.
- **A correctness cross-check** asserts both paths agree on every probe (span and ordinal) before either is timed, so the baseline cannot silently drift into measuring something else.

The structural assertions that already pinned shape without a clock — `prefixCount === occurrenceCount`, bytes-per-occurrence under 512, no syntax/token leakage — are untouched.

## Acceptance criteria

### 1. Sub-linear lookup pinned without depending on machine speed

The assertion compares two measurements taken on the same hardware in the same process, so the pass/fail boundary is a ratio, not a duration. Sampled across 10 runs — indexed vs linear scan over 8602 occurrences:

```
indexed 7.24ms  vs scan 56.05ms   (7.7x)
indexed 7.49ms  vs scan 55.34ms   (7.4x)
indexed 7.35ms  vs scan 56.53ms   (7.7x)
indexed 6.87ms  vs scan 54.28ms   (7.9x)
indexed 7.34ms  vs scan 57.38ms   (7.8x)
indexed 7.26ms  vs scan 58.75ms   (8.1x)
indexed 7.11ms  vs scan 57.83ms   (8.1x)
indexed 7.14ms  vs scan 56.29ms   (7.9x)
indexed 7.08ms  vs scan 56.84ms   (8.0x)
indexed 7.17ms  vs scan 57.74ms   (8.1x)
```

Observed ratio spans 7.4x–8.1x against a required 4x. The margin is on the *ratio*, which a slower runner does not move: it would inflate both sides together.

### 2. 50 consecutive local runs pass

50 separate `vitest run` processes, not 50 repeats inside one process — each pays its own cold start:

```
$ pass=0; fail=0
$ for i in $(seq 1 50); do
    if npx vitest run test/OccurrencePerformance.test.ts 2>&1 | grep -q "Tests  1 passed"
      then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL on run $i"; fi
  done
$ echo "=== 50 consecutive runs: pass=$pass fail=$fail ==="

=== 50 consecutive runs: pass=50 fail=0 ===
```

### 3. A deliberate regression still fails

`lastStartAtOrBefore` in `packages/compiler/src/SemanticOccurrence.ts` — the binary search behind `SemanticOccurrence.at` — temporarily replaced with a linear scan:

```diff
-  let low = 0
-  let high = occurrences.length - 1
-  let answer = -1
-  while (low <= high) {
-    const middle = Math.floor((low + high) / 2)
-    const candidate = occurrences.at(middle)
-    if (candidate !== undefined && candidate.span.start <= offset) {
-      answer = middle
-      low = middle + 1
-    } else high = middle - 1
-  }
+  let answer = -1
+  for (let cursor = 0; cursor < occurrences.length; cursor += 1) {
+    const candidate = occurrences.at(cursor)
+    if (candidate !== undefined && candidate.span.start <= offset) answer = cursor
+  }
   return answer
```

The new test fails, and says why:

```
AssertionError: indexed lookup 170.80ms is not 4x cheaper than the 61.04ms linear
scan over 8602 occurrences: expected 683.1949599999989 to be below 61.03833500000019

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Indexed lookup goes from 7.8x cheaper than the scan to 2.8x **more expensive** — the ratio moves by a factor of ~22 against a 2x margin, so the guard fires with room to spare. Reverted with `git checkout packages/compiler/src/SemanticOccurrence.ts`; the diff on this branch touches the test file only.

#### Why the old gate could not have been re-tuned instead

The old test was also run against that same regression, and it too failed — but only just:

```
expected 1139.5048469999997 to be below 1000
```

1139ms for a fully linear lookup on this machine, against the 1131ms the *healthy* code produced on the CI runner in #143. The old gate's reading for a real regression here is indistinguishable from its reading for correct code on a busy runner. There is no budget value that separates those two, which is why the clock had to go rather than move.

## Full gate

CI is green on this branch — `validate` and `webcontainer-browser` both pass ([run 31732876908](https://github.com/julia-script/silk-effect/actions/runs/31732876908)).

Locally, `pnpm check` in this container ends red on one unrelated test — `packages/wasm/test/Extended.test.ts > threads address types through memory instructions`, a `WebAssembly.validate` returning false:

- The diff is one file, `packages/compiler/test/OccurrencePerformance.test.ts` (`git diff origin/main --stat`). `packages/wasm` is byte-identical to `origin/main` and fails there the same way — verified by A/B, restoring main's version of the test file and re-running the gate in this same container.
- The container runs Node v22.22.2 while `.github/workflows/ci.yml` pins Node 24, so the rejection of a memory64 address-type encoding is a V8 version difference. CI passing `validate` confirms it.

`pnpm check` also produces *spurious* extra failures here — turbo runs 15 tasks concurrently and children die on resource contention in this container — so the tasks were re-run serially:

- `npx biome check .` → `Checked 564 files in 1126ms. No fixes applied.`
- `turbo run build --concurrency=1` → `Tasks: 10 successful, 10 total`
- `npx turbo run typecheck test --filter=@silk-effect/compiler --concurrency=1 --force` → `Tasks: 6 successful, 6 total`
- `npx vitest run` in `packages/compiler` → `Test Files 170 passed (170)`, `Tests 1369 passed (1369)`
