### PR TITLE
test(compiler): fail when two diagnostic constants share a stable code

### DIFF
--- a/packages/compiler/scripts/generate-documentation.mjs
+++ b/packages/compiler/scripts/generate-documentation.mjs
@@ -126,6 +126,7 @@ const diagnosticsPage = () => {
   const source = readFileSync(diagnosticSource, 'utf8')
 
   const documented = new Map()
+  const collisions = new Map()
   // `[^*]` in the comment body keeps the match from reaching back past an earlier `*/`.
   const declaration =
     /(?:\/\*\*((?:[^*]|\*(?!\/))*)\*\/\s*)?export const (\w+)Code = '([A-Z]{3}[0-9]{4})' as const/g
@@ -134,7 +135,24 @@ const diagnosticsPage = () => {
       .replace(/^\s*\*\s?/gm, '')
       .replace(/\s+/g, ' ')
       .trim()
+    // Keyed by code, so a second constant claiming a taken code would silently displace the first
+    // and this page would document one meaning while the compiler reports two. Refuse instead: a
+    // published index that resolves a collision by dropping a diagnostic is worse than no index.
+    const taken = documented.get(match[3])
+    if (taken !== undefined)
+      collisions.set(match[3], [
+        ...(collisions.get(match[3]) ?? [`${taken.name}Code`]),
+        `${match[2]}Code`,
+      ])
     documented.set(match[3], { name: match[2], comment })
+  }
+
+  if (collisions.size > 0) {
+    console.error('Duplicate stable diagnostic codes in src/Diagnostic.ts:')
+    for (const [code, names] of collisions)
+      console.error(`  ${code} is held by ${names.join(' and ')}`)
+    console.error('A stable code identifies one condition. Renumber the newer constant.')
+    process.exit(1)
   }
 
   // The constructor bodies carry the user-visible message template, which is the most precise
@@ -231,5 +249,10 @@ const write = (name, contents) => {
   writeFileSync(destination, contents)
 }
 
-write('stdlib.md', await stdlibPage())
-write('diagnostics.md', diagnosticsPage())
+// Both pages are rendered before either is written, so a rejected diagnostic index leaves the
+// documentation exactly as it was rather than half-regenerated.
+const stdlib = await stdlibPage()
+const diagnostics = diagnosticsPage()
+
+write('stdlib.md', stdlib)
+write('diagnostics.md', diagnostics)

--- a/packages/compiler/test/DocumentationExamples.test.ts
+++ b/packages/compiler/test/DocumentationExamples.test.ts
@@ -5,6 +5,7 @@ import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
 import * as Stdlib from '../src/Stdlib.js'
+import { raise } from './support/raise.js'
 
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
@@ -57,6 +58,26 @@ const documents = readdirSync(documentationRoot)
 
 const blocks = documents.filter((entry) => !generated.has(entry)).flatMap(blocksOf)
 
+const diagnosticText = readFileSync(diagnosticSource, 'utf8')
+
+interface Declaration {
+  readonly name: string
+  readonly code: string
+}
+
+// Every stable code is declared as `export const <name>Code = '<CODE>' as const`. Reading the
+// source rather than the module keeps the constant name, which a collision report has to carry.
+const declarations: ReadonlyArray<Declaration> = [
+  ...diagnosticText.matchAll(/export const (\w+Code) = '([A-Z]{3}[0-9]{4})' as const/g),
+].map((match) => ({
+  name: match[1] ?? raise('the declaration pattern must capture a constant name'),
+  code: match[2] ?? raise('the declaration pattern must capture a stable code'),
+}))
+
+const codeLiterals = [...diagnosticText.matchAll(/'([A-Z]{3}[0-9]{4})' as const/g)].map(
+  (match) => match[1] ?? raise('the literal pattern must capture a stable code'),
+)
+
 it('finds Silk examples in the tutorial and the reference', () => {
   assert.isTrue(
     documents.includes('tutorial.md'),
@@ -72,14 +93,49 @@ it('documents every standard library module and every diagnostic code', () => {
     assert.include(stdlib, `## ${module.module}`, `${module.module} is missing from stdlib.md`)
 
   const diagnostics = readFileSync(join(documentationRoot, 'diagnostics.md'), 'utf8')
-  const declared = new Set(
-    [...readFileSync(diagnosticSource, 'utf8').matchAll(/'([A-Z]{3}[0-9]{4})' as const/g)].map(
-      (match) => match[1],
-    ),
-  )
+  const declared = new Set(codeLiterals)
   assert.isAbove(declared.size, 0, 'Diagnostic.ts must declare stable codes')
   for (const code of declared)
     assert.include(diagnostics, `\`${code}\``, `${code} is missing from diagnostics.md`)
+})
+
+/**
+ * A stable code is a public contract: it appears in diagnostics.md, in user-facing messages, and
+ * in tests that assert on it by string. Two constants holding one code ship two meanings under
+ * that contract, and nothing else notices — the containment check above passes for both, since
+ * both find the code present.
+ *
+ * Concurrent branches each take "the next free code" against a `main` that lacks the other's, so
+ * a collision is only ever visible on the merge result. Git catches it only when both branches
+ * happen to insert at the same line; when they do not, the merge is clean and the duplicate ships.
+ * This test is the check that does not depend on that coincidence, so it must hold for constants
+ * declared anywhere in the file, not just adjacent ones.
+ */
+it('gives every diagnostic constant a distinct stable code', () => {
+  assert.isAbove(declarations.length, 0, 'Diagnostic.ts must declare stable codes')
+  // A code literal the declaration pattern cannot see is a code this test cannot check.
+  assert.strictEqual(
+    declarations.length,
+    codeLiterals.length,
+    'every stable code in Diagnostic.ts must be declared as `export const <name>Code`',
+  )
+
+  const names = new Map<string, Array<string>>()
+  for (const { name, code } of declarations) {
+    const holders = names.get(code)
+    if (holders === undefined) names.set(code, [name])
+    else holders.push(name)
+  }
+
+  const collisions = [...names]
+    .filter(([, holders]) => holders.length > 1)
+    .map(([code, holders]) => `${code} is held by ${holders.join(' and ')}`)
+
+  assert.deepEqual(
+    collisions,
+    [],
+    'each stable diagnostic code must belong to exactly one constant; renumber the newer one',
+  )
 })
 
 for (const block of blocks) {


### PR DESCRIPTION
Closes #152

## The gap

A stable diagnostic code is a public contract — it appears in `diagnostics.md`, in user-facing messages, and in tests that assert on it by string. Nothing enforced that two constants cannot claim the same one.

- **The guard test did not check uniqueness.** `DocumentationExamples.test.ts:82` is `assert.include(diagnostics, \`${code}\`, …)`, a per-code *containment* check. Two constants holding `'SEM0097'` produce two iterations that both find the string present, and both pass.
- **The generator did not reject a duplicate.** `generate-documentation.mjs` keys `documented` by code, so a second constant claiming a taken code silently displaces the first. The published index would document one meaning while the compiler reports two. (The issue predicted two rows; the map keying makes the real behaviour a silent drop, which is quieter still.)

Concurrent branches each take "the next free code" against a `main` that lacks the other's, so a collision is only ever visible on the merge result. Git surfaces it only when both branches happen to insert at the same line — the `SEM0097` case. `SEM0098` had no shared line, and would have merged clean.

## The change

**`test/DocumentationExamples.test.ts`** — a new test asserts every `export const <name>Code` holds a distinct value, and reports each colliding code with **both** constant names. The parse is now shared with the existing `diagnostics.md` containment check rather than duplicated.

It also pins that every stable-code literal in `Diagnostic.ts` is reachable through the declaration pattern, since a literal the pattern cannot see is a code the uniqueness check cannot cover.

**`scripts/generate-documentation.mjs`** — collects constants that claim an already-taken code and exits non-zero naming both, instead of rendering the index. Both pages now render before either is written, so a rejected index leaves the documentation as it was rather than half-regenerated.

## Requirement 3 — meaningful on the merge result

No CI change was needed. `.github/workflows/ci.yml` runs `pnpm check` on `push: branches: [main]`, and `pnpm check` reaches both guards: the compiler package's `test` script runs `documentation:check` and then the vitest suite. A collision that merges clean is caught by the first `main` build after the second branch lands — which is the only place it can be caught, since it requires both branches to exist.

## Verification

Recorded in a follow-up comment: the guard is exercised against a deliberate duplicate placed in a **different region** of `Diagnostic.ts` from the constant it collides with — a `LEX`-region constant taking `SEM0097` — since the same-region case is the one git already covers.

## Out of scope

The issue floats allocating codes from a checked-in registry, or deriving them from constant names. Neither is implemented here, per the issue's own note that they only matter if collisions recur once a guard exists.

No diagnostic was renumbered; the existing `SEM0097` / `SEM0098` split is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSP7na8nv6TfhSSBBbLWTS)_