### PR TITLE
tooling: size compiler-cli native-build timeouts from measurement

### DIFF
--- a/packages/compiler-cli/test/BuildExeCommand.test.ts
+++ b/packages/compiler-cli/test/BuildExeCommand.test.ts
@@ -6,6 +6,7 @@ import { NodeServices } from '@effect/platform-node'
 import { afterAll, assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as BuildExeCommand from '../src/BuildExeCommand.js'
+import * as Timeouts from './timeouts.js'
 
 const clang = '/usr/bin/clang'
 const root = mkdtempSync(join(tmpdir(), 'silk-build-exe-test-'))
@@ -34,31 +35,37 @@ const run = (source: string, overrides: Partial<BuildExeCommand.Options> = {}) =
     ...overrides,
   }).pipe(Effect.provide(NodeServices.layer))
 
-it.effect('compiles a single file to a runnable executable and exits zero', () =>
-  Effect.gen(function* () {
-    const source = sourceFile('main.silk', 'pub fn main() -> i32 { return 42 }')
-    const output = join(root, 'answer')
+it.effect(
+  'compiles a single file to a runnable executable and exits zero',
+  () =>
+    Effect.gen(function* () {
+      const source = sourceFile('main.silk', 'pub fn main() -> i32 { return 42 }')
+      const output = join(root, 'answer')
 
-    const status = yield* run(source, { output })
+      const status = yield* run(source, { output })
 
-    assert.strictEqual(status, 0)
-    assert.strictEqual(spawnSync(output).status, 42)
-  }),
+      assert.strictEqual(status, 0)
+      assert.strictEqual(spawnSync(output).status, 42)
+    }),
+  Timeouts.nativeBuild,
 )
 
-it.effect('resolves nested imports from the source root rather than the importer directory', () =>
-  Effect.gen(function* () {
-    const source = sourceFile(
-      'src/app/Main.silk',
-      'import compiler.Syntax { answer }\npub fn main() -> i32 { return answer() }',
-    )
-    sourceFile('src/compiler/Syntax.silk', 'pub fn answer() -> i32 { return 42 }')
-    const output = join(root, 'nested-answer')
-    const status = yield* run(source, { sourceRoot: join(root, 'src'), output })
+it.effect(
+  'resolves nested imports from the source root rather than the importer directory',
+  () =>
+    Effect.gen(function* () {
+      const source = sourceFile(
+        'src/app/Main.silk',
+        'import compiler.Syntax { answer }\npub fn main() -> i32 { return answer() }',
+      )
+      sourceFile('src/compiler/Syntax.silk', 'pub fn answer() -> i32 { return 42 }')
+      const output = join(root, 'nested-answer')
+      const status = yield* run(source, { sourceRoot: join(root, 'src'), output })
 
-    assert.strictEqual(status, 0)
-    assert.strictEqual(spawnSync(output).status, 42)
-  }),
+      assert.strictEqual(status, 0)
+      assert.strictEqual(spawnSync(output).status, 42)
+    }),
+  Timeouts.nativeBuild,
 )
 
 it.effect('returns one for an absent import and leaves no artifact', () =>

--- a/packages/compiler-cli/test/Cli.test.ts
+++ b/packages/compiler-cli/test/Cli.test.ts
@@ -5,6 +5,7 @@ import * as FileSystem from 'effect/FileSystem'
 import * as Result from 'effect/Result'
 import { Command } from 'effect/unstable/cli'
 import * as Cli from '../src/Cli.js'
+import * as Timeouts from './timeouts.js'
 
 it('exposes the project-first command surface without a compile alias', () => {
   const names = Cli.command.subcommands.flatMap((group) =>
@@ -65,7 +66,7 @@ it.effect(
       const ran = yield* execute(['run', '--manifest-path', `${projectRoot}/silk.toml`])
       assert.strictEqual(Result.isSuccess(ran), true)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect(
@@ -97,7 +98,7 @@ it.effect(
         if (executed.failure._tag === 'CommandExit') assert.strictEqual(executed.failure.status, 42)
       }
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it('lists clean with its purpose in root help', () => {

--- a/packages/compiler-cli/test/Workflow.test.ts
+++ b/packages/compiler-cli/test/Workflow.test.ts
@@ -8,6 +8,7 @@ import * as Fiber from 'effect/Fiber'
 import * as FileSystem from 'effect/FileSystem'
 import * as Project from '../src/Project.js'
 import * as Workflow from '../src/Workflow.js'
+import * as Timeouts from './timeouts.js'
 
 const source = 'pub fn main() -> i32 { return 42 }'
 
@@ -120,7 +121,7 @@ it.effect(
         true,
       )
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect(
@@ -145,7 +146,7 @@ it.effect(
         true,
       )
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect(
@@ -177,7 +178,7 @@ pub fn main() -> i32 {
         false,
       )
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect('attempts a source rejection and operational failure, preferring exit two', () =>
@@ -268,7 +269,7 @@ it.effect(
 
       assert.strictEqual(status, 42)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect(
@@ -288,7 +289,7 @@ it.effect(
       assert.strictEqual(yield* fileSystem.exists(`${root}/src/Main.silk`), true)
       assert.strictEqual(yield* fileSystem.exists(`${root}/silk.toml`), true)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.effect('exits zero cleaning a project that was never built', () =>
@@ -327,7 +328,7 @@ it.live(
 
       assert.deepStrictEqual(passes.slice(0, 2), [0, 0])
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.live(
@@ -358,7 +359,7 @@ it.live(
 
       assert.deepStrictEqual(passes.slice(0, 2), [0, 0])
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )
 
 it.live(
@@ -383,5 +384,5 @@ it.live(
       assert.strictEqual(passes[1], 0)
       yield* Fiber.interrupt(watching)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  30_000,
+  Timeouts.nativeBuild,
 )

--- a/packages/compiler-cli/test/timeouts.ts
+++ b/packages/compiler-cli/test/timeouts.ts
@@ -1,0 +1,16 @@
+/**
+ * Wall-clock budget for a test that drives the native toolchain: Clang emits objects for the
+ * program and every shim, links them, and the test then executes the result.
+ *
+ * The value is sized from measurement, not from feel. On an idle 4-core machine the slowest
+ * such test in this package (`Cli.test.ts > initializes a project that loads, checks, builds,
+ * and runs with defaults`) takes ~474 ms. Issue #147 recorded `Workflow.test.ts > builds to the
+ * deterministic target and profile path` taking 13,572 ms on a shared CI runner, against ~238 ms
+ * for the same test locally — an amplification of roughly 57x. Applying that amplification to
+ * the slowest test puts the worst case near 27 s, so 60 s leaves a little over 2x headroom.
+ *
+ * This is not a performance gate. Nothing here asserts how fast a build is; the budget exists
+ * only so a correctness assertion is never reported as a timeout. If build speed is worth
+ * guarding, that belongs in a separate test that says so.
+ */
+export const nativeBuild = 60_000

--- a/packages/compiler-cli/vitest.config.ts
+++ b/packages/compiler-cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import * as Timeouts from './test/timeouts.js'
+
+export default defineConfig({
+  test: {
+    // Tests in this package shell out to Clang to compile and link real executables, which costs
+    // far more than Vitest's 5 s default on a loaded shared runner. Raising the package default
+    // keeps a newly added build test from silently inheriting a budget below the cost of the
+    // operation it exercises, which is how #147 reached `main`.
+    testTimeout: Timeouts.nativeBuild,
+    hookTimeout: Timeouts.nativeBuild,
+  },
+})


### PR DESCRIPTION
Closes #147

`BuildExeCommand.test.ts` drove a real Clang compile and link under Vitest's default 5000 ms budget. That budget is below the normal cost of the operation, so it timed out and turned `main` red at `a151d94` for ~27 minutes.

**This is deliberately the opposite fix from #143.** There, the wall-clock number stands in for a real property (sub-linear lookup), so raising the budget would kill the gate. Here nothing asserts how fast a build is — the subject of the test is *"does this produce a runnable executable and exit zero"*. The timeout was truncating a correctness test, not guarding a performance one, so an explicit generous budget is the correct fix. No comparative or structural measurement was invented, because there is no property to measure.

## Root cause

`packages/compiler` already carries a `vitest.config.ts` with `testTimeout: 30_000` for exactly this reason. **`compiler-cli` never had a config at all**, so every test in it silently inherited the 5 s default. That is the actual defect: not one bad test, a missing package default.

## Which tests actually shell out to the toolchain

Rather than guessing from names or durations, I instrumented `child_process` in a Vitest setup file and recorded every spawn attributed to the test that made it. Full map (instrumentation was temporary and is not in this diff):

| test | spawns |
|---|---|
| `BuildExeCommand` › compiles a single file to a runnable executable | 3× clang + exec artifact |
| `BuildExeCommand` › resolves nested imports from the source root | 3× clang + exec artifact |
| `Cli` › initializes a project that loads, checks, builds, and runs | 3× clang + exec artifact |
| `Cli` › parses run arguments after `--` | 3× clang + exec artifact |
| `Workflow` › builds to the deterministic target and profile path | 3× clang |
| `Workflow` › builds ordered native and LLVM-Wasm targets | clang (wasm) |
| `Workflow` › retains a successful sibling when another target rejects | 3× clang |
| `Workflow` › builds and returns the compiled program exact exit status | exec artifact |
| `Workflow` › removes the build artifacts and keeps the source files | (cache hit) |
| `Workflow` › attempts a source rejection …, `returns source and toolchain failure classes` | `/nonexistent/clang` — ENOENT, fails fast |
| `Program` › forwards literal arguments | spawns `node`, not the toolchain |

Two things this turned up:

- The remaining four `BuildExeCommand` tests and every watch test never reach Clang, so their cost is unrelated to the toolchain.
- Several build tests spawn **no** clang, because `NativeToolchain` keeps a process-local `processArtifactCache`. **The first native build in each worker pays full cost; byte-identical rebuilds after it are nearly free.** That is why `BuildExeCommand` is the exposed file — its very first test is a real build.

## Measurement behind the value

Per-test wall clock, 12 repetitions per load level, on an idle 4-core machine and under background CPU oversubscription (busy loops, no I/O) to model a contended shared runner. Median/max ms:

| test | idle | 2× load | 6× load |
|---|---|---|---|
| Cli › initializes a project … | 430 / **474** | 1196 / 1428 | 3154 / 3453 |
| Cli › parses run arguments after `--` | 173 / 209 | 458 / 489 | 1100 / 1278 |
| BuildExe › compiles a single file … | 277 / 299 | 764 / 838 | 1840 / 2051 |
| BuildExe › resolves nested imports … | 224 / 261 | 567 / 670 | 1334 / 1550 |
| Workflow › builds to the deterministic target … | 238 / 275 | 657 / 715 | 1665 / 1876 |
| Workflow › retains a successful sibling … | 219 / 232 | 573 / 696 | 1443 / 1566 |
| Workflow › builds ordered native and LLVM-Wasm … | 140 / 166 | 378 / 524 | 996 / 1161 |

Local contention amplifies by ~2.8× at 2× oversubscription and ~7.3× at 6×, but **it does not reach CI's numbers, and I am not claiming it does.** The governing figure is the field observation in #147: `Workflow › builds to the deterministic target` took **13,572 ms** on CI against ~238 ms median here — an amplification of roughly **57×**.

Derivation of the budget:

- slowest toolchain test locally, idle: **474 ms**
- × worst attested CI amplification (57×) ≈ **27,000 ms** estimated worst case
- that leaves the existing `30_000` budgets only ~11% headroom, and `builds to the deterministic target` had already consumed 45% of its 30 s
- **60,000 ms** ≈ 2.2× the derived worst case and ≈ 4.4× the worst directly observed CI time

## Changes

- New `packages/compiler-cli/vitest.config.ts` — `testTimeout` / `hookTimeout` at the measured value, so a future build test cannot silently inherit 5 s.
- New `packages/compiler-cli/test/timeouts.ts` — one documented constant carrying the derivation above, so the number is greppable and retunable in one place.
- Every toolchain test routed through that constant, replacing the nine hand-written `30_000` literals in `Cli.test.ts` and `Workflow.test.ts` and adding explicit budgets to the two `BuildExeCommand` build tests that had none.

**No assertion is changed, weakened, or removed.** The diff touches timeout arguments and imports only.

## Verification

**The new budget is actually in effect.** A deliberate 6.5 s probe test passes under the new config; the old 5 s default would have failed it. (Probe was temporary, not committed.)

**20 consecutive runs of the `compiler-cli` suite, under 2× CPU oversubscription — 20/20 pass, 92/92 tests each:**

```
run  1: PASS  32282ms  Tests  92 passed (92)     run 11: PASS  28550ms  Tests  92 passed (92)
run  2: PASS  30684ms  Tests  92 passed (92)     run 12: PASS  30307ms  Tests  92 passed (92)
run  3: PASS  28155ms  Tests  92 passed (92)     run 13: PASS  30829ms  Tests  92 passed (92)
run  4: PASS  29728ms  Tests  92 passed (92)     run 14: PASS  30288ms  Tests  92 passed (92)
run  5: PASS  29612ms  Tests  92 passed (92)     run 15: PASS  30357ms  Tests  92 passed (92)
run  6: PASS  29793ms  Tests  92 passed (92)     run 16: PASS  31409ms  Tests  92 passed (92)
run  7: PASS  29452ms  Tests  92 passed (92)     run 17: PASS  28880ms  Tests  92 passed (92)
run  8: PASS  28714ms  Tests  92 passed (92)     run 18: PASS  29779ms  Tests  92 passed (92)
run  9: PASS  30258ms  Tests  92 passed (92)     run 19: PASS  28783ms  Tests  92 passed (92)
run 10: PASS  30386ms  Tests  92 passed (92)     run 20: PASS  30015ms  Tests  92 passed (92)
-----
passed 20 / 20   failed 0
```

These runs drop `cap_dac_override`/`cap_dac_read_search`. Without that, three permission-injection tests (`FormatCommand` › maps read and write failures…, `FormatWorkflow` › reports storage failures…, `FormatWorkflow` › reports an atomic commit failure…) fail in this container purely because the agent runs as **root**, and root ignores `chmod 0o000`. That is a sandbox artifact, not a repo defect, and not something this PR changes.

### `pnpm check`

`biome check .` clean (566 files) · `turbo run build` clean · `pnpm test:scripts` 8/8 · `turbo run typecheck test --continue`:

| | this branch | pristine `origin/main` (b20c3a2) |
|---|---|---|
| tasks | **29 successful / 30** | **29 successful / 30** |
| failing | `@silk-effect/wasm#test` | `@silk-effect/wasm#test` |

**Identical — this branch introduces no regression.** The single failure is `packages/wasm/test/Extended.test.ts › threads address types through memory instructions`, where `WebAssembly.validate` rejects memory64 address types on this container's Node v22.22.2. It reproduces on a clean `origin/main` worktree with none of these changes present, so it is a pre-existing, Node/V8-version-dependent failure unrelated to #147. Flagging rather than fixing; say the word if you want it filed.

`compiler-cli` and `docs` on this branch: 92/92 and 89/89 with typecheck, 13/13 tasks green.

## The `Workflow.test.ts:383` watcher failure → filed as #158

The #135 report called this a "stable, unrelated watcher failure". **It is not stable — and it is not a test-only problem.** I did not repeat the claim; I tested it.

- **25 consecutive runs of `Workflow.test.ts` under 6× load: 0 failures.** It does not reproduce here at all, matching the CI run in #147 where it was 15/15.
- Instrumenting the test to record every pass *and the bytes it compiled* shows **a single write produces two recompiles** in 11 of 12 runs — `Workflow.watch` recompiles on every raw fs event, with no debounce (the source's own `ponytail` comment anticipates this).
- `fs.writeFile` is `open(O_TRUNC)` → `write` → `close`, and `fs.watch` fires on the truncate. Measuring that window directly — watch a directory, read the file on each event while rewriting it non-atomically — gives **~71% zero-length reads**:

```
{"writes":3000,"events":5149,"empty":3683,"short":0,"lengths":[[34,1466],[0,3683]]}
{"writes":3000,"events":5270,"empty":3607,"short":0,"lengths":[[34,1663],[0,3607]]}
{"writes":3000,"events":5202,"empty":3774,"short":0,"lengths":[[34,1428],[0,3774]]}
```

An empty `Main.silk` has no `main` entry, so `check` returns **1** — exactly the reported `passes[1]` is 1. Whether the reader wins that race is decided by filesystem and watch-backend scheduling, which is why it looks deterministic on one machine and is invisible on another.

**I deliberately did not "fix" it here.** Making the test's helper write atomically would let every assertion pass untouched — and would hide a real product behaviour: anything writing non-atomically into a watched tree (shell `>`, `sed -i`, editors without atomic save) makes watch mode emit a spurious "no main entry" diagnostic on an ordinary save. That is the #143 trap wearing a different hat. The real fix is debounce/settle in `Workflow.watch`, which is a product decision beyond this issue. Filed with the full reproduction as **#158**.

## Note on shared configuration

A worker is concurrently fixing #143 in `packages/compiler`. That package's `vitest.config.ts` is **untouched** here — this PR adds a *new* config to `compiler-cli` and edits only `compiler-cli` test files. No shared or root-level test configuration is modified, so the two branches should not collide.

## Deliberately not done

`packages/compiler` sets `SILK_NATIVE_CACHE_DIR` to share a durable on-disk artifact cache across runs, which would cut these build costs substantially. I left it out: it changes what the tests actually exercise (cold build vs. cache hit), which is a semantic change beyond sizing a timeout. Worth considering separately.