### PR TITLE
fix(compiler-cli): compile a settled source tree in watch mode

### DIFF
--- a/packages/compiler-cli/src/Workflow.ts
+++ b/packages/compiler-cli/src/Workflow.ts
@@ -383,10 +383,12 @@ export const watch = Effect.fn('Workflow.watch')(function* (
   const loaded = yield* Effect.result(loadProject(options))
   if (Result.isFailure(loaded)) return yield* reportPreparationFailure(loaded.failure)
   const sourceRoot = loaded.success.entry.sourceRoot
+  // Taken before the pass rather than after it: an edit that lands while the pass is running must
+  // look like a change the pass did not read, so it recompiles instead of being skipped.
+  const compiled = yield* Ref.make(yield* sourceFingerprint(sourceRoot))
   yield* run(options)
   // ponytail: directories are enumerated once; a directory created later needs a restart.
   const directories = yield* sourceDirectories(sourceRoot)
-  const compiled = yield* Ref.make(yield* sourceFingerprint(sourceRoot))
   yield* Console.log(`Watching ${sourceRoot} for changes.`)
   yield* Stream.mergeAll(
     directories.map((directory) => fileSystem.watch(directory)),

--- a/packages/compiler-cli/src/Workflow.ts
+++ b/packages/compiler-cli/src/Workflow.ts
@@ -9,7 +9,9 @@ import type * as ToolchainPlan from '@silk-effect/compiler/ToolchainPlan'
 import * as Console from 'effect/Console'
 import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
+import * as Option from 'effect/Option'
 import * as Path from 'effect/Path'
+import * as Ref from 'effect/Ref'
 import * as Result from 'effect/Result'
 import * as Stream from 'effect/Stream'
 import type { ChildProcessSpawner } from 'effect/unstable/process'
@@ -286,9 +288,90 @@ const sourceDirectories = Effect.fnUntraced(function* (
 })
 
 /**
+ * How long the event stream must fall quiet before a burst counts as one finished edit.
+ *
+ * A save is not one event. `writeFile` is `open(O_TRUNC)`, `write`, `close`, and the watch fires
+ * on the truncate, so recompiling per raw event reads a file that is still being written — issue
+ * #158 measured 71% of watch-woken reads observing zero bytes. Coalescing sub-millisecond bursts
+ * needs only a few milliseconds; 50 ms also absorbs an editor that writes a backup or a swap file
+ * beside the source, while staying far enough below the ~100 ms threshold where a feedback loop
+ * starts to feel delayed. Two edits further apart than this window remain two compilations.
+ */
+const quietWindow = '50 millis'
+
+/**
+ * Gap between the two source-tree samples that decide whether a writer is still mid-flight.
+ *
+ * Quiet is not the same as finished: one large `write` is a single event that arrives when the
+ * write completes, so a slow writer can leave the stream silent while the file on disk is
+ * truncated. Comparing the tree against itself across this gap catches that case, and costs one
+ * extra sample of the source tree per compilation.
+ */
+const settleInterval = '25 millis'
+
+/** Caps the settle wait at one second so a continuously rewritten tree still compiles. */
+const settleSamples = 40
+
+/**
+ * Fingerprints every file under the source root by path, size, and modification time.
+ *
+ * Two equal fingerprints taken `settleInterval` apart mean no writer is mid-flight; a fingerprint
+ * equal to the one already compiled means the burst left the tree byte-identical to what the last
+ * pass read. Deliberately not a content hash: rewriting a file with its previous contents is a
+ * real edit that must recompile, and a fingerprint records that the file was written at all.
+ */
+const sourceFingerprint = Effect.fnUntraced(function* (
+  root: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  const fileSystem = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const entries: Array<string> = []
+  const pending: Array<string> = [root]
+  while (pending.length > 0) {
+    const directory = pending.pop()
+    if (directory === undefined) continue
+    const names = yield* Effect.result(fileSystem.readDirectory(directory))
+    if (Result.isFailure(names)) continue
+    for (const name of names.success) {
+      const candidate = path.resolve(directory, name)
+      const info = yield* Effect.result(fileSystem.stat(candidate))
+      if (Result.isFailure(info)) continue
+      if (info.success.type === 'Directory') {
+        pending.push(candidate)
+        continue
+      }
+      const modified = Option.match(info.success.mtime, {
+        onNone: () => 'unknown',
+        onSome: (at) => `${at.getTime()}`,
+      })
+      entries.push(`${candidate} ${info.success.size} ${modified}`)
+    }
+  }
+  return entries.sort().join('\n')
+})
+
+/** Samples the source tree until two consecutive samples agree, or the settle budget runs out. */
+const settledFingerprint = Effect.fnUntraced(function* (
+  root: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  let previous = yield* sourceFingerprint(root)
+  for (let sample = 0; sample < settleSamples; sample += 1) {
+    yield* Effect.sleep(settleInterval)
+    const current = yield* sourceFingerprint(root)
+    if (current === previous) return current
+    previous = current
+  }
+  return previous
+})
+
+/**
  * Runs one compilation, then repeats it after every change under the project source root. The
  * status of each pass is reported but never returned: only stopping the watch ends the command,
  * so a pass that reports diagnostics leaves the watch running.
+ *
+ * A pass reads the source tree only once the tree has settled, so an ordinary non-atomic save is
+ * compiled whole rather than at the zero length the truncate left behind, and one edit produces
+ * one pass rather than one per raw event.
  */
 export const watch = Effect.fn('Workflow.watch')(function* (
   run: (
@@ -303,14 +386,21 @@ export const watch = Effect.fn('Workflow.watch')(function* (
   yield* run(options)
   // ponytail: directories are enumerated once; a directory created later needs a restart.
   const directories = yield* sourceDirectories(sourceRoot)
+  const compiled = yield* Ref.make(yield* sourceFingerprint(sourceRoot))
   yield* Console.log(`Watching ${sourceRoot} for changes.`)
   yield* Stream.mergeAll(
     directories.map((directory) => fileSystem.watch(directory)),
     { concurrency: 'unbounded' },
   ).pipe(
-    // ponytail: every event recompiles the whole graph; debounce if editors emit noisy bursts.
+    Stream.debounce(quietWindow),
     Stream.runForEach(
       Effect.fnUntraced(function* () {
+        const fingerprint = yield* settledFingerprint(sourceRoot)
+        // The burst carried no edit the last pass did not already read: the events were the
+        // truncate and the write of one save, or a file was rewritten with the same bytes at the
+        // same time. Recompiling would only repeat the result already on screen.
+        if (fingerprint === (yield* Ref.get(compiled))) return
+        yield* Ref.set(compiled, fingerprint)
         yield* run(options)
         yield* Console.log(`Watching ${sourceRoot} for changes.`)
       }),

--- a/packages/compiler-cli/test/Workflow.test.ts
+++ b/packages/compiler-cli/test/Workflow.test.ts
@@ -6,6 +6,7 @@ import * as Target from '@silk-effect/compiler/Target'
 import * as Effect from 'effect/Effect'
 import * as Fiber from 'effect/Fiber'
 import * as FileSystem from 'effect/FileSystem'
+import * as Result from 'effect/Result'
 import * as Project from '../src/Project.js'
 import * as Workflow from '../src/Workflow.js'
 import * as Timeouts from './timeouts.js'
@@ -66,6 +67,62 @@ const editUntilRecompiled = Effect.fnUntraced(function* (
     }
   }
   throw new Error('Timed out waiting for the watch mode to compile again')
+})
+
+/**
+ * Waits until the watch mode stops producing passes and returns the count it stopped at, so a
+ * test can count the passes one edit produced rather than only the first of them.
+ */
+const passesSettled = Effect.fnUntraced(function* (passes: ReadonlyArray<unknown>) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const before = passes.length
+    yield* Effect.sleep('400 millis')
+    if (passes.length === before) return before
+  }
+  throw new Error('The watch mode never stopped compiling')
+})
+
+/**
+ * One watch-mode compilation: its reported status, and the entry source the pass read. The status
+ * alone cannot see a torn read — `check` of an empty entry finds no declaration to reject and
+ * reports success — so a test that asks whether a pass compiled a finished file has to look at
+ * the bytes the pass loaded.
+ */
+interface Pass {
+  readonly status: Workflow.ExitStatus
+  readonly source: string
+}
+
+const unreadable = '<unreadable>'
+
+/**
+ * Starts a watch whose passes are recorded, and returns once the watcher is demonstrably
+ * subscribed: the first compilation has run, an edit has been seen, and the passes it caused have
+ * finished. A test that counts passes needs that, because `Workflow.watch` registers the watcher
+ * only after its first compilation, so an early edit can land before anything is listening.
+ */
+const watchRecording = Effect.fnUntraced(function* (root: string) {
+  const passes: Array<Pass> = []
+  const record = (selection: Workflow.ProjectSelection) =>
+    Effect.gen(function* () {
+      // The same read `check` is about to perform, taken at the moment the pass begins.
+      const loaded = yield* Effect.result(Project.load({ workingDirectory: root }))
+      const status = yield* Workflow.check(selection)
+      const source = Result.isSuccess(loaded)
+        ? new TextDecoder().decode(loaded.success.entry.bytes)
+        : unreadable
+      passes.push({ status, source })
+      return status
+    })
+  const watching = yield* Effect.forkChild(Workflow.watch(record, options(root)))
+  yield* waitUntil(() => passes.length >= 1)
+  yield* editUntilRecompiled(
+    `${root}/src/Main.silk`,
+    'pub fn main() -> i32 { return 11 }',
+    () => passes.length >= 2,
+  )
+  yield* passesSettled(passes)
+  return { passes, watching } as const
 })
 
 it.effect('checks a whole project without creating build artifacts', () =>
@@ -358,6 +415,135 @@ it.live(
       yield* Fiber.interrupt(watching)
 
       assert.deepStrictEqual(passes.slice(0, 2), [0, 0])
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  Timeouts.nativeBuild,
+)
+
+/**
+ * `fileSystem.writeFileString` is `open(O_TRUNC)`, `write`, `close`, exactly what shell
+ * redirection, `sed -i`, and an editor without atomic save do. The watch fires on the truncate, so
+ * a watcher that reads on the raw event reads the file at zero length: issue #158 measured 71% of
+ * watch-woken reads observing no bytes at all. Every pass here must have read one of the whole
+ * programs this test wrote, never a truncated or half-written prefix of one.
+ */
+it.live(
+  'compiles the finished file when a burst of saves writes non-atomically',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      const { passes, watching } = yield* watchRecording(root)
+      const before = passes.length
+      const written = new Set(['pub fn main() -> i32 { return 11 }'])
+
+      for (let write = 0; write < 200; write += 1) {
+        const program = `pub fn main() -> i32 { return ${'4'.repeat((write % 8) + 1)} }`
+        written.add(program)
+        yield* fileSystem.writeFileString(`${root}/src/Main.silk`, program)
+      }
+      yield* waitUntil(() => passes.length > before)
+      yield* passesSettled(passes)
+      yield* Fiber.interrupt(watching)
+
+      const observed = passes.slice(before)
+      const torn = observed.filter((pass) => !written.has(pass.source))
+      assert.deepStrictEqual(
+        torn.map((pass) => pass.source.length),
+        [],
+        `${torn.length} of ${observed.length} passes read a file that was still being written`,
+      )
+      assert.deepStrictEqual(
+        observed.filter((pass) => pass.status !== 0),
+        [],
+      )
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  Timeouts.nativeBuild,
+)
+
+it.live(
+  'compiles once for one logical edit',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      const { passes, watching } = yield* watchRecording(root)
+      const before = passes.length
+
+      yield* fileSystem.writeFileString(
+        `${root}/src/Main.silk`,
+        'pub fn main() -> i32 { return 7 }',
+      )
+      yield* waitUntil(() => passes.length > before)
+      const settled = yield* passesSettled(passes)
+      yield* Fiber.interrupt(watching)
+
+      assert.strictEqual(settled - before, 1)
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  Timeouts.nativeBuild,
+)
+
+/**
+ * The settle must coalesce one edit's events without swallowing a second edit: distinct saves are
+ * distinct work no matter how quickly they follow one another.
+ */
+it.live(
+  'compiles once per edit for a rapid sequence of distinct edits',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      const { passes, watching } = yield* watchRecording(root)
+      const before = passes.length
+      const edits = [
+        'pub fn main() -> i32 { return 1 }',
+        'pub fn main() -> i32 { return 22 }',
+        'pub fn main() -> i32 { return 333 }',
+        'pub fn main() -> i32 { return 4444 }',
+      ]
+
+      for (const [index, edit] of edits.entries()) {
+        yield* fileSystem.writeFileString(`${root}/src/Main.silk`, edit)
+        yield* waitUntil(() => passes.length >= before + index + 1)
+      }
+      const settled = yield* passesSettled(passes)
+      yield* Fiber.interrupt(watching)
+
+      assert.strictEqual(settled - before, edits.length)
+      assert.deepStrictEqual(
+        passes.slice(before).map((pass) => pass.source),
+        edits,
+      )
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  Timeouts.nativeBuild,
+)
+
+/**
+ * The settle decides that a file stopped changing, never that its contents are plausible. A user
+ * who empties a source file has made an edit like any other: it recompiles, and whatever the
+ * emptied graph deserves is what gets reported.
+ */
+it.live(
+  'compiles a source file the user emptied on purpose',
+  () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const root = yield* fileSystem.makeTempDirectoryScoped()
+      yield* makeProject(root)
+      const { passes, watching } = yield* watchRecording(root)
+      const before = passes.length
+
+      yield* fileSystem.writeFileString(`${root}/src/Main.silk`, '')
+      yield* waitUntil(() => passes.length > before)
+      yield* passesSettled(passes)
+      yield* Fiber.interrupt(watching)
+
+      assert.deepStrictEqual(
+        passes.slice(before).map((pass) => pass.source),
+        [''],
+      )
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   Timeouts.nativeBuild,
 )


### PR DESCRIPTION
Closes #158

## The defect

`Workflow.watch` recompiled on every raw filesystem event. `fs.writeFile` is `open(O_TRUNC)` → `write` → `close` and the watch fires on the **truncate**, so a pass woken by that event reads the file at zero length. Anything that writes non-atomically into a watched tree — shell `>`, `sed -i`, an editor without atomic save — hits this on an ordinary save.

Fixed in the product, not in the test. The test helper still writes non-atomically on purpose.

## The fix

`packages/compiler-cli/src/Workflow.ts`, at the watch seam:

1. **`Stream.debounce(50 ms)`** on the merged watch streams — one save is a sub-millisecond burst of events, and the burst becomes one element.
2. **Settle before reading.** After the burst, fingerprint every file under the source root by path, size, and mtime, sleep 25 ms, fingerprint again, and only compile when two consecutive samples agree (capped at 1 s so a continuously rewritten tree still compiles). Debouncing alone is not enough: one large `write` is a *single* event that arrives when the write finishes, so a slow writer leaves the event stream quiet while the file on disk is still truncated. Quiet is not the same as finished, and only the tree can answer that.
3. **Skip a burst that changed nothing.** If the settled fingerprint equals the one already compiled, the pass is skipped. The fingerprint is recorded *before* the pass it describes, so an edit landing while a compilation runs looks like a change that pass did not read, and recompiles rather than being swallowed.

Deliberately a fingerprint, not a content hash: rewriting a file with its previous bytes is a real edit and must recompile.

### Latency, and why these numbers

Added latency on a save is the 50 ms quiet window plus one 25 ms settle sample — **~75 ms**, below the ~100 ms threshold where a feedback loop starts to feel delayed, and small next to the compilation it precedes. 50 ms is far more than the sub-millisecond gap between a truncate and its write; the headroom is there to absorb an editor that drops a backup or swap file beside the source.

### Property 1 vs property 4 — one compile per edit, but never a swallowed edit

These pull against each other, and the debounce alone resolves them badly: raise the window until every duplicate is coalesced and you eventually merge two real edits; lower it and duplicates return.

The resolution is that the two properties are answered by different mechanisms rather than by one tuned number. The debounce only groups events that are *close in time*. Whether a group is worth compiling is decided by the tree itself: a group whose settled fingerprint matches the last compiled one carried no edit and is skipped, and a group whose fingerprint differs carries one and compiles. So the truncate and the write of a single save collapse to one compilation even when they straddle the window, and a second edit is never dropped no matter how fast it follows the first, because it changes the fingerprint. The window sets how long an edit waits, never whether it is seen.

## Empty-read rate, before and after

**The issue's harness** (bare `readFile` on each raw event, 3000 non-atomic writes), reproduced on this machine — the ~71% baseline holds:

| run | events | empty reads | rate |
| --- | --- | --- | --- |
| 1 | 5204 | 3440 | 66.1% |
| 2 | 5067 | 3504 | 69.2% |
| 3 | 5121 | 3530 | 68.9% |

**Through the real watch path**, measured by the new test — 200 non-atomic writes, recording the entry source each pass actually loaded:

| | passes | passes reading an empty entry | rate |
| --- | --- | --- | --- |
| before | 370 / 370 / 362 | 20 / 16 / 21 | **5.4% / 4.3% / 5.8%** |
| after | 1 / 1 / 1 | 0 / 0 / 0 | **0% / 0% / 0%** |

Two things worth naming. The through-the-workflow rate is lower than the bare-read rate because each pass spends ~10 ms compiling, which lets most queued events fall outside the truncate window — the bare read is the honest measure of the window itself, and ~5% is what survives the compile latency to reach a user as a wrong result. And 200 writes produced **370 passes** before this change: 1.85 compilations per write, the two-recompiles-per-save the issue reported.

## One correction to the issue's causal story

The issue says an empty `Main.silk` makes `check` return 1, so a torn read surfaces as exit 1. `check` on an empty entry actually returns **0** — `Analysis` finds no declaration to reject, so it reports success. Verified directly. `check` only reports 1 on a *partial* read, where a truncated prefix fails to parse; the `NoEntry` → exit 1 path belongs to `Driver.compile`, so it is `build --watch` that reports "no main entry".

That makes the defect slightly worse than reported rather than better: on `check --watch` a torn read is a **false green** — `check ok` for a file whose real contents may not compile at all — and only sometimes a spurious diagnostic. It also means exit status cannot be the instrument, so the tests assert on the bytes each pass loaded.

## Tests

`packages/compiler-cli/test/Workflow.test.ts` — four new `it.live` tests over the real watcher:

- **non-atomic burst**: 200 plain `writeFileString` saves; every pass must have read one of the whole programs written, never a truncated prefix, and every pass reports 0.
- **one edit, one compile**: exactly one pass, verified after the passes stop arriving.
- **N distinct edits, N compiles**: four rapid sequential edits produce four passes whose sources are exactly the four programs, in order.
- **an intentionally emptied file still compiles**: settle decides that a file stopped changing, never that its contents are plausible — the emptied entry is read and reported (per the triage note on #158).

The three pre-existing watch tests keep their assertions verbatim.

## Verification

- `Workflow.test.ts`: **25/25 consecutive runs green** under 2× CPU oversubscription (8 spinners on 4 cores, alongside Vitest's own workers). 17–19 s per run against ~9 s idle; 449 s total.
- `pnpm typecheck`: 18/18 green.
- `turbo run test --continue` (so no task is cancelled by a sibling's failure): every package green except the two known pre-existing failures, both being fixed on `agent/159-baseline-health` —
  - `@silk-effect/wasm` `Extended.test.ts > threads address types through memory instructions` (#161);
  - three `compiler-cli` tests that `chmod 0o000` / `0o555` a path and expect the failure — `FormatWorkflow` (2) and `FormatCommand` (1) — which root ignores (#159).
  - `compiler-cli` otherwise: 93 passed, including all 19 of `Workflow.test.ts`.