### PR TITLE
test: make `pnpm check` pass on a clean checkout as root and on Node 22

### DIFF
--- a/packages/compiler-cli/test/FormatCommand.test.ts
+++ b/packages/compiler-cli/test/FormatCommand.test.ts
@@ -5,6 +5,7 @@ import * as FileSystem from 'effect/FileSystem'
 import * as Result from 'effect/Result'
 import { Command } from 'effect/unstable/cli'
 import * as Cli from '../src/Cli.js'
+import { denying } from './fileSystemFailures.js'
 
 const compact = 'pub fn main() -> i32 { return 42 }'
 const canonical = 'pub fn main() -> i32 {\n  return 42\n}\n'
@@ -100,18 +101,26 @@ it.effect('maps read and write failures to exit class two without corrupting sou
     const readRoot = yield* fileSystem.makeTempDirectoryScoped()
     yield* makeProject(readRoot, canonical)
     yield* fileSystem.writeFileString(`${readRoot}/src/A-Unreadable.silk`, compact)
-    const readFailure = yield* Effect.acquireUseRelease(
-      fileSystem.chmod(`${readRoot}/src/A-Unreadable.silk`, 0o000),
-      () => execute(['format', '--manifest-path', `${readRoot}/silk.toml`]),
-      () => fileSystem.chmod(`${readRoot}/src/A-Unreadable.silk`, 0o644),
+    const canonicalReadRoot = yield* fileSystem.realPath(readRoot)
+    const readFailure = yield* execute(['format', '--manifest-path', `${readRoot}/silk.toml`]).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        denying(fileSystem, { readFile: [`${canonicalReadRoot}/src/A-Unreadable.silk`] }),
+      ),
     )
 
     const writeRoot = yield* fileSystem.makeTempDirectoryScoped()
     yield* makeProject(writeRoot)
-    const writeFailure = yield* Effect.acquireUseRelease(
-      fileSystem.chmod(`${writeRoot}/src`, 0o555),
-      () => execute(['format', '--manifest-path', `${writeRoot}/silk.toml`]),
-      () => fileSystem.chmod(`${writeRoot}/src`, 0o755),
+    const canonicalWriteRoot = yield* fileSystem.realPath(writeRoot)
+    const writeFailure = yield* execute([
+      'format',
+      '--manifest-path',
+      `${writeRoot}/silk.toml`,
+    ]).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        denying(fileSystem, { rename: [`${canonicalWriteRoot}/src/Main.silk`] }),
+      ),
     )
 
     assert.strictEqual(status(readFailure), 2)

--- a/packages/compiler-cli/test/FormatWorkflow.test.ts
+++ b/packages/compiler-cli/test/FormatWorkflow.test.ts
@@ -4,6 +4,7 @@ import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
 import * as Result from 'effect/Result'
 import * as FormatWorkflow from '../src/FormatWorkflow.js'
+import { denying } from './fileSystemFailures.js'
 
 const canonical = 'pub fn main() -> i32 {\n  return 42\n}\n'
 const compact = 'pub fn main() -> i32 { return 42 }'
@@ -176,11 +177,13 @@ it.effect('reports storage failures, continues in order, and gives exit class tw
     yield* makeProject(root, canonical)
     yield* writeFile(`${root}/src/A-Unreadable.silk`, compact)
     yield* writeFile(`${root}/src/Zeta.silk`, compact)
+    const canonicalRoot = yield* fileSystem.realPath(root)
 
-    const summary = yield* Effect.acquireUseRelease(
-      fileSystem.chmod(`${root}/src/A-Unreadable.silk`, 0o000),
-      () => FormatWorkflow.run({ workingDirectory: root }),
-      () => fileSystem.chmod(`${root}/src/A-Unreadable.silk`, 0o644),
+    const summary = yield* FormatWorkflow.run({ workingDirectory: root }).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        denying(fileSystem, { readFile: [`${canonicalRoot}/src/A-Unreadable.silk`] }),
+      ),
     )
 
     assert.deepEqual(
@@ -197,11 +200,13 @@ it.effect('reports an atomic commit failure without replacing the original file'
     const fileSystem = yield* FileSystem.FileSystem
     const root = yield* fileSystem.makeTempDirectoryScoped()
     yield* makeProject(root, compact)
+    const canonicalRoot = yield* fileSystem.realPath(root)
 
-    const summary = yield* Effect.acquireUseRelease(
-      fileSystem.chmod(`${root}/src`, 0o555),
-      () => FormatWorkflow.run({ workingDirectory: root }),
-      () => fileSystem.chmod(`${root}/src`, 0o755),
+    const summary = yield* FormatWorkflow.run({ workingDirectory: root }).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        denying(fileSystem, { rename: [`${canonicalRoot}/src/Main.silk`] }),
+      ),
     )
 
     assert.deepEqual(

--- a/packages/compiler-cli/test/fileSystemFailures.ts
+++ b/packages/compiler-cli/test/fileSystemFailures.ts
@@ -1,0 +1,62 @@
+/**
+ * Deterministic storage failures for the format tests.
+ *
+ * The failure paths these tests cover — a source file that cannot be read, an atomic commit that
+ * cannot be completed — used to be induced with `chmod(path, 0o000)` and `chmod(directory, 0o555)`.
+ * That works for an unprivileged user and silently does nothing for root, which bypasses the file
+ * permission check entirely: the read succeeds, the rename succeeds, and the assertion that wanted
+ * `Failed` sees `Changed`. Issue #159 records the cost — a clean checkout is red in any root
+ * container, and every contributor working in one pays to rediscover that the red is not theirs.
+ *
+ * Injecting the failure at the `FileSystem` seam removes the dependency on who is running the
+ * suite. The workflow still takes the same branch it takes when the operating system denies the
+ * operation for real, because it reaches that branch through the same `PlatformError` the platform
+ * layer would have produced. The precondition is now expressible under every UID rather than only
+ * under some, so the coverage is the same everywhere instead of silently better on CI.
+ *
+ * Only the two operations the failure paths depend on are overridden, and only for paths named by
+ * the caller. Every other call — including the reads a test makes to assert that a file was left
+ * untouched — goes to the real filesystem.
+ */
+import * as Effect from 'effect/Effect'
+import type * as FileSystem from 'effect/FileSystem'
+import * as PlatformError from 'effect/PlatformError'
+
+export interface Denials {
+  /** Canonical paths whose `readFile` fails, standing in for a source file the process cannot read. */
+  readonly readFile?: ReadonlyArray<string>
+  /** Canonical destination paths whose `rename` fails, standing in for an atomic commit that cannot land. */
+  readonly rename?: ReadonlyArray<string>
+}
+
+const denied = (method: string, syscall: string, path: string): PlatformError.PlatformError =>
+  PlatformError.systemError({
+    _tag: 'PermissionDenied',
+    module: 'FileSystem',
+    method,
+    syscall,
+    pathOrDescriptor: path,
+    description: `Injected permission denial for ${path}`,
+  })
+
+/**
+ * Wraps a filesystem so the named operations fail with `PermissionDenied` on the named paths.
+ *
+ * Paths are compared exactly, so callers pass canonical paths: the workflow resolves its selection
+ * through `realPath` before touching anything, and a temporary directory is a symlink on some
+ * platforms.
+ */
+export const denying = (
+  fileSystem: FileSystem.FileSystem,
+  denials: Denials,
+): FileSystem.FileSystem => ({
+  ...fileSystem,
+  readFile: (path) =>
+    denials.readFile?.includes(path)
+      ? Effect.fail(denied('readFile', 'open', path))
+      : fileSystem.readFile(path),
+  rename: (oldPath, newPath) =>
+    denials.rename?.includes(newPath)
+      ? Effect.fail(denied('rename', 'rename', newPath))
+      : fileSystem.rename(oldPath, newPath),
+})

--- a/packages/wasm/test/Extended.test.ts
+++ b/packages/wasm/test/Extended.test.ts
@@ -12,6 +12,7 @@ import * as Table from '../src/Table.js'
 import * as Type from '../src/Type.js'
 import * as ValType from '../src/ValType.js'
 import type { WasmError } from '../src/WasmError.js'
+import { mixedMemoryCopy, requiring } from './support/hostCapability.js'
 
 const failure = <A>(effect: Effect.Effect<A, WasmError>) =>
   effect.pipe(
@@ -154,33 +155,58 @@ it.effect('rejects a shared memory without a maximum', () =>
   }),
 )
 
+/**
+ * An i64-address memory beside an i32-address one, an i32 index the i64 memory must reject, and a
+ * body that copies between the two memories, loads above 2^32, and reads the wide memory's size.
+ *
+ * Encoding it is one test and asking the host to validate it is another, because only the second
+ * depends on the host implementing mixed-address `memory.copy`.
+ */
+const addressThreadedModule = Effect.fnUntraced(function* () {
+  const builder = yield* Builder.make()
+  const wide = yield* Memory.make(builder, { min: 1 }, { addressType: 'i64', name: 'wide' })
+  const narrow = yield* Memory.make(builder, { min: 1 }, { name: 'narrow' })
+  const type = yield* Type.func(builder, [], [ValType.i64])
+  const func = yield* Func.declare(builder, type, { name: 'probe' })
+  const wrongAddress = yield* failure(
+    Func.define(builder, func, {
+      body: [Instr.i32Const(0), Instr.memoryAccess('i64.load', wide)],
+    }),
+  )
+  yield* Func.define(builder, func, {
+    body: [
+      Instr.i64Const(8n),
+      Instr.i32Const(0),
+      Instr.i32Const(4),
+      // Mixed 64/32-bit copy takes an i32 count.
+      Instr.memoryCopy(wide, narrow),
+      Instr.i64Const(0n),
+      Instr.memoryAccess('i64.load', wide, { offset: 2n ** 32n }),
+      Instr.memorySize(wide),
+      Instr.op('i64.add'),
+    ],
+  })
+  return { wrongAddress, bytes: yield* Binary.encode(builder) }
+})
+
+const hostValidatesAddressThreaded = requiring(
+  mixedMemoryCopy,
+  'the host validates a module threading address types through memory instructions',
+)
+
 it.effect('threads address types through memory instructions', () =>
   Effect.gen(function* () {
-    const builder = yield* Builder.make()
-    const wide = yield* Memory.make(builder, { min: 1 }, { addressType: 'i64', name: 'wide' })
-    const narrow = yield* Memory.make(builder, { min: 1 }, { name: 'narrow' })
-    const type = yield* Type.func(builder, [], [ValType.i64])
-    const func = yield* Func.declare(builder, type, { name: 'probe' })
-    const wrongAddress = yield* failure(
-      Func.define(builder, func, {
-        body: [Instr.i32Const(0), Instr.memoryAccess('i64.load', wide)],
-      }),
-    )
+    const { wrongAddress, bytes } = yield* addressThreadedModule()
     assert.strictEqual(wrongAddress?.reason._tag, 'ValidationFailed')
-    yield* Func.define(builder, func, {
-      body: [
-        Instr.i64Const(8n),
-        Instr.i32Const(0),
-        Instr.i32Const(4),
-        // Mixed 64/32-bit copy takes an i32 count.
-        Instr.memoryCopy(wide, narrow),
-        Instr.i64Const(0n),
-        Instr.memoryAccess('i64.load', wide, { offset: 2n ** 32n }),
-        Instr.memorySize(wide),
-        Instr.op('i64.add'),
-      ],
-    })
-    const bytes = yield* Binary.encode(builder)
+    assert.isDefined(bytes)
+  }),
+)
+
+it.effect.skipIf(hostValidatesAddressThreaded.skip)(hostValidatesAddressThreaded.name, () =>
+  Effect.gen(function* () {
+    if (hostValidatesAddressThreaded.failure !== undefined)
+      return assert.fail(hostValidatesAddressThreaded.failure)
+    const { bytes } = yield* addressThreadedModule()
     assert.isTrue(WebAssembly.validate(bytes))
   }),
 )

--- a/packages/wasm/test/support/hostCapability.ts
+++ b/packages/wasm/test/support/hostCapability.ts
@@ -1,0 +1,112 @@
+/**
+ * Host WebAssembly features a test may need but cannot assume.
+ *
+ * Some assertions in this suite ask the host's own `WebAssembly.validate` to accept a module the
+ * builder emitted. That is the right oracle when the host implements the proposal in question, and
+ * the wrong one when it does not: the module is still valid, the host is simply older. Issue #161
+ * measured that gap for one construct, and the repository's declared engine range spans both sides
+ * of it, so the suite has to detect the difference rather than assume it away.
+ *
+ * A capability is probed with a module written out by hand rather than one produced by the builder.
+ * If the probe went through the encoder under test, an encoder regression would look exactly like a
+ * missing host feature, and the assertion it guards would turn itself off in the one situation it
+ * exists to catch.
+ */
+
+/**
+ * The package builds against the ES library, which does not describe `process`. Declaring the one
+ * field used here keeps that build honest without pulling in Node's types, and `typeof` reaches for
+ * it without assuming a runtime that has it.
+ *
+ * @internal
+ */
+declare const process: { readonly env: { readonly CI?: string | undefined } } | undefined
+
+/** @internal */
+const inContinuousIntegration = (): boolean =>
+  typeof process !== 'undefined' && process.env.CI !== undefined
+
+export interface Capability {
+  /** Whether the running host accepts the construct. */
+  readonly supported: boolean
+  /** What a guarded assertion must report when it does not run. */
+  readonly reason: string
+}
+
+/**
+ * `memory.copy` between an i64-address memory and an i32-address memory.
+ *
+ * The memory64 proposal takes the destination index at the destination memory's address type, the
+ * source index at the source memory's, and the count at the narrower of the two. V8 13.6 (Node 24)
+ * implements that rule. V8 12.4 (Node 22) requires both memories to share an address type and
+ * rejects the mixed form in either direction, while accepting i64 memories, `i64.load` at an offset
+ * above 2^32, and `memory.size` on an i64 memory — so the gap is specific to this instruction, not
+ * to memory64 as a whole.
+ *
+ * The probe below is that instruction and nothing else: two memories, one i64 and one i32, and a
+ * function that copies between them.
+ */
+const mixedMemoryCopyProbe = Uint8Array.from([
+  // magic and version
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+  // type section: one type `() -> ()`
+  0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+  // function section: one function of that type
+  0x03, 0x02, 0x01, 0x00,
+  // memory section: memory 0 is i64-addressed (limits flag 0x04), memory 1 is i32-addressed
+  0x05, 0x05, 0x02, 0x04, 0x01, 0x00, 0x01,
+  // code section: one body of twelve bytes, no locals
+  0x0a, 0x0e, 0x01, 0x0c, 0x00,
+  // destination index at memory 0's address type, source index at memory 1's, count at the narrower
+  0x42, 0x00, 0x41, 0x00, 0x41, 0x00,
+  // memory.copy, destination memory 0, source memory 1, then end
+  0xfc, 0x0a, 0x00, 0x01, 0x0b,
+])
+
+/**
+ * Whether the running host validates a mixed 64/32-address `memory.copy`, and what to report when
+ * it does not.
+ */
+export const mixedMemoryCopy: Capability = (() => {
+  const supported = WebAssembly.validate(mixedMemoryCopyProbe)
+  return {
+    supported,
+    reason: supported
+      ? 'host validates a mixed 64/32-address memory.copy'
+      : "this host's WebAssembly rejects a mixed 64/32-address memory.copy, so it cannot serve as the validity oracle for a module containing one; the encoding is unchecked here. Node 24 accepts it (see issue #161)",
+  }
+})()
+
+export interface Requirement {
+  /** Whether the guarded test should be skipped rather than run. */
+  readonly skip: boolean
+  /** The test's name, carrying the reason when the capability is absent. */
+  readonly name: string
+  /** Present only when the test must run and fail, carrying what to fail with. */
+  readonly failure: string | undefined
+}
+
+/**
+ * Describes how a test that can only run on a capable host should be registered.
+ *
+ * The reason goes into the test's own name rather than into a `console.log`, because the default
+ * reporter prints neither log output nor annotations: a skip explained only by a log is a skip
+ * nobody reads, which is how #151's `opt` cross-check went its whole life without running. A named
+ * skip still counts in the run summary, so the run reports that something did not happen, and every
+ * reporter that lists a test at all shows why.
+ *
+ * A capability missing under CI is a failure rather than a skip. CI pins a runtime that has it, so
+ * its absence there means the pinned runtime changed and the assertion has quietly stopped running
+ * — the outcome this guard exists to prevent, not one for it to produce.
+ */
+export const requiring = (capability: Capability, name: string): Requirement => {
+  if (capability.supported) return { skip: false, name, failure: undefined }
+  const explanation = `${name}: ${capability.reason}`
+  return inContinuousIntegration()
+    ? {
+        skip: false,
+        name,
+        failure: `${explanation}. CI pins a runtime that supports it, so this is a change in the pinned runtime rather than an environment to skip.`,
+      }
+    : { skip: true, name: `${name} — skipped: ${capability.reason}`, failure: undefined }
+}


### PR DESCRIPTION
Closes #159
Closes #161

Two causes of the same symptom — a red baseline on a clean checkout — kept as two commits. Fixing either alone leaves the tax in place, so they travel together.

No production code changes. No assertion deleted or weakened.

## #159 — permission tests fail as root

`FormatWorkflow.test.ts` and one case in `FormatCommand.test.ts` established their failure preconditions with `chmod(path, 0o000)` and `chmod(directory, 0o555)`. Root bypasses the file permission check, so the read and the rename both succeed, the outcome is `Changed` where the assertion wants `Failed`, and three tests fail. CI never saw it because GitHub runners are non-root.

**Approach 1 (induce the failure without permissions) worked for both tests, so no skip was needed anywhere.** The failure is injected at the `FileSystem` seam by `test/fileSystemFailures.ts`, which wraps the platform filesystem so a named operation on a named path fails with the same `PermissionDenied` `PlatformError` the platform layer produces when the OS denies it for real:

| test | old precondition | new precondition |
|---|---|---|
| `FormatWorkflow` › reports storage failures… | `chmod 0o000` on the source | `readFile` denied on that path |
| `FormatWorkflow` › reports an atomic commit failure… | `chmod 0o555` on `src/` | `rename` denied on the destination — the atomic swap itself |
| `FormatCommand` › maps read and write failures… | both of the above | both of the above |

Only those two operations are overridden, and only for paths the caller names — the reads each test makes to assert a file was left untouched still go to the real filesystem. Coverage is now identical under every UID instead of silently better on CI. If a refactor moved the workflow off `readFile`/`rename`, the injection would stop firing and the tests would fail rather than pass quietly.

## #161 — `engines` promises Node 22, the suite could not pass on it

I did not re-derive the diagnosis; #161's is complete and correct. I did re-confirm it with a hand-written module independent of the encoder, which reproduces the reported table exactly — including that the first hypothesis (missing memory64) is wrong:

```
node v22.22.2  v8 12.4.254.21
i32<-i32         true
i64<-i64         true
i64<-i32 mixed   false
i32<-i64 mixed   false
```

Taking **option 2** — a runtime capability probe — rather than narrowing `engines`, which is a support-policy call for the maintainer to make deliberately rather than as a side effect of one V8 gap. `engines` is unchanged.

`test/support/hostCapability.ts` validates a 41-byte hand-written mixed-copy module once. It is hand-written rather than built through the builder on purpose: a probe routed through the encoder under test would make an encoder regression look exactly like a missing host feature and would disable the assertion in the one situation it exists to catch. Verified the probe module is genuinely valid — `validate: false` on Node 22 / V8 12.4, `true` on Node 24 / V8 13.6 — so the guard cannot be permanently stuck off.

The host validation moved into its own test so the skip is a real skip. Everything else in the original test — the address-type rejection, the encode — still runs unconditionally on every host.

### On "prints why it skipped"

`console.log` is not enough, and this is measurable rather than a matter of taste. The default reporter this repo runs prints neither log output nor test annotations:

```
$ vitest run test/diag.test.ts               # console.log in the test body
 Test Files  1 passed (1)
      Tests  1 passed (1)                    # ← the log appears nowhere
```

That is exactly how #151's `opt` cross-check went its whole life without running. The same pattern is still live at `packages/compiler/test/ModuleVerification.test.ts:55` — worth a follow-up, out of scope here.

So the reason goes into the skipped test's **name**, which every reporter that lists a test at all will show, and the skip itself raises a non-zero skipped count in the summary — the run reports that something did not happen:

```
 ✓ threads address types through memory instructions
 ↓ the host validates a module threading address types through memory instructions — skipped:
   this host's WebAssembly rejects a mixed 64/32-address memory.copy, so it cannot serve as the
   validity oracle for a module containing one; the encoding is unchecked here. Node 24 accepts
   it (see issue #161)

      Tests  8 passed | 1 skipped (9)
```

Under CI a missing capability **fails instead of skipping** — CI pins a runtime that has it, so its absence means the pinned runtime changed and the assertion has quietly stopped running:

```
$ CI=1 vitest run test/Extended.test.ts      # on Node 22
AssertionError: the host validates a module threading address types through memory instructions:
this host's WebAssembly rejects a mixed 64/32-address memory.copy … CI pins a runtime that
supports it, so this is a change in the pinned runtime rather than an environment to skip.
      Tests  1 failed | 8 passed (9)
```

The condition is a probed capability, not a version string or an environment guess.

## Verification

Full `pnpm check`, both UIDs × both Node versions, `TURBO_FORCE=true` throughout so nothing replays from cache. **Both issues in this lane are fixed in all four cells** — `compiler-cli` 92/92 and `wasm` 9/9 files in every run:

```
every run:  @silk-effect/compiler-cli:test:  Tests  92 passed (92)          ← #159, was 3 failed as root
Node 24:    @silk-effect/wasm:test:          Tests  83 passed (83)          ← assertion runs
Node 22:    @silk-effect/wasm:test:          Tests  82 passed | 1 skipped   ← #161, was 1 failed
```

`pnpm check` overall, however, is still not green on Node 22 — for a **third, unrelated** reason:

| | root (uid 0) | non-root (uid 1000) |
|---|---|---|
| **Node 24.19.0** | `EXIT=0` — 30/30 tasks | `EXIT=0` — 30/30 tasks |
| **Node 22.22.2** | `EXIT=1` — `@silk-effect/compiler#test` | `EXIT=1` — `@silk-effect/compiler#test` |

`packages/compiler/test/LexerPressure.test.ts › rolls back every token and diagnostic allocation failure on all three engines` exceeds its `180_000` ms budget on Node 22 (180 028 ms / 180 031 ms) while taking 139–150 s on Node 24. `git diff origin/main --stat -- packages/compiler packages/lsp` is empty — this branch does not touch that package.

**[The verification comment](https://github.com/julia-script/silk-effect/pull/163#issuecomment-5287350304) has the full matrix and three further pre-existing baseline problems I found while running it**, with measurements: the `LexerPressure` budget above, an `lsp` test running against vitest's default 5 s timeout, and a `NativeToolchain` test that promotes to the fixed shared path `/tmp/promoted.o` and collides across users. None are fixed here — reported rather than silently absorbed, and happy to take any of them in a follow-up.