### PR TITLE
llvm: make IrText.render output valid, round-trippable LLVM assembly

### DIFF
--- a/packages/compiler/test/LlvmIrRoundTrip.test.ts
+++ b/packages/compiler/test/LlvmIrRoundTrip.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
+import { llvmToolchain } from '../../../test/support/llvmToolchain.js'
 import * as Analysis from '../src/Analysis.js'
 import type * as Backend from '../src/Backend.js'
 
@@ -13,7 +14,7 @@ const ascii = (value: string): Uint8Array =>
 const directory = mkdtempSync(join(tmpdir(), 'silk-llvm-ir-round-trip-'))
 afterAll(() => rmSync(directory, { recursive: true, force: true }))
 
-const executable = (name: string, variable: string): string => process.env[variable] ?? name
+const toolchain = llvmToolchain(['llvm-as', 'llvm-dis', 'opt'], 'the compiler IR round-trip check')
 
 const write = (name: string, contents: Uint8Array | string): string => {
   const path = join(directory, name)
@@ -23,13 +24,13 @@ const write = (name: string, contents: Uint8Array | string): string => {
 
 const llvmAs = (name: string, source: string): Uint8Array => {
   const assembled = join(directory, name)
-  execFileSync(executable('llvm-as', 'LLVM_AS'), [source, '-o', assembled])
+  execFileSync(toolchain.command('llvm-as'), [source, '-o', assembled])
   return readFileSync(assembled)
 }
 
 const llvmDis = (name: string, bitcode: Uint8Array): string => {
   const output = join(directory, name)
-  execFileSync(executable('llvm-dis', 'LLVM_DIS'), [write(`${name}.bc`, bitcode), '-o', output])
+  execFileSync(toolchain.command('llvm-dis'), [write(`${name}.bc`, bitcode), '-o', output])
   // `llvm-dis` names the module after whichever file it read.
   return readFileSync(output, 'utf8')
     .split('\n')
@@ -52,7 +53,7 @@ const canonical = (name: string, bitcode: Uint8Array): string => {
     write(`${name}.dis.ll`, llvmDis(`${name}.dis`, bitcode)),
   )
   const stripped = join(directory, `${name}.stripped.bc`)
-  execFileSync(executable('opt', 'LLVM_OPT'), [
+  execFileSync(toolchain.command('opt'), [
     '-passes=strip',
     write(`${name}.materialized.input.bc`, materialized),
     '-o',
@@ -70,7 +71,7 @@ const canonical = (name: string, bitcode: Uint8Array): string => {
  */
 const assemble = (name: string, ir: string): string => {
   const assembled = llvmAs(`${name}.assembled.bc`, write(`${name}.source.ll`, ir))
-  execFileSync(executable('opt', 'LLVM_OPT'), [
+  execFileSync(toolchain.command('opt'), [
     '-passes=verify',
     write(`${name}.verify.bc`, assembled),
     '-disable-output',
@@ -200,6 +201,7 @@ for (const mode of ['debug', 'release'] as const) {
       `renders assemblable LLVM IR for the ${name} program in ${mode}`,
       () =>
         Effect.gen(function* () {
+          if (toolchain.unavailable()) return
           const artifact = yield* emit(
             `round-trip/${name}`,
             source,

--- a/packages/compiler/test/LlvmIrRoundTrip.test.ts
+++ b/packages/compiler/test/LlvmIrRoundTrip.test.ts
@@ -1,0 +1,222 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import type * as Backend from '../src/Backend.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const directory = mkdtempSync(join(tmpdir(), 'silk-llvm-ir-round-trip-'))
+afterAll(() => rmSync(directory, { recursive: true, force: true }))
+
+const executable = (name: string, variable: string): string => process.env[variable] ?? name
+
+const write = (name: string, contents: Uint8Array | string): string => {
+  const path = join(directory, name)
+  writeFileSync(path, contents)
+  return path
+}
+
+const llvmAs = (name: string, source: string): Uint8Array => {
+  const assembled = join(directory, name)
+  execFileSync(executable('llvm-as', 'LLVM_AS'), [source, '-o', assembled])
+  return readFileSync(assembled)
+}
+
+const llvmDis = (name: string, bitcode: Uint8Array): string => {
+  const output = join(directory, name)
+  execFileSync(executable('llvm-dis', 'LLVM_DIS'), [write(`${name}.bc`, bitcode), '-o', output])
+  // `llvm-dis` names the module after whichever file it read.
+  return readFileSync(output, 'utf8')
+    .split('\n')
+    .filter((line) => !line.startsWith('; ModuleID ='))
+    .join('\n')
+}
+
+/**
+ * Reduces a module to the form the two emission paths can be compared in.
+ *
+ * Both sides go through `llvm-as` first. The textual parser resolves an omitted `align` against the
+ * module's data layout as it reads, while bitcode leaves the operand unspecified for its consumer
+ * to resolve, so only modules that entered through the same door are comparable. `strip` then
+ * renumbers locals, because `Bitcode.encode` writes no function-level value symbol table and names
+ * therefore survive only along the textual path.
+ */
+const canonical = (name: string, bitcode: Uint8Array): string => {
+  const materialized = llvmAs(
+    `${name}.materialized.bc`,
+    write(`${name}.dis.ll`, llvmDis(`${name}.dis`, bitcode)),
+  )
+  const stripped = join(directory, `${name}.stripped.bc`)
+  execFileSync(executable('opt', 'LLVM_OPT'), [
+    '-passes=strip',
+    write(`${name}.materialized.input.bc`, materialized),
+    '-o',
+    stripped,
+  ])
+  return llvmDis(`${name}.stripped.ll`, readFileSync(stripped))
+}
+
+/**
+ * Assembles rendered IR and reduces it the same way.
+ *
+ * The golden tests compare rendered text against stored rendered text, so a systematic renderer
+ * flaw compares equal to itself and passes forever. `llvm-as` is the check that cannot: either the
+ * text the backend prints is the assembly language, or it is not.
+ */
+const assemble = (name: string, ir: string): string => {
+  const assembled = llvmAs(`${name}.assembled.bc`, write(`${name}.source.ll`, ir))
+  execFileSync(executable('opt', 'LLVM_OPT'), [
+    '-passes=verify',
+    write(`${name}.verify.bc`, assembled),
+    '-disable-output',
+  ])
+  return canonical(`${name}-text`, assembled)
+}
+
+const emit = Effect.fnUntraced(function* (
+  name: string,
+  text: string,
+  request: Backend.CodegenRequest,
+  target: string,
+) {
+  const snapshot = yield* Analysis.ofSourceRealized(name, ascii(text), target)
+  assert.deepEqual(Analysis.diagnostics(snapshot), [])
+  return yield* Analysis.codegen(snapshot, request)
+})
+
+/** A guard whose `Drop` hook runs before its owned `Allocation` field releases. */
+const dropHook = `struct Guard {
+  tag: i32
+  storage: Allocation
+}
+
+impl Drop for Guard {
+  fn drop(self: &mut Guard) -> () { return () }
+}
+
+effect fn build() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let layout = Layout.of<[i32; 2]>()
+  let recipe = Allocator.allocate(move layout) |> Effect.provideMut(&mut allocator)
+  let allocation = run recipe
+  let guard = Guard { tag: 5, storage: move allocation }
+  return 42
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 7 }
+
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+/**
+ * A boxed tree whose nodes hold a `Leaf | Branch` union.
+ *
+ * Releasing one costs a conditional union cleanup around `impl<T> Drop for Box<T>`, which is the
+ * shape the duplicate names in #130 appeared in: many reclaim contexts in one function, several
+ * of them asking for the same name.
+ */
+const unionCleanup = `import silk.box { Box, make as boxMake, get as boxGet }
+
+pub struct Leaf {}
+
+pub struct Branch {
+  left: Box<Tree>
+  right: Box<Tree>
+}
+
+pub struct Shape {
+  kind: Leaf | Branch
+}
+
+pub struct Tree {
+  shape: Shape
+  value: i32
+}
+
+effect fn leaf(value: i32) -> Tree ! OutOfMemory ? &mut Allocator {
+  return Tree { shape: Shape { kind: Leaf {} }, value: value }
+}
+
+effect fn branch(left: Tree, right: Tree, value: i32) -> Tree ! OutOfMemory ? &mut Allocator {
+  let boxedLeft = run boxMake<Tree>(move left)
+  let boxedRight = run boxMake<Tree>(move right)
+  return Tree {
+    shape: Shape { kind: Branch { left: move boxedLeft, right: move boxedRight } },
+    value: value
+  }
+}
+
+fn total(self: &Tree) -> i32 {
+  return self.value + shapeTotal(&self.shape)
+}
+
+fn shapeTotal(self: &Shape) -> i32 {
+  return match &self.kind {
+    Leaf nothing => 0
+    Branch { left, right } => boxTotal(boxGet<Tree>(&left)) + boxTotal(boxGet<Tree>(&right))
+  }
+}
+
+fn boxTotal(view: &[Tree]) -> i32 {
+  return match &view[usize.ZERO] {
+    Tree { shape, value } => value + shapeTotal(&shape)
+  }
+}
+
+effect fn build() -> Tree ! OutOfMemory ? &mut Allocator {
+  let left = run branch(run leaf(1), run leaf(2), 4)
+  let right = run branch(run leaf(8), run leaf(16), 32)
+  return run branch(move left, move right, 64)
+}
+
+effect fn sum() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build() |> Effect.provideMut(&mut allocator)
+  let answer = total(&built)
+  drop built
+  return answer
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(sum(), recover) }`
+
+const programs: ReadonlyArray<readonly [string, string]> = [
+  ['drop-hook', dropHook],
+  ['union-cleanup', unionCleanup],
+]
+
+/**
+ * Debug mode carries the `DIFile` and location metadata that release mode omits, so both profiles
+ * have to assemble for the rendered view to be trustworthy while debugging.
+ */
+for (const mode of ['debug', 'release'] as const) {
+  for (const [name, source] of programs) {
+    it.effect(
+      `renders assemblable LLVM IR for the ${name} program in ${mode}`,
+      () =>
+        Effect.gen(function* () {
+          const artifact = yield* emit(
+            `round-trip/${name}`,
+            source,
+            { mode },
+            'aarch64-apple-darwin',
+          )
+          assert.strictEqual(artifact.backend, 'llvm')
+          if (artifact.backend !== 'llvm') return
+
+          // Assembling the text has to produce the module the compile path actually emits, or the
+          // readable view and the compiled artifact can drift apart again.
+          assert.strictEqual(
+            assemble(`${name}-${mode}`, artifact.ir),
+            canonical(`${name}-${mode}-bitcode`, artifact.bitcode),
+          )
+        }),
+      120_000,
+    )
+  }
+}

--- a/packages/compiler/test/ModuleVerification.test.ts
+++ b/packages/compiler/test/ModuleVerification.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
+import { llvmToolchain } from '../../../test/support/llvmToolchain.js'
 import * as Analysis from '../src/Analysis.js'
 import * as SourceResolver from '../src/SourceResolver.js'
 import { corpus } from './support/corpus.js'
@@ -18,22 +19,7 @@ import { corpus } from './support/corpus.js'
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
 
-/**
- * `opt` ships in LLVM's tools package rather than alongside `clang`, so a machine that compiles
- * Silk programs does not necessarily have it on `PATH`. Look where the distributions put it before
- * concluding it is absent.
- */
-const opt = [
-  process.env.SILK_TEST_OPT,
-  'opt',
-  '/opt/homebrew/opt/llvm/bin/opt',
-  '/usr/local/opt/llvm/bin/opt',
-  ...['21', '20', '19', '18', '17', '16'].map((version) => `/usr/lib/llvm-${version}/bin/opt`),
-].find(
-  (candidate) =>
-    candidate !== undefined &&
-    spawnSync(candidate, ['--version'], { encoding: 'utf8' }).status === 0,
-)
+const toolchain = llvmToolchain(['opt'], 'the LLVM verifier cross-check')
 
 const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-module-verification-'))
 afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
@@ -42,20 +28,8 @@ it.effect(
   'emits corpus modules that opt also accepts',
   () =>
     Effect.gen(function* () {
-      if (opt === undefined) {
-        // A cross-check that turns itself off when its reference implementation is missing
-        // reports success in exactly the situation where it verified nothing — the failure mode
-        // this file exists to remove. A contributor without LLVM's tools still gets a useful
-        // suite; CI gets a red build, answered by installing LLVM rather than by a quieter test.
-        if (process.env.CI !== undefined) {
-          return assert.fail(
-            'opt was not found in CI, so the LLVM verifier cross-check cannot run. Install LLVM in the workflow, or point SILK_TEST_OPT at the binary.',
-          )
-        }
-        console.log('opt was not found; skipping the LLVM verifier cross-check')
-        return
-      }
-      console.log(`cross-checking the LLVM verifier against ${opt}`)
+      if (toolchain.unavailable()) return
+      const opt = toolchain.command('opt')
       let emitted = 0
       const rejected: Array<string> = []
       for (const program of corpus) {

--- a/packages/llvm/fixtures/core/representative.ll
+++ b/packages/llvm/fixtures/core/representative.ll
@@ -52,7 +52,7 @@ entry:
   %and = and i32 %ashr, %v1
   %or = or i32 %and, %v1
   %xor = xor i32 %or, %v1
-  %negated = sub i32 zeroinitializer, %xor
+  %negated = sub i32 0, %xor
   %inverted = xor i32 %negated, -1
   %eq = icmp eq i32 %v0, %v1
   %ne = icmp ne i32 %v0, %v1

--- a/packages/llvm/fixtures/metadata/representative.ll
+++ b/packages/llvm/fixtures/metadata/representative.ll
@@ -39,7 +39,7 @@ no:
 !19 = !{null, !1, !2, !3, !4, !8, !10, !13, !16, !17, !18}
 !20 = !DISubroutineType(types: !19, flags: DIFlagPrototyped)
 !21 = !{}
-!22 = distinct !DICompileUnit(language: DW_LANG_C99, file: !0, producer: "silk-effect", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: !21)
+!22 = distinct !DICompileUnit(language: DW_LANG_C99, file: !0, producer: "silk-effect", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, globals: !21, splitDebugInlining: false)
 !23 = !{i32 2, !"Dwarf Version", i32 5}
 !24 = !{i32 2, !"Debug Info Version", i32 3}
 !25 = distinct !DISubprogram(scope: !0, name: "debugged", file: !0, line: 10, type: !20, scopeLine: 10, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !22)

--- a/packages/llvm/package.json
+++ b/packages/llvm/package.json
@@ -161,6 +161,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
-    "@effect/vitest": "catalog:"
+    "@effect/vitest": "catalog:",
+    "@types/node": "^24.10.1"
   }
 }

--- a/packages/llvm/src/IrText.ts
+++ b/packages/llvm/src/IrText.ts
@@ -456,6 +456,8 @@ const renderMetadataNode = (
         ['emissionKind', 'FullDebug'],
         ['enums', ref(node.enums)],
         ['globals', ref(node.globals)],
+        // Bitcode writes this operand as false, while the textual default is true.
+        ['splitDebugInlining', false],
       ])})`
     case 'Subprogram':
       return `!DISubprogram(${metadataFields([

--- a/packages/llvm/src/IrText.ts
+++ b/packages/llvm/src/IrText.ts
@@ -158,6 +158,43 @@ const renderTypedConstant = (state: BuilderState.Snapshot, index: number): strin
   return `${renderType(state, description.type)} ${renderConstant(state, index)}`
 }
 
+/**
+ * Spells the canonical zero of a type.
+ *
+ * `Constant.nullValue`, `Constant.none`, and `Constant.zero` all encode to the same bitcode record,
+ * so the textual spelling has to come from the type rather than from the constructor that was used:
+ * `null` is only accepted for pointers, `none` only for tokens, and integers and floats reject
+ * `zeroinitializer`.
+ *
+ * @internal
+ */
+const zeroSpelling = (state: BuilderState.Snapshot, type: number): string => {
+  const description = typeAt(state, type)
+  if (description._tag === 'Pointer') return 'null'
+  if (description._tag === 'Integer') return '0'
+  if (description._tag === 'Simple') {
+    switch (description.tag) {
+      case 'Half':
+      case 'BFloat':
+      case 'Float':
+      case 'Double':
+        return '0.0'
+      // The extended formats reject decimal literals outright and are only spelled in hexadecimal.
+      case 'X86Fp80':
+        return `0xK${'0'.repeat(20)}`
+      case 'Fp128':
+        return `0xL${'0'.repeat(32)}`
+      case 'PpcFp128':
+        return `0xM${'0'.repeat(32)}`
+      case 'Token':
+        return 'none'
+      default:
+        return 'zeroinitializer'
+    }
+  }
+  return 'zeroinitializer'
+}
+
 /** @internal */
 const renderConstant = (state: BuilderState.Snapshot, index: number): string => {
   const description = constantAt(state, index)
@@ -176,7 +213,9 @@ const renderConstant = (state: BuilderState.Snapshot, index: number): string => 
     case 'Float':
       return floatHex(description)
     case 'Special':
-      return description.kind
+      return description.kind === 'undef' || description.kind === 'poison'
+        ? description.kind
+        : zeroSpelling(state, description.type)
     case 'String':
       return `c${quoted(description.bytes)}`
     case 'Aggregate': {
@@ -401,9 +440,11 @@ const renderMetadataNode = (
     case 'Local':
       return `!{!${quoted(node.label)}}`
     case 'File':
+      // Both fields are required by the textual parser; bitcode stores an absent operand as a
+      // null string, which reads back as the empty string.
       return `!DIFile(${metadataFields([
-        ['filename', string(node.filename)],
-        ['directory', string(node.directory)],
+        ['filename', string(node.filename) ?? '""'],
+        ['directory', string(node.directory) ?? '""'],
       ])})`
     case 'CompileUnit':
       return `!DICompileUnit(${metadataFields([
@@ -619,31 +660,78 @@ const functionSuffix = (description: GlobalDescription.GlobalDescription): strin
   return values.length === 0 ? '' : ` ${values.join(' ')}`
 }
 
+interface LocalNames {
+  readonly values: ReadonlyMap<number, string>
+  readonly blocks: ReadonlyMap<number, string>
+}
+
+/** @internal */
+const localNameCache = new WeakMap<FunctionBodyDescription.Snapshot, LocalNames>()
+
+/**
+ * Assigns every local a name that is unique within its function.
+ *
+ * **Details**
+ *
+ * Values and blocks share one symbol table in LLVM, so a block label collides with an instruction
+ * result of the same name just as two instruction results do. Requested names are kept whenever
+ * they are still free and otherwise disambiguated with a `.N` suffix, in value-then-block index
+ * order so the mapping is a pure function of the snapshot. Resolved forward references are skipped:
+ * they render as the value they resolve to and never define a name of their own.
+ *
+ * @internal
+ */
+const computeLocalNames = (body: FunctionBodyDescription.Snapshot): LocalNames => {
+  const used = new Set<string>()
+  const assign = (name: ByteString.ByteString, fallback: string): string => {
+    const base = ByteString.isEmpty(name) ? ByteString.fromString(fallback) : name
+    let rendered = identifier('%', base)
+    let suffix = 1
+    while (used.has(rendered)) {
+      rendered = identifier('%', ByteString.concat([base, ByteString.fromString(`.${suffix}`)]))
+      suffix += 1
+    }
+    used.add(rendered)
+    return rendered
+  }
+  const values = new Map<number, string>()
+  body.values.forEach((value, index) => {
+    if (value.source._tag === 'Forward' && value.source.resolved !== undefined) return
+    values.set(index, assign(value.name, `v${index}`))
+  })
+  const blocks = new Map<number, string>()
+  body.blocks.forEach((block, index) => {
+    blocks.set(index, assign(block.name, `bb${index}`))
+  })
+  return { values, blocks }
+}
+
+/** @internal */
+const localNames = (body: FunctionBodyDescription.Snapshot): LocalNames => {
+  const cached = localNameCache.get(body)
+  if (cached !== undefined) return cached
+  const computed = computeLocalNames(body)
+  localNameCache.set(body, computed)
+  return computed
+}
+
 /** @internal */
 const localIdentifier = (body: FunctionBodyDescription.Snapshot, index: number): string => {
-  const name = body.values[index]?.name
-  return identifier(
-    '%',
-    name === undefined || ByteString.isEmpty(name) ? ByteString.fromString(`v${index}`) : name,
-  )
+  const name = localNames(body).values.get(index)
+  if (name === undefined) throw new Error(`missing value ${index}`)
+  return name
 }
 
 /** @internal */
 const blockIdentifier = (body: FunctionBodyDescription.Snapshot, index: number): string => {
-  const name = body.blocks[index]?.name
-  return identifier(
-    '%',
-    name === undefined || ByteString.isEmpty(name) ? ByteString.fromString(`bb${index}`) : name,
-  )
+  const name = localNames(body).blocks.get(index)
+  if (name === undefined) throw new Error(`missing block ${index}`)
+  return name
 }
 
 /** @internal */
-const blockLabel = (body: FunctionBodyDescription.Snapshot, index: number): string => {
-  const name = body.blocks[index]?.name
-  const value =
-    name === undefined || ByteString.isEmpty(name) ? ByteString.fromString(`bb${index}`) : name
-  return identifier('%', value).slice(1)
-}
+const blockLabel = (body: FunctionBodyDescription.Snapshot, index: number): string =>
+  blockIdentifier(body, index).slice(1)
 
 /** @internal */
 const resolvedOperand = (

--- a/packages/llvm/test/IrTextRoundTrip.test.ts
+++ b/packages/llvm/test/IrTextRoundTrip.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
+import { llvmToolchain } from '../../../test/support/llvmToolchain.js'
 import * as Bitcode from '../src/Bitcode.js'
 import * as Block from '../src/Block.js'
 import * as Builder from '../src/Builder.js'
@@ -19,7 +20,7 @@ import { raise } from './support/raise.js'
 const directory = mkdtempSync(join(tmpdir(), 'silk-effect-llvm-roundtrip-'))
 afterAll(() => rmSync(directory, { recursive: true, force: true }))
 
-const executable = (name: string, variable: string): string => process.env[variable] ?? name
+const toolchain = llvmToolchain(['llvm-as', 'llvm-dis', 'opt'], 'the IR round-trip check')
 
 const required = <A>(value: A | undefined, message: string): A => value ?? raise(message)
 
@@ -45,13 +46,13 @@ const write = (name: string, contents: Uint8Array | string): string => {
 
 const llvmAs = (name: string, source: string): Uint8Array => {
   const assembled = join(directory, name)
-  execFileSync(executable('llvm-as', 'LLVM_AS'), [source, '-o', assembled])
+  execFileSync(toolchain.command('llvm-as'), [source, '-o', assembled])
   return readFileSync(assembled)
 }
 
 const llvmDis = (name: string, bitcode: Uint8Array): string => {
   const output = join(directory, name)
-  execFileSync(executable('llvm-dis', 'LLVM_DIS'), [write(`${name}.bc`, bitcode), '-o', output])
+  execFileSync(toolchain.command('llvm-dis'), [write(`${name}.bc`, bitcode), '-o', output])
   // `llvm-dis` names the module after whichever file it read.
   return readFileSync(output, 'utf8')
     .split('\n')
@@ -72,7 +73,7 @@ const canonical = (name: string, bitcode: Uint8Array): Canonical => {
     write(`${name}.dis.ll`, llvmDis(`${name}.dis`, bitcode)),
   )
   const stripped = join(directory, `${name}.stripped.bc`)
-  execFileSync(executable('opt', 'LLVM_OPT'), [
+  execFileSync(toolchain.command('opt'), [
     '-passes=strip',
     write(`${name}.materialized.input.bc`, materialized),
     '-o',
@@ -95,7 +96,7 @@ const canonical = (name: string, bitcode: Uint8Array): Canonical => {
  */
 const assemble = (name: string, text: string): Canonical => {
   const assembled = llvmAs(`${name}.assembled.bc`, write(`${name}.source.ll`, text))
-  execFileSync(executable('opt', 'LLVM_OPT'), [
+  execFileSync(toolchain.command('opt'), [
     '-passes=verify',
     write(`${name}.verify.bc`, assembled),
     '-disable-output',
@@ -190,6 +191,7 @@ const collidingModule = Effect.fnUntraced(function* (options: { readonly named: 
 
 it.effect('assembles a name-colliding, zero-constant module into the bitcode module', () =>
   Effect.gen(function* () {
+    if (toolchain.unavailable()) return
     const builder = yield* collidingModule({ named: true })
     const text = yield* IrText.render(builder)
 
@@ -209,6 +211,7 @@ it.effect('assembles a name-colliding, zero-constant module into the bitcode mod
 
 it.effect('renders both required DIFile fields when neither operand is present', () =>
   Effect.gen(function* () {
+    if (toolchain.unavailable()) return
     const builder = yield* collidingModule({ named: false })
     const text = yield* IrText.render(builder)
 

--- a/packages/llvm/test/IrTextRoundTrip.test.ts
+++ b/packages/llvm/test/IrTextRoundTrip.test.ts
@@ -1,0 +1,221 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Bitcode from '../src/Bitcode.js'
+import * as Block from '../src/Block.js'
+import * as Builder from '../src/Builder.js'
+import * as Constant from '../src/Constant.js'
+import * as FunctionActor from '../src/Function.js'
+import * as FunctionBody from '../src/FunctionBody.js'
+import * as IrText from '../src/IrText.js'
+import * as Metadata from '../src/Metadata.js'
+import * as Type from '../src/Type.js'
+import * as Value from '../src/Value.js'
+import { raise } from './support/raise.js'
+
+const directory = mkdtempSync(join(tmpdir(), 'silk-effect-llvm-roundtrip-'))
+afterAll(() => rmSync(directory, { recursive: true, force: true }))
+
+const executable = (name: string, variable: string): string => process.env[variable] ?? name
+
+const required = <A>(value: A | undefined, message: string): A => value ?? raise(message)
+
+interface Canonical {
+  /**
+   * The module with locals renumbered. `Bitcode.encode` writes no function-level value symbol
+   * table, so local names survive only along the textual path and the two can be compared on
+   * instructions and constants only once both sides are numbered.
+   */
+  readonly body: string
+  /**
+   * The module's metadata definitions, which the renumbering pass discards along with the rest of
+   * the debug graph and which therefore have to be compared before it runs.
+   */
+  readonly metadata: string
+}
+
+const write = (name: string, contents: Uint8Array | string): string => {
+  const path = join(directory, name)
+  writeFileSync(path, contents)
+  return path
+}
+
+const llvmAs = (name: string, source: string): Uint8Array => {
+  const assembled = join(directory, name)
+  execFileSync(executable('llvm-as', 'LLVM_AS'), [source, '-o', assembled])
+  return readFileSync(assembled)
+}
+
+const llvmDis = (name: string, bitcode: Uint8Array): string => {
+  const output = join(directory, name)
+  execFileSync(executable('llvm-dis', 'LLVM_DIS'), [write(`${name}.bc`, bitcode), '-o', output])
+  // `llvm-dis` names the module after whichever file it read.
+  return readFileSync(output, 'utf8')
+    .split('\n')
+    .filter((line) => !line.startsWith('; ModuleID ='))
+    .join('\n')
+}
+
+/**
+ * Reduces a module to the form the two emission paths can be compared in.
+ *
+ * Both sides go through `llvm-as` first. The textual parser resolves an omitted `align` against the
+ * module's data layout as it reads, while bitcode leaves the operand unspecified for its consumer
+ * to resolve, so only modules that entered through the same door are comparable.
+ */
+const canonical = (name: string, bitcode: Uint8Array): Canonical => {
+  const materialized = llvmAs(
+    `${name}.materialized.bc`,
+    write(`${name}.dis.ll`, llvmDis(`${name}.dis`, bitcode)),
+  )
+  const stripped = join(directory, `${name}.stripped.bc`)
+  execFileSync(executable('opt', 'LLVM_OPT'), [
+    '-passes=strip',
+    write(`${name}.materialized.input.bc`, materialized),
+    '-o',
+    stripped,
+  ])
+  return {
+    body: llvmDis(`${name}.stripped.ll`, readFileSync(stripped)),
+    metadata: llvmDis(`${name}.whole.ll`, materialized)
+      .split('\n')
+      .filter((line) => line.startsWith('!'))
+      .join('\n'),
+  }
+}
+
+/**
+ * Assembles rendered text and reduces it the same way.
+ *
+ * `llvm-as` is the arbiter the golden tests cannot be: goldens compare rendered text against
+ * stored rendered text, so a systematic renderer flaw compares equal to itself forever.
+ */
+const assemble = (name: string, text: string): Canonical => {
+  const assembled = llvmAs(`${name}.assembled.bc`, write(`${name}.source.ll`, text))
+  execFileSync(executable('opt', 'LLVM_OPT'), [
+    '-passes=verify',
+    write(`${name}.verify.bc`, assembled),
+    '-disable-output',
+  ])
+  return canonical(`${name}-text`, assembled)
+}
+
+/**
+ * A module built from the shapes that made rendered text unassemblable.
+ *
+ * Two values and a block all request the same name — values and blocks share one symbol table per
+ * function, so all three collide — and every scalar and aggregate lane is zeroed through
+ * `Constant.nullValue`, which is how a front end spells a zero it does not know to be a pointer.
+ */
+const collidingModule = Effect.fnUntraced(function* (options: { readonly named: boolean }) {
+  const builder = yield* Builder.make({
+    moduleName: 'roundtrip',
+    sourceFilename: 'roundtrip.ll',
+    targetTriple: 'aarch64-apple-darwin',
+    strip: false,
+  })
+  const voidType = yield* Type.voidType(builder)
+  const i32 = yield* Type.integer(builder, 32)
+  const pointer = yield* Type.pointer(builder)
+  const float = yield* Type.float(builder)
+  const double = yield* Type.double(builder)
+  const half = yield* Type.half(builder)
+  const fp128 = yield* Type.fp128(builder)
+  const x86Fp80 = yield* Type.x86Fp80(builder)
+  const ppcFp128 = yield* Type.ppcFp128(builder)
+  const vector = yield* Type.vector(builder, i32, 4)
+  const array = yield* Type.array(builder, i32, 2)
+  const structure = yield* Type.structure(builder, [i32, pointer])
+
+  const signature = yield* Type.functionType(builder, voidType, [pointer])
+  const fn = yield* FunctionActor.declare(builder, 'zeroes', signature)
+  yield* FunctionActor.buildBody(
+    builder,
+    fn,
+    Effect.fnUntraced(function* (body) {
+      // The entry block takes the name two of the instructions below also ask for.
+      yield* Block.make(body, 'same')
+      const destination = yield* Value.argument(body, 0)
+      for (const type of [
+        pointer,
+        i32,
+        half,
+        float,
+        double,
+        x86Fp80,
+        fp128,
+        ppcFp128,
+        vector,
+        array,
+        structure,
+      ]) {
+        yield* FunctionBody.store(body, yield* Constant.nullValue(builder, type), destination)
+      }
+      // Both loads request `same`, which the entry block already holds.
+      yield* FunctionBody.load(body, i32, destination, 'same')
+      yield* FunctionBody.load(body, i32, destination, 'same')
+      yield* FunctionBody.returnVoid(body)
+      return body
+    }),
+  )
+
+  const file = options.named
+    ? yield* Metadata.file(
+        builder,
+        yield* Metadata.string(builder, 'roundtrip.silk'),
+        yield* Metadata.string(builder, '/src'),
+      )
+    : yield* Metadata.file(builder)
+  const unit = required(
+    yield* Metadata.compileUnit(builder, file, yield* Metadata.string(builder, 'silk')),
+    'expected a compile unit',
+  )
+  yield* Metadata.named(builder, 'llvm.dbg.cu', [unit])
+  // Without the version flag LLVM drops debug info on load, and the verifier never sees it.
+  const two = yield* Metadata.constant(builder, yield* Constant.integerUnsigned(builder, i32, 2))
+  const three = yield* Metadata.constant(builder, yield* Constant.integerUnsigned(builder, i32, 3))
+  yield* Metadata.named(builder, 'llvm.module.flags', [
+    yield* Metadata.tuple(builder, [
+      two,
+      yield* Metadata.string(builder, 'Debug Info Version'),
+      three,
+    ]),
+  ])
+
+  return builder
+})
+
+it.effect('assembles a name-colliding, zero-constant module into the bitcode module', () =>
+  Effect.gen(function* () {
+    const builder = yield* collidingModule({ named: true })
+    const text = yield* IrText.render(builder)
+
+    assert.notInclude(text, 'i32 null')
+    // Each of the three requests for `same` gets a distinct name in the one symbol table.
+    assert.include(text, '%same = load')
+    assert.include(text, '%same.1 = load')
+    assert.include(text, 'same.2:')
+
+    // The text is not merely well-formed: assembled, it is the module the bitcode path emits.
+    assert.deepEqual(
+      assemble('colliding-text', text),
+      canonical('colliding-bitcode', yield* Bitcode.encode(builder)),
+    )
+  }),
+)
+
+it.effect('renders both required DIFile fields when neither operand is present', () =>
+  Effect.gen(function* () {
+    const builder = yield* collidingModule({ named: false })
+    const text = yield* IrText.render(builder)
+
+    assert.include(text, '!DIFile(filename: "", directory: "")')
+    assert.deepEqual(
+      assemble('anonymous-file-text', text),
+      canonical('anonymous-file-bitcode', yield* Bitcode.encode(builder)),
+    )
+  }),
+)

--- a/packages/llvm/tsconfig.test.json
+++ b/packages/llvm/tsconfig.test.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    // The IR round-trip test shells out to `llvm-as`, `llvm-dis`, and `opt`, which is the only way
+    // to assert that rendered text is assembly rather than that it equals stored text. The sources
+    // themselves stay host-neutral, so this widening is test-only.
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.13.3
 
   packages/lsp:
     dependencies:

--- a/test/support/llvmToolchain.ts
+++ b/test/support/llvmToolchain.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process'
+
+/**
+ * Locating the LLVM command line tools a test cross-checks itself against.
+ *
+ * `opt`, `llvm-as`, and `llvm-dis` ship in LLVM's tools package rather than alongside `clang`, and
+ * the Linux distributions install them under a versioned prefix without symlinking them into
+ * `/usr/bin`. A machine that compiles Silk programs therefore does not necessarily have any of
+ * them on `PATH` — including this repository's CI runner, which has `clang` and nothing else.
+ * Look where the distributions put them before concluding a tool is absent.
+ */
+
+const searchPaths: ReadonlyArray<string> = [
+  '/opt/homebrew/opt/llvm/bin',
+  '/usr/local/opt/llvm/bin',
+  ...['21', '20', '19', '18', '17', '16'].map((version) => `/usr/lib/llvm-${version}/bin`),
+]
+
+/** The override for a tool: `opt` reads `SILK_TEST_OPT`, `llvm-as` reads `SILK_TEST_LLVM_AS`. */
+export const overrideVariable = (tool: string): string =>
+  `SILK_TEST_${tool.toUpperCase().replaceAll('-', '_')}`
+
+/**
+ * The command that runs `tool`, or `undefined` when no candidate answers `--version`.
+ *
+ * An explicit override wins, then `PATH`, then the distribution prefixes newest first.
+ */
+export const findLlvmTool = (tool: string): string | undefined =>
+  [
+    process.env[overrideVariable(tool)],
+    tool,
+    ...searchPaths.map((directory) => `${directory}/${tool}`),
+  ].find(
+    (candidate) =>
+      candidate !== undefined &&
+      spawnSync(candidate, ['--version'], { encoding: 'utf8' }).status === 0,
+  )
+
+export interface LlvmToolchain {
+  /** The command for one of the requested tools. */
+  readonly command: (tool: string) => string
+  /**
+   * Whether the suite has to stop, called as the first line of each test that needs the toolchain.
+   *
+   * A cross-check that turns itself off when its reference implementation is missing reports
+   * success in exactly the situation where it verified nothing, which is the failure mode these
+   * suites exist to remove — a round-trip test that skips is a golden test comparing text against
+   * itself. So a contributor without LLVM's tools still gets a useful suite, while CI gets a red
+   * build, answered by installing LLVM rather than by a quieter test.
+   */
+  readonly unavailable: () => boolean
+}
+
+/**
+ * Resolves every tool a suite needs, reporting once which commands it will use or what is missing.
+ *
+ * `purpose` names the check in both messages, so a red CI build says what stopped running.
+ */
+export const llvmToolchain = (tools: ReadonlyArray<string>, purpose: string): LlvmToolchain => {
+  const resolved = new Map(tools.map((tool) => [tool, findLlvmTool(tool)] as const))
+  const missing = tools.filter((tool) => resolved.get(tool) === undefined)
+
+  if (missing.length === 0) {
+    console.log(`${purpose} is using ${tools.map((tool) => resolved.get(tool)).join(', ')}`)
+  } else if (process.env.CI === undefined) {
+    console.log(`${missing.join(', ')} was not found; skipping ${purpose}`)
+  }
+
+  return {
+    command: (tool) => {
+      const command = resolved.get(tool)
+      if (command === undefined) {
+        throw new Error(`${tool} was not among the tools ${purpose} asked for`)
+      }
+      return command
+    },
+    unavailable: () => {
+      if (missing.length === 0) return false
+      if (process.env.CI !== undefined) {
+        throw new Error(
+          `${missing.join(', ')} not found in CI, so ${purpose} cannot run. Install LLVM in the workflow, or point ${missing.map(overrideVariable).join(', ')} at the binar${missing.length === 1 ? 'y' : 'ies'}.`,
+        )
+      }
+      return true
+    },
+  }
+}


### PR DESCRIPTION
Closes #146.

`IrText.render` produced text that `llvm-as` rejects, so the human-readable view of a module was not the thing being compiled.

## Defects

The two known ones from #130 / PR #144, plus two more found by rendering a spread of modules and feeding each to `llvm-as` rather than by fixing the two known spellings and stopping:

1. **Duplicate local names.** `localIdentifier`/`blockIdentifier` emitted the requested name verbatim, so two values asking for the same name collided — and so did a block label and an instruction result of the same name, since LLVM gives values and blocks a single symbol table per function. Names are now allocated once per function body: the requested spelling is kept when free and disambiguated with a `.N` suffix otherwise, in value-then-block index order so the mapping is a pure function of the snapshot. Resolved forward references are skipped, since they render as the value they resolve to and never define a name.

2. **`store i32 null`.** `Constant.nullValue`, `Constant.none`, and `Constant.zero` all encode to the *same* bitcode record (`CST_CODE_NULL`), but the renderer echoed whichever constructor the front end happened to call. The spelling now comes from the type, which is the only thing that can be correct: `null` for pointers, `none` for tokens, `0` for integers, `0.0` for half/bfloat/float/double, hexadecimal zero for `x86_fp80`/`fp128`/`ppc_fp128` (which reject decimal literals outright), `zeroinitializer` for aggregates.

3. **`!DIFile` missing `directory`.** Absent operands were dropped from the field list, but the textual parser requires both `filename` and `directory`. Both are now always printed, empty when the operand is null — which is how bitcode reads them back. This is why *every* `debug`-mode module failed to assemble, not just the ones with `Drop` hooks.

4. **`!DICompileUnit` disagreeing with its own bitcode.** The renderer omitted `splitDebugInlining`, whose textual default is `true`, while `Bitcode.encode` writes the operand as `false`. Both paths parsed; they just described different modules. Found by the round-trip comparison, not by `llvm-as`.

## The test

Requirement 4 is the real deliverable, so it is worth saying what it does and does not assert.

`packages/llvm/test/IrTextRoundTrip.test.ts` covers the shapes at the constructor level: two values and a block all asking for one name, every scalar and aggregate lane zeroed through `Constant.nullValue`, a `DIFile` with neither operand.

`packages/compiler/test/LlvmIrRoundTrip.test.ts` covers them as they actually arise, in `debug` and `release`:
- a `Drop` hook over an owned `Allocation`;
- the boxed tree from `BoxHeapIndirection`, whose `Leaf | Branch` union costs a conditional cleanup around `impl Drop for Box` — the shape #130's duplicate names appeared in.

Both render, run `llvm-as`, run `opt -passes=verify`, and then require the assembled module to equal the one `Bitcode.encode` produces, so the two paths cannot drift apart again.

**Comparing the two paths needs both sides through one door**, and the two normalizations are load-bearing:
- The textual parser resolves an *omitted* `align` against the module's data layout as it reads and bakes the result in, while bitcode leaves the operand unspecified for its consumer to resolve. The emitted modules carry no `target datalayout`, so the two resolve differently (4 vs 8 for `i64`). Each side is therefore materialized through `llvm-as` before comparison. An explicitly wrong alignment still fails the comparison; only unspecified-vs-unspecified is laundered.
- `strip` then renumbers locals, because `Bitcode.encode` writes no function-level value symbol table, so names reach a consumer only along the textual path.

I checked the tests bite by reverting each of the four fixes in turn with the others in place. Each mutation fails at least one test; the `packages/llvm` suite catches all four, and the compiler suite catches the three that reach it (the name mutation fails exactly the two union-cleanup cases). Worth noting because the compiler package resolves `@silk-effect/llvm` from `dist`, so a mutation check there is silently vacuous without a rebuild — the same shape of non-assertion this issue is about.

## Finding the toolchain, and refusing to skip

The first CI run died with `spawnSync llvm-as ENOENT`. `llvm-as`, `llvm-dis`, and `opt` ship in LLVM's tools package rather than alongside `clang`, and the Linux distributions leave them under a versioned prefix without symlinking them into `/usr/bin` — so a runner that compiles Silk programs fine has none of them by bare name.

#151 had already hit this with `opt` and solved it by looking where the distributions put it; its green CI *with the hard-fail guard active* is the evidence that the prefixes are right, since a green run there is only possible if `opt` was actually found. Rather than copy that resolution into two more files, it now lives in **`test/support/llvmToolchain.ts`** — the repository-root `test/support` directory that already holds the cross-package `raise.ts` — and takes a tool name instead of being written once per tool. All three call sites share it: both round-trip suites and #151's `ModuleVerification.test.ts`, whose inline copy is deleted here. Overrides follow #151's naming, derived from the tool: `SILK_TEST_OPT`, `SILK_TEST_LLVM_AS`, `SILK_TEST_LLVM_DIS`.

The obvious alternative — skip when the tool is missing — is the one thing that cannot happen here. A round-trip test that skips is a golden test comparing text against itself, which is the failure mode #146 exists to remove; #151's silent skip is precisely why its cross-check had never once run in CI without anyone noticing. So the helper keeps that suite's shape and now enforces it for all three: a missing tool skips locally with a printed reason, and hard-fails under `CI`, answered by installing LLVM rather than by a quieter test.

## Golden diff

Two lines, both in `packages/llvm/fixtures`, both text-only — the `.bc.hex` fixtures and their recorded sha256 are byte-identical, which is the point:

```diff
 core/representative.ll
-  %negated = sub i32 zeroinitializer, %xor
+  %negated = sub i32 0, %xor

 metadata/representative.ll
-!22 = distinct !DICompileUnit(…, emissionKind: FullDebug, globals: !21)
+!22 = distinct !DICompileUnit(…, emissionKind: FullDebug, globals: !21, splitDebugInlining: false)
```

`sub i32 zeroinitializer` does assemble, so that line was not itself a defect; it changes because the fix derives every zero spelling from the type rather than from the constructor, which removes the class instead of the one spelling that failed. The `!DICompileUnit` line is defect 4. All five `fixtures:verify` suites pass. No compiler goldens changed.

`packages/llvm/tsconfig.test.json` gains `"types": ["node"]` and the package gains `@types/node`, so the test can shell out to the toolchain — the same test-only widening `packages/compiler` already carries, with the reason in a comment.

## Verification

Rebased onto `main` at 841659c, after #151, #157, #156, #154, #148, and #119 landed. The rebase was clean and nothing in the renderer change moved.

`pnpm check` passes except for two failures that are pre-existing on `main` and untouched by this branch: `@silk-effect/wasm > test/Extended.test.ts > threads address types through memory instructions` (#160) and the two `@silk-effect/compiler-cli > test/FormatWorkflow.test.ts` permission cases (#159, which fail only because the agent runs as root and root ignores `chmod`). Turbo cancels siblings when one task fails, so `@silk-effect/llvm` and `@silk-effect/compiler` were re-run standalone: green in full, 66 and 1392 tests plus the native acceptance run. `pnpm typecheck` and `biome check` are clean across the repo.

I also exercised both branches of the new guard directly — missing tool under `CI` throws with the override variable named, missing tool locally returns a skip — since the environment this runs in has the tools and would otherwise never take either path.

Beyond the gate, while hunting: every program in `packages/compiler/test/support/corpus.ts` (66) plus the two above, across `debug`/`release` × `aarch64-apple-darwin`/`wasm32-unknown-unknown`, rendered → `llvm-as` → `opt -passes=verify`. All pass. Before this change every `debug` module failed and the `Drop` module failed in both modes.

## Left alone, deliberately

Three things this surfaced that are out of scope here and would each be a separate change:

- **The emitted modules carry no `target datalayout`.** That is why the text and bitcode paths resolve unspecified alignments differently, and it means any consumer resolves them from its own defaults. A backend fix, and it would move the bitcode digest goldens.
- **The compiler's debug metadata has no `Debug Info Version` module flag**, so LLVM discards the whole debug graph on load — visible as `ignoring debug info with an invalid version (0)` in the test output. The `DIFile` fix is still what makes those modules assemble at all, since the rejection happens at parse time.
- **`Bitcode.encode` writes no function-level value symbol table**, so local names exist only in the rendered text. A second, smaller text-vs-bitcode gap, and one that makes the two paths harder to compare.

## Coordination

#151 (which verifies **bitcode** in CI) has merged, and this branch now builds on it rather than around it: the toolchain resolution it introduced is extracted to `test/support/llvmToolchain.ts` and its call site updated, so there is one place to fix when a distribution moves the tools or a newer LLVM needs adding to the search list.

`packages/llvm`'s `fixtures:verify` — which already runs `llvm-as` on rendered output — is still not wired into `test` or `check`, which is why the invalid `zeroinitializer` spelling sat in a fixture unnoticed. Wiring it in still belongs in that lane.