### PR TITLE
docs: document and characterize the ordinary-recursion stack boundary

### DIFF
--- a/packages/compiler/test/RecursionStackBoundary.test.ts
+++ b/packages/compiler/test/RecursionStackBoundary.test.ts
@@ -1,0 +1,387 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as NativeToolchain from '../src/NativeToolchain.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+/**
+ * Ordinary recursion is bounded by the machine stack, deliberately: the compiler adds no shadow
+ * stack and no per-call allocation, so a call costs a call. These tests pin the *shape* of that
+ * boundary rather than the depth at which it arrives — the depth belongs to the host's stack size,
+ * the optimizer's frame layout, and the engine, and asserting one would only manufacture flakes.
+ *
+ * What is pinned:
+ *
+ * - a shallow chain traverses on all three engines and releases every link exactly once,
+ * - a deep chain fails on every engine, each in that engine's own way, and
+ * - the escape hatch — an explicit iterative teardown — carries a chain far beyond the depth at
+ *   which the recursive form dies.
+ *
+ * Recorded on this branch, x86_64 Linux, Node 22.22, clang 18, release profile: the recursive walk
+ * survives 500 links in the evaluator, 950 in Wasm, and 100,000 natively, and fails by 510, 1,000,
+ * and 128,000 respectively. Those numbers are evidence, not contract; nothing below asserts them.
+ */
+
+const clang =
+  process.env.SILK_TEST_CLANG ??
+  (existsSync('/opt/homebrew/opt/llvm/bin/clang')
+    ? '/opt/homebrew/opt/llvm/bin/clang'
+    : existsSync('/usr/local/opt/llvm/bin/clang')
+      ? '/usr/local/opt/llvm/bin/clang'
+      : 'clang')
+const toolchain: NativeToolchain.Toolchain = Object.freeze({
+  _tag: 'Toolchain',
+  clang,
+  shimCache: NativeToolchain.makeShimCache(),
+})
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-recursion-stack-boundary-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+/**
+ * A singly linked chain of boxed nodes, with three phases that can be measured apart:
+ *
+ * - `build` is iterative, so construction never contributes call depth and a failure is always
+ *   attributable to the phase under test,
+ * - `stepDepth`/`viewDepth` is the ordinary recursive walk, borrowing one level at a time, and
+ * - `drain` is the explicit iterative teardown: it unlinks one level per loop turn, so the chain
+ *   is already flat by the time automatic cleanup sees it.
+ *
+ * `Intrinsic.replace` is what makes both loops expressible. A local cannot be partially moved out
+ * of and a `match` arm is an expression rather than a statement, so a loop that walks ownership
+ * down a chain has to swap a sentinel into the place it takes from.
+ */
+const prelude = `import silk.box { Box, make as boxMake, get as boxGet, into as boxInto }
+
+pub struct End {}
+
+pub struct Link {
+  next: Box<Chain>
+}
+
+pub struct Step {
+  kind: End | Link
+}
+
+pub struct Chain {
+  step: Step
+}
+
+pub struct Drained {
+  chain: Chain
+  more: bool
+}
+
+fn stepDepth(step: &Step) -> i32 {
+  return match &step.kind {
+    End nothing => 0
+    Link { next } => viewDepth(boxGet<Chain>(&next))
+  }
+}
+
+fn viewDepth(view: &[Chain]) -> i32 {
+  return match &view[usize.ZERO] {
+    Chain { step } => 1 + stepDepth(&step)
+  }
+}
+
+fn unlink(chain: Chain) -> Drained {
+  return match move chain {
+    Chain { step } => unlinkStep(move step)
+  }
+}
+
+fn unlinkStep(step: Step) -> Drained {
+  return match move step {
+    Step { kind } => unlinkKind(move kind)
+  }
+}
+
+fn unlinkKind(kind: End | Link) -> Drained {
+  return match move kind {
+    End nothing => Drained { chain: Chain { step: Step { kind: End {} } }, more: false }
+    Link { next } => Drained { chain: boxInto<Chain>(move next), more: true }
+  }
+}
+
+fn drain(chain: Chain) -> i32 {
+  let mut current = move chain
+  let mut released = 0
+  let mut going = true
+  while going {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let mut stepped = unlink(move taken)
+    current = Intrinsic.replace(stepped.chain, Chain { step: Step { kind: End {} } })
+    going = stepped.more
+    if stepped.more { released = released + 1 }
+  }
+  return released
+}
+
+effect fn build(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  let mut current = Chain { step: Step { kind: End {} } }
+  let mut remaining = depth
+  while remaining > 0 {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let boxed = run boxMake<Chain>(move taken)
+    current = Chain { step: Step { kind: Link { next: move boxed } } }
+    remaining = remaining - 1
+  }
+  return move current
+}
+`
+
+const program = (body: string, depth: number): string => `${prelude}
+${body}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(measure(${depth}), recover) }`
+
+/** Recursive traversal, then an iterative teardown so only the walk can exhaust the stack. */
+const walk = (depth: number): string =>
+  program(
+    `effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  let counted = stepDepth(&built.step)
+  let released = drain(move built)
+  if counted == released { return 0 }
+  return 2
+}`,
+    depth,
+  )
+
+/** Iterative throughout: build, unlink, release. Nothing here recurses. */
+const drain = (depth: number): string =>
+  program(
+    `effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  let released = drain(move built)
+  if released == depth { return 0 }
+  return 2
+}`,
+    depth,
+  )
+
+const realize = (id: string, source: string) =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      [],
+      id,
+    )
+    return snapshot
+  })
+
+interface Outcome {
+  readonly _tag: 'Returned' | 'Failed'
+  readonly detail: string
+}
+
+const returned = (value: number): Outcome =>
+  Object.freeze({ _tag: 'Returned' as const, detail: String(value) })
+
+/**
+ * Runs the module under Wasm and reports whether the host survived it.
+ *
+ * A host out of stack is a `RangeError` from V8. A Wasm `RuntimeError` is accepted as the same
+ * observation because the trap the engine reaches first is platform-sensitive — on this machine a
+ * band of depths just under the host limit traps `unreachable` instead, which is the separate
+ * defect tracked in #134. Both mean "this engine could not carry the chain"; neither means the
+ * traversal produced a wrong answer, which is what a returned non-zero value would mean.
+ */
+const runWasm = (bytes: Uint8Array): Outcome => {
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
+  try {
+    return returned((instance.exports.silk_main as () => number)())
+  } catch (error) {
+    const failure = error as Error
+    assert.isTrue(
+      failure instanceof RangeError || failure instanceof WebAssembly.RuntimeError,
+      `unexpected Wasm failure: ${failure.constructor.name}: ${failure.message}`,
+    )
+    return Object.freeze({
+      _tag: 'Failed' as const,
+      detail: `${failure.constructor.name}: ${failure.message}`,
+    })
+  }
+}
+
+/**
+ * Compiles and runs the module natively. A machine stack overrun arrives as a signal rather than an
+ * exit status, and which signal is the platform's business: Linux and macOS both raise `SIGSEGV`
+ * for the guard page, and `SIGBUS` is accepted for the platforms that map it differently.
+ */
+const runNative = (id: string, source: string, destination: string) =>
+  Effect.gen(function* () {
+    const compiled = yield* Driver.compile({
+      compilation: { root: SourceFile.make(id, ascii(source)) },
+      toolchain,
+      profile: 'release',
+      destination,
+    })
+    assert.strictEqual(compiled._tag, 'Compiled', id)
+    if (compiled._tag !== 'Compiled') return Object.freeze({ _tag: 'Failed' as const, detail: id })
+    const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+    if (run.signal === null) {
+      assert.strictEqual(run.stderr, '', id)
+      return returned(run.status ?? -1)
+    }
+    assert.oneOf(run.signal, ['SIGSEGV', 'SIGBUS'], `${id}: ${run.stderr}`)
+    return Object.freeze({ _tag: 'Failed' as const, detail: run.signal })
+  }).pipe(Effect.provide(SourceResolver.empty))
+
+/**
+ * Doubles the depth until the engine gives out, and reports the first depth that failed.
+ *
+ * This is what keeps the test honest on a machine whose stack is larger than the one the numbers
+ * above were measured on: the assertion is that some depth within reach fails, and that the failure
+ * looks the way this engine's stack exhaustion looks. A machine that carries the cap without
+ * failing is a machine on which the documented boundary did not hold, and the test should say so
+ * rather than pass quietly.
+ */
+const escalate = <E>(
+  from: number,
+  cap: number,
+  attempt: (depth: number) => Effect.Effect<Outcome, E, never>,
+): Effect.Effect<{ readonly depth: number; readonly outcome: Outcome }, E, never> =>
+  Effect.gen(function* () {
+    let depth = from
+    while (depth <= cap) {
+      const outcome = yield* attempt(depth)
+      if (outcome._tag === 'Failed') return Object.freeze({ depth, outcome })
+      assert.strictEqual(outcome.detail, '0', `depth ${depth} must still compute the right answer`)
+      depth = depth * 2
+    }
+    assert.fail(`no depth up to ${cap} exhausted the stack`)
+  })
+
+it.effect(
+  'traverses, drains, and releases a shallow chain identically on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const depth = 64
+      const source = walk(depth)
+      const snapshot = yield* realize('recursion-stack-boundary/shallow', source)
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(evaluated._tag, 'Completed')
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 0)
+
+      // The walk counted every link and the teardown released every one of them: 64 boxes, 64
+      // acquires, 64 releases. Borrowing and ownership are unchanged by the depth question.
+      const events = Analysis.allocationTraceEventsOf(evaluated)
+      const acquires = events.filter((event) => event._tag === 'AllocationAcquire').length
+      const releases = events.filter((event) => event._tag === 'AllocationRelease').length
+      assert.strictEqual(acquires, depth)
+      assert.strictEqual(releases, acquires)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      assert.deepEqual(runWasm(wasm.bytes), returned(0))
+
+      assert.deepEqual(
+        yield* runNative(
+          'recursion-stack-boundary/shallow',
+          source,
+          join(destinationRoot, 'shallow'),
+        ),
+        returned(0),
+      )
+    }),
+  180_000,
+)
+
+/**
+ * The evaluator is the one engine that does not fail by exhausting a real stack: the accepted
+ * contract makes depth a deterministic budget, so the same program blocks identically on every
+ * host instead of crashing on some of them. That is why the failure mode has to be documented per
+ * engine — the same source is a `Blocked` value here and a signal on the target.
+ */
+it.effect('blocks a deep recursive traversal on the evaluator call-depth limit', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realize('recursion-stack-boundary/evaluator', walk(4_000))
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Blocked')
+    if (evaluated._tag !== 'Blocked') return
+    assert.strictEqual(evaluated.reason._tag, 'EvaluationLimit')
+    if (evaluated.reason._tag !== 'EvaluationLimit') return
+    assert.strictEqual(evaluated.reason.kind, 'CallDepth')
+    // The blocked frame names the recursive walk itself, which is the provenance a reader needs to
+    // recognise the shape rather than guess at an unrelated limit.
+    assert.strictEqual(evaluated.reason.function.name, 'stepDepth')
+  }),
+)
+
+it.effect(
+  'exhausts the Wasm host stack on a deep recursive traversal',
+  () =>
+    Effect.gen(function* () {
+      const found = yield* escalate(8_000, 512_000, (depth) =>
+        Effect.gen(function* () {
+          const snapshot = yield* realize(`recursion-stack-boundary/wasm/${depth}`, walk(depth))
+          const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+          return runWasm(wasm.bytes)
+        }),
+      )
+      assert.strictEqual(found.outcome._tag, 'Failed')
+    }),
+  300_000,
+)
+
+it.effect(
+  'exhausts the native machine stack on a deep recursive traversal',
+  () =>
+    Effect.gen(function* () {
+      const found = yield* escalate(200_000, 6_400_000, (depth) =>
+        runNative(
+          `recursion-stack-boundary/native/${depth}`,
+          walk(depth),
+          join(destinationRoot, `native-walk-${depth}`),
+        ),
+      )
+      assert.strictEqual(found.outcome._tag, 'Failed')
+    }),
+  600_000,
+)
+
+/**
+ * The sanctioned way out, pinned against the depth that kills the recursive form. One million
+ * links is an order of magnitude past the native limit measured above and three past the Wasm one,
+ * and the iterative teardown carries it on both, because its stack is one frame deep whatever the
+ * chain length is.
+ */
+it.effect(
+  'carries a chain past every recursive limit when the traversal is written iteratively',
+  () =>
+    Effect.gen(function* () {
+      const depth = 1_000_000
+      const source = drain(depth)
+      const snapshot = yield* realize('recursion-stack-boundary/iterative', source)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      assert.deepEqual(runWasm(wasm.bytes), returned(0))
+
+      assert.deepEqual(
+        yield* runNative(
+          'recursion-stack-boundary/iterative',
+          source,
+          join(destinationRoot, 'iterative'),
+        ),
+        returned(0),
+      )
+    }),
+  600_000,
+)

--- a/packages/compiler/test/RecursionStackBoundary.test.ts
+++ b/packages/compiler/test/RecursionStackBoundary.test.ts
@@ -174,6 +174,54 @@ const drain = (depth: number): string =>
     depth,
   )
 
+/**
+ * Iterative construction, then ordinary automatic cleanup. `Box.drop` drops the element it holds,
+ * so releasing the outermost link calls the hook of the one below it: the chain is destroyed by
+ * recursion nobody wrote, and there is no call site at which to write it differently.
+ */
+const dropped = (depth: number): string =>
+  program(
+    `effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  drop built
+  return 0
+}`,
+    depth,
+  )
+
+/**
+ * The case with no escape hatch at all: construction runs out of allocations partway, and the
+ * half-built chain is released by the failure path. `drain` cannot be called on it — the value is
+ * never named by user code, it exists only inside the cleanup the compiler runs on the way out.
+ *
+ * Recovering the `OutOfMemory` is the point: at a shallow depth this returns 1, having unwound
+ * cleanly. Deep, the unwinding is what dies.
+ */
+const failedBuild = (depth: number): string => `${prelude}
+struct QuotaAllocator { remaining: i32 }
+
+effect fn allocate(self: &mut QuotaAllocator, layout: Layout) -> Allocation ! OutOfMemory {
+  if self.remaining == 0 { fail OutOfMemory {} }
+  self.remaining = self.remaining - 1
+  let mut inner = SystemAllocator.make()
+  let pending = Allocator.allocate(move layout) |> Effect.provideMut(&mut inner)
+  return run pending
+}
+
+impl Allocator for QuotaAllocator { allocate: QuotaAllocator.allocate }
+
+effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = QuotaAllocator { remaining: ${Math.floor(depth / 2)} }
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  drop built
+  return 0
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(measure(${depth}), recover) }`
+
 const realize = (id: string, source: string) =>
   Effect.gen(function* () {
     const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
@@ -384,4 +432,143 @@ it.effect(
       )
     }),
   600_000,
+)
+
+/**
+ * Automatic cleanup is the same boundary reached from the other side, and it is the harder half.
+ *
+ * A traversal can be rewritten as a loop because the call site owns the shape of the traversal. A
+ * `Drop` chain cannot: the recursion is `Box`'s hook dropping the element that is itself a `Box`,
+ * and it runs wherever the value happens to go out of scope. A `Drop` hook may declare no failure
+ * row and no capability requirement, so the escape offered for a traversal — express it as an
+ * Effect that crosses a suspension boundary — is not open to it either. Cleanup cannot allocate,
+ * cannot fail, and cannot suspend.
+ *
+ * What is left is an explicit iterative teardown, called before the value goes out of scope, and
+ * the case below pins that it works. What it cannot cover is pinned after it.
+ */
+it.effect(
+  'releases a shallow chain through recursive cleanup on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const depth = 64
+      const source = dropped(depth)
+      const snapshot = yield* realize('recursion-stack-boundary/drop-shallow', source)
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(evaluated._tag, 'Completed')
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 0)
+
+      const events = Analysis.allocationTraceEventsOf(evaluated)
+      const acquires = events.filter((event) => event._tag === 'AllocationAcquire').length
+      const releases = events.filter((event) => event._tag === 'AllocationRelease').length
+      assert.strictEqual(acquires, depth)
+      assert.strictEqual(releases, acquires)
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      assert.deepEqual(runWasm(wasm.bytes), returned(0))
+
+      assert.deepEqual(
+        yield* runNative(
+          'recursion-stack-boundary/drop-shallow',
+          source,
+          join(destinationRoot, 'drop-shallow'),
+        ),
+        returned(0),
+      )
+    }),
+  180_000,
+)
+
+it.effect('blocks a deep recursive Drop on the evaluator call-depth limit', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realize('recursion-stack-boundary/drop-evaluator', dropped(4_000))
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Blocked')
+    if (evaluated._tag !== 'Blocked') return
+    assert.strictEqual(evaluated.reason._tag, 'EvaluationLimit')
+    if (evaluated.reason._tag !== 'EvaluationLimit') return
+    assert.strictEqual(evaluated.reason.kind, 'CallDepth')
+    // The frame that ran out belongs to the standard library, not to the program: the recursion
+    // here is `Box`'s hook descending into the box it holds, which no call site wrote.
+    assert.strictEqual(evaluated.reason.function.module, 'silk/box')
+    assert.strictEqual(evaluated.reason.function.name, 'dropElement')
+  }),
+)
+
+it.effect(
+  'exhausts the Wasm host stack when a deep chain is dropped',
+  () =>
+    Effect.gen(function* () {
+      const found = yield* escalate(8_000, 512_000, (depth) =>
+        Effect.gen(function* () {
+          const snapshot = yield* realize(
+            `recursion-stack-boundary/drop-wasm/${depth}`,
+            dropped(depth),
+          )
+          const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+          return runWasm(wasm.bytes)
+        }),
+      )
+      assert.strictEqual(found.outcome._tag, 'Failed')
+    }),
+  300_000,
+)
+
+/**
+ * Cleanup frames are narrower than the walk's, so this needs an order of magnitude more depth than
+ * the traversal did before the guard page arrives — which is precisely why it is worth pinning
+ * separately. "Deep enough to be safe for a walk" is not deep enough to be safe for a teardown.
+ */
+it.effect(
+  'exhausts the native machine stack when a deep chain is dropped',
+  () =>
+    Effect.gen(function* () {
+      const found = yield* escalate(1_000_000, 8_000_000, (depth) =>
+        runNative(
+          `recursion-stack-boundary/drop-native/${depth}`,
+          dropped(depth),
+          join(destinationRoot, `native-drop-${depth}`),
+        ),
+      )
+      assert.strictEqual(found.outcome._tag, 'Failed')
+    }),
+  900_000,
+)
+
+/**
+ * The gap the guidance cannot close, pinned so it is a known shape rather than a surprise.
+ *
+ * A value you hold can be drained before it goes out of scope. A value that never becomes yours
+ * cannot: when construction fails partway, the half-built chain is released by the failure path,
+ * and there is no point in the source at which an iterative teardown could be called on it. So a
+ * program that always drains explicitly still meets recursive `Drop` on its allocation-failure
+ * path, at whatever depth construction had reached.
+ *
+ * Shallow, this recovers the `OutOfMemory` and returns 1. Deep, the recovery never happens.
+ */
+it.effect(
+  'has no teardown to offer when construction fails partway down a deep chain',
+  () =>
+    Effect.gen(function* () {
+      const shallow = yield* realize('recursion-stack-boundary/failure-shallow', failedBuild(64))
+      const shallowWasm = yield* Analysis.codegenWasm(shallow, { mode: 'release' })
+      assert.deepEqual(runWasm(shallowWasm.bytes), returned(1))
+
+      const found = yield* escalate(8_000, 512_000, (depth) =>
+        Effect.gen(function* () {
+          const snapshot = yield* realize(
+            `recursion-stack-boundary/failure-wasm/${depth}`,
+            failedBuild(depth),
+          )
+          const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+          const outcome = runWasm(wasm.bytes)
+          // A recovered failure is a survived depth here, not a wrong answer.
+          return outcome._tag === 'Returned' && outcome.detail === '1' ? returned(0) : outcome
+        }),
+      )
+      assert.strictEqual(found.outcome._tag, 'Failed')
+    }),
+  300_000,
 )

--- a/packages/language/docs/README.md
+++ b/packages/language/docs/README.md
@@ -5,6 +5,9 @@
 - **[Tutorial](./tutorial.md)** — start here: from `silk init` to a program that runs.
 - **[Language reference](./reference.md)** — the lexical form, the types, the memory and ownership
   rules, and the effect system.
+- **[Recursion and the machine stack](./recursion.md)** — what ordinary recursion does and does not
+  guarantee, how running out of stack looks on each engine, and the iterative pattern to use
+  instead.
 - **[Standard library](./stdlib.md)** — every module and public declaration, generated from the
   source doc comments.
 - **[Diagnostic index](./diagnostics.md)** — every compiler error code and what it means.

--- a/packages/language/docs/recursion.md
+++ b/packages/language/docs/recursion.md
@@ -1,0 +1,251 @@
+# Recursion and the machine stack
+
+Silk gives ordinary recursion **no bounded-stack guarantee**. A call costs a machine call frame, so
+a recursive function is limited by the stack of whatever is running it, and a recursion deep enough
+to run out of stack fails the way that engine fails — abruptly, and differently on each one.
+
+This page states that boundary, shows what hitting it looks like on each engine, and gives the
+pattern to use instead when a structure can be arbitrarily deep.
+
+## 1. The guarantee, stated plainly
+
+- An ordinary call is an ordinary call. It consumes a frame on the machine or host stack and
+  releases it on return.
+- **Recursion depth is bounded by the target's stack**, which is a property of the host, the profile,
+  and the frame the optimizer chose — not of Silk. The bound is not a number the language promises.
+- The compiler **does not** add a shadow stack, a per-call heap allocation, or a trampoline to make
+  deep recursion survivable.
+- A traversal that must handle unbounded depth is **written iteratively**. That is the supported
+  answer, and it is a source-level answer, not a compiler feature.
+
+### Why the compiler stays out of it
+
+The rule is pay-for-use. Making arbitrary recursion stack-safe means spilling frames somewhere other
+than the stack, and there is no version of that which only the deep call sites pay for:
+
+- **Every call would pay.** The overwhelming majority of calls in a program are shallow. A shadow
+  stack taxes all of them to protect the few that are not, and it does so in the hottest thing a
+  compiler emits.
+- **Every call would need an allocator.** Spilled frames live somewhere, and in Silk there is no
+  ambient heap — allocation is an `Allocator` capability that a function has to require, and it can
+  fail with `OutOfMemory`. Hidden per-call spilling would give an allocator requirement and a
+  failure row to functions that declare neither.
+- **Some calls cannot have one.** A `Drop` hook may declare no failure row and no capability
+  requirement at all, so there is no legal place to put a hidden allocation inside cleanup. A
+  guarantee the language cannot extend to cleanup is not a guarantee the language can state.
+
+So the machine stack stays the machine stack, and depth stays the program's problem to structure.
+
+## 2. The same limit has three faces
+
+A deep recursion does not fail the same way twice, and a reader who has only seen one of these will
+not recognise the others. They are one boundary:
+
+| Engine | What you see | Recoverable? |
+| --- | --- | --- |
+| **Bootstrap evaluator** | A `Blocked` outcome whose reason is `EvaluationLimit` with kind `CallDepth`, naming the recursive function, the span, and the whole active call path | Yes — it is a value, not a crash |
+| **Native** | The process dies on a signal: `SIGSEGV` (the stack guard page), no exit status, no diagnostic, no unwinding, no partial output | No |
+| **WebAssembly** | The host throws out of the exported call — under V8, `RangeError: Maximum call stack size exceeded` | No, but the host survives |
+
+The evaluator is deliberately the odd one out. Its depth limit is a deterministic budget rather than
+a real stack, so the same program blocks at the same place on every machine instead of crashing on
+some of them. That is why evaluating a program successfully does not prove the compiled program has
+the stack for it, and why a `CallDepth` block is worth reading as "this recursion is deep", not as
+"the evaluator is small".
+
+On WebAssembly the specific trap is **platform-sensitive**: a band of depths just below the host
+limit may trap `unreachable` (`WebAssembly.RuntimeError`) rather than raise the host's `RangeError`.
+Either way the meaning is the same — the engine could not carry the chain.
+
+## 3. Measured depths, for calibration only
+
+These are observations on one machine, at one moment, at one optimization level. They move with the
+host's stack size, the profile, and the frame layout the optimizer picks, and **nothing in the
+compiler promises them**. They are here so the numbers feel concrete, not so you can rely on one.
+
+Recorded on x86_64 Linux, Node 22.22, clang 18, release profile, walking a chain of boxed nodes one
+level per recursive call:
+
+| Engine | Deepest chain that survived | Shallowest that failed |
+| --- | --- | --- |
+| Bootstrap evaluator | 500 | 510 (the 1,024-frame `CallDepth` budget) |
+| WebAssembly (Node/V8) | 950 | 1,000 |
+| Native (release) | 100,000 | 128,000 |
+
+The three differ by more than two orders of magnitude, which is the practical point: a depth that is
+comfortable natively is fatal in a browser, and a depth the evaluator accepts proves nothing about
+either.
+
+## 4. The iterative pattern
+
+The chain below is built, walked, and destroyed without a single recursive call. Two things carry
+the weight:
+
+- **`while`** is the loop, and
+- **`Intrinsic.replace`** is what lets ownership walk down the chain. A local cannot be partially
+  moved out of, and a `match` arm is an expression rather than a statement, so a loop that takes the
+  next link out of the value it holds has to swap a sentinel into the place it took from.
+
+```silk
+import silk.box { Box, make as boxMake, into as boxInto }
+
+pub struct End {}
+
+pub struct Link {
+  next: Box<Chain>
+}
+
+pub struct Step {
+  kind: End | Link
+}
+
+pub struct Chain {
+  step: Step
+}
+
+// One unlink step, carrying back both the next level and whether there was one. A match arm cannot
+// assign, so the loop below needs the answer as a value rather than as a side effect.
+pub struct Unlinked {
+  chain: Chain
+  more: bool
+}
+
+fn unlink(chain: Chain) -> Unlinked {
+  return match move chain {
+    Chain { step } => unlinkStep(move step)
+  }
+}
+
+fn unlinkStep(step: Step) -> Unlinked {
+  return match move step {
+    Step { kind } => unlinkKind(move kind)
+  }
+}
+
+fn unlinkKind(kind: End | Link) -> Unlinked {
+  return match move kind {
+    End nothing => Unlinked { chain: Chain { step: Step { kind: End {} } }, more: false }
+    Link { next } => Unlinked { chain: boxInto<Chain>(move next), more: true }
+  }
+}
+
+// Builds outward instead of downward: each turn wraps the chain built so far in one more link.
+effect fn build(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  let mut current = Chain { step: Step { kind: End {} } }
+  let mut remaining = depth
+  while remaining > 0 {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let boxed = run boxMake<Chain>(move taken)
+    current = Chain { step: Step { kind: Link { next: move boxed } } }
+    remaining = remaining - 1
+  }
+  return move current
+}
+
+// Counts the links by walking one level per loop turn. However long the chain is, this function's
+// own stack is one frame deep.
+fn length(chain: Chain) -> i32 {
+  let mut current = move chain
+  let mut counted = 0
+  let mut going = true
+  while going {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let mut stepped = unlink(move taken)
+    current = Intrinsic.replace(stepped.chain, Chain { step: Step { kind: End {} } })
+    going = stepped.more
+    if stepped.more { counted = counted + 1 }
+  }
+  return counted
+}
+
+effect fn measure() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(4096) |> Effect.provideMut(&mut allocator)
+  let counted = length(move built)
+  if counted == 4096 { return 0 }
+  return 2
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(measure(), recover) }
+```
+
+The recursive spelling of `length` is shorter and reads better, and for a chain of known-small depth
+it is the right code. The version above is what you reach for when the depth comes from input.
+
+For comparison, this is the recursive walk that the boundary applies to — correct, idiomatic, and
+bounded by the stack:
+
+```silk
+import silk.box { Box, make as boxMake, get as boxGet }
+
+pub struct End {}
+
+pub struct Link {
+  next: Box<Chain>
+}
+
+pub struct Step {
+  kind: End | Link
+}
+
+pub struct Chain {
+  step: Step
+}
+
+// One frame per level, plus one for the view. Fine at 64 levels; fatal at a million.
+fn stepDepth(step: &Step) -> i32 {
+  return match &step.kind {
+    End nothing => 0
+    Link { next } => viewDepth(boxGet<Chain>(&next))
+  }
+}
+
+fn viewDepth(view: &[Chain]) -> i32 {
+  return match &view[usize.ZERO] {
+    Chain { step } => 1 + stepDepth(&step)
+  }
+}
+
+effect fn build(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  let mut current = Chain { step: Step { kind: End {} } }
+  let mut remaining = depth
+  while remaining > 0 {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let boxed = run boxMake<Chain>(move taken)
+    current = Chain { step: Step { kind: Link { next: move boxed } } }
+    remaining = remaining - 1
+  }
+  return move current
+}
+
+effect fn measure() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(64) |> Effect.provideMut(&mut allocator)
+  let counted = stepDepth(&built.step)
+  drop built
+  if counted == 64 { return 0 }
+  return 2
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(measure(), recover) }
+```
+
+## 5. What about effects?
+
+Wrapping the recursion in `effect fn` does not change any of this. An effect that is `run` at the
+call site is an ordinary call and costs an ordinary frame; the effect system describes what a
+computation may do, not where its frames live.
+
+A recursion that explicitly crosses a suspension boundary — where the continuation is reified rather
+than left on the stack — is the other shape that can be deep by construction. That boundary is being
+designed with the coroutine work and **is not available today**. Until it is, iterate.
+
+## See also
+
+- [Language reference](./reference.md) — `while`, `match`, and the ownership rules the loops above
+  are working within.
+- [Standard library](./stdlib.md) — `silk.box` and the rest of the modules.

--- a/packages/language/docs/recursion.md
+++ b/packages/language/docs/recursion.md
@@ -244,6 +244,60 @@ A recursion that explicitly crosses a suspension boundary — where the continua
 than left on the stack — is the other shape that can be deep by construction. That boundary is being
 designed with the coroutine work and **is not available today**. Until it is, iterate.
 
+## 6. Cleanup has the same limit and fewer ways out
+
+Everything above is about recursion you wrote. Automatic cleanup is the same boundary reached from
+the other side, and it is the harder half.
+
+A `Box` releases the value it holds, so releasing the outermost link of a chain calls the hook of
+the link below it, which calls the hook below that. Destroying a chain of a million boxed nodes is a
+million-deep recursion **that nobody wrote and no call site can see**. It runs wherever the value
+happens to go out of scope, including on paths you did not think about.
+
+The escapes offered above do not carry over:
+
+- **It is not a traversal you control.** There is no call site to rewrite as a loop; the recursion
+  is the cleanup plan descending through hooks.
+- **It cannot cross a suspension boundary.** A `Drop` hook may declare neither a failure row nor a
+  capability requirement. Cleanup cannot allocate, cannot fail, and cannot suspend, so the "express
+  it as an Effect" answer is closed to it — and closed permanently, not just until the coroutine
+  work lands.
+
+### What to do
+
+**Give any type that can form a deep chain an explicit, consuming, iterative teardown, and call it
+before the value goes out of scope.** The `length` loop in §4 is exactly that shape: it consumes the
+chain one link per loop turn, so by the time automatic cleanup runs, the value it sees is one level
+deep. A teardown that returns nothing is the same loop without the counter.
+
+This works today. It is also, honestly, incomplete, and it is worth knowing where it stops:
+
+- **Nothing enforces it.** Forgetting to drain compiles, passes review, and works — until the chain
+  gets deep in production. There is no diagnostic for "this type recurses through cleanup".
+- **It cannot be written once.** Only the holder knows which field is the next link, so every
+  recursive type hand-rolls its own teardown. `silk.box` cannot provide a generic one.
+- **The failure path is not covered at all.** If construction runs out of allocations halfway down,
+  the half-built chain is released by the ordinary failure path, and there is no point in the source
+  at which a teardown could be called on it — the value never becomes yours. A program that drains
+  religiously still meets recursive cleanup on its `OutOfMemory` path, at whatever depth
+  construction had reached. That is a real gap, and today it has no answer beyond bounding the
+  depth you build.
+
+### Measured depths for cleanup
+
+Same machine and profile as §3, dropping a chain built iteratively:
+
+| Engine | Deepest chain released | Shallowest that failed |
+| --- | --- | --- |
+| Bootstrap evaluator | 300 | 340 (the 1,024-frame `CallDepth` budget) |
+| WebAssembly (Node/V8) | 5,000 | 6,000 |
+| Native (release) | 200,000 | 1,000,000 |
+
+Cleanup frames are narrower than the walk's, so the numbers are larger than §3's — and that is the
+trap. The two limits differ by roughly a factor of five, so neither calibrates the other: a chain
+comfortably droppable is not necessarily walkable, and a depth that survived a walk on one engine
+says nothing about a teardown on another. Both are the same rule — a call costs a frame.
+
 ## See also
 
 - [Language reference](./reference.md) — `while`, `match`, and the ownership rules the loops above

--- a/packages/language/docs/reference.md
+++ b/packages/language/docs/reference.md
@@ -595,6 +595,11 @@ arm-local binding is released at its arm boundary. Every `return` is its own exi
 `drop value` consumes a value early. Dropping a borrowed owner is rejected. A `Drop` hook may
 declare neither a failure row nor a capability requirement.
 
+Cleanup descends through hooks by ordinary calls, so releasing a deeply nested owned value is a deep
+recursion and is bounded by the machine stack like any other. A type that can form an unbounded
+chain needs an explicit iterative teardown — see
+[Recursion and the machine stack](./recursion.md#6-cleanup-has-the-same-limit-and-fewer-ways-out).
+
 ### 4.4 Allocation
 
 There is no ambient heap. Allocation is a capability obtained through the `Allocator` service, and

--- a/packages/language/docs/reference.md
+++ b/packages/language/docs/reference.md
@@ -834,6 +834,10 @@ pub fn main() -> i32 {
 }
 ```
 
+`while` is also the answer to depth. An ordinary recursive call costs a machine stack frame and Silk
+promises no bound on how many are available, so a traversal whose depth comes from input is written
+as a loop — see [Recursion and the machine stack](./recursion.md).
+
 ### 6.3 `match`
 
 `match` **is** an expression and is valid anywhere an expression is. Its access mode is part of the
@@ -917,5 +921,7 @@ Concurrency, networking, a package registry, broad FFI, and self-hosting are fut
 ## See also
 
 - [Tutorial](./tutorial.md) — from `silk init` to a running program.
+- [Recursion and the machine stack](./recursion.md) — the bound on ordinary recursion, and how it
+  fails on each engine.
 - [Standard library](./stdlib.md) — every module and public declaration.
 - [Diagnostic index](./diagnostics.md) — every error code, including those cited above.


### PR DESCRIPTION
Follows the definition decisions of 2026-08-13 on #132 and #133: ordinary recursive calls — including recursive `Drop` — do not get a bounded machine-stack guarantee, and the compiler must not add hidden per-call machinery. So this is documentation and characterization work, not a backend fix. Nothing here changes lowering, the evaluator's `CallDepth` cap, or any backend.

## What lands

**#132 — deep recursive traversal** (first commit)

- `packages/compiler/test/RecursionStackBoundary.test.ts` — a three-engine characterization that pins the *shape* of the failure rather than a depth. A shallow chain traverses and releases every link identically on evaluator, Wasm, and native; a deep one blocks the evaluator on `EvaluationLimit`/`CallDepth`, throws out of the Wasm host, and dies on a signal natively. The deep cases escalate the depth until the engine gives out instead of naming one, so a machine with a larger stack still exercises the boundary rather than passing by accident.
- `packages/language/docs/recursion.md` — states the guarantee, says *why* (pay-for-use: every call would pay, every call would need an allocator, and `Drop` cannot have one at all), tabulates the three failure modes so a reader who has met one recognises the others, records the measured depths as calibration rather than contract, and works the iterative pattern through compilable examples.

**#133 — deep recursive `Drop`** (second commit) — see the commit body and the finding posted on the issue.

## Re-measured on this branch

x86_64 Linux, Node 22.22, clang 18, release profile. `main` has moved a great deal since the issues were filed, so the native figure in particular is no longer ~32,000:

| Engine | Recursive walk survives | Fails by |
| --- | --- | --- |
| Bootstrap evaluator | 500 | 510 (the 1,024-frame budget) |
| Wasm (Node/V8) | 950 | 1,000 |
| Native (release) | 100,000 | 128,000 |

The iterative teardown carries 1,000,000 links on both Wasm and native.

## Out of scope

- **#134** — on this machine a band of Wasm depths just under the host limit traps `unreachable` rather than raising `RangeError`. It reproduces here on x86_64 Linux where it did not on arm64 Darwin. Not folded in and not fixed; the test accepts either failure and names #134 in a comment for the reason.
- No change to `Workflow`, the backends, or the evaluator's `CallDepth` cap; no dependency on #24 / PR #135.

## Verification

`pnpm check`, with the two known pre-existing failures (`@silk-effect/wasm` `Extended.test.ts` on Node 22, #161; `compiler-cli` `FormatWorkflow` permission tests, #159) — both being fixed on `agent/159-baseline-health`.

Closes #132
Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VhbDk8rqvmAwziWMsXiEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_019VhbDk8rqvmAwziWMsXiEZ)_