### PR TITLE
fix(compiler): bound the Wasm shadow stack against the heap

### DIFF
--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -94,6 +94,30 @@ const heapBase =
   heapTableBase + Math.ceil(((heapIrregularClass + 1) * 4) / heapHeaderBytes) * heapHeaderBytes
 
 /**
+ * The shadow stack may not reach the allocator's region.
+ *
+ * The two bump regions share one linear memory and point at each other: the shadow stack starts at
+ * the end of static data and grows up, while the heap starts at the fixed `heapTableBase` and grows
+ * up from there. Without a bound between them a deep enough chain of frames walks over the
+ * allocator's free-list table and then over live blocks, and nothing traps at the overwrite — the
+ * corrupted bytes are read back later, by whichever guard happens to see them first (#134).
+ *
+ * `memory.grow` cannot stand in for this bound. Growth appends pages above everything, so the stack
+ * reaches the heap long before a reservation runs past the memory that is mapped.
+ */
+const stackLimit = heapTableBase
+
+/**
+ * Linear memory opens with a 16-byte hole so that address 0 is never a live object. The backend
+ * spends its first word on a status word: a deliberate trap writes the reason there before
+ * `unreachable`, so a host that catches the trap can name what happened instead of inferring it
+ * from a byte offset. Memory is exported already, and it survives the trap.
+ */
+export const statusAddress = 0
+/** A frame reservation would have crossed out of the shadow stack's region. */
+export const statusStackOverflow = 1
+
+/**
  * A second `Backend` implementation emitting WebAssembly through the Silk wasm builder, for the
  * same MIR subset the bootstrap LLVM backend covers: logical scalar/aggregate locals, trapping
  * arithmetic, direct calls, checked replacement, and canonical structured control regions.
@@ -997,6 +1021,13 @@ const emitIntegerConversionValue = (
 interface MemoryContext {
   readonly memory: Memory.Memory
   readonly stackPointer: Global.Global
+  /** Where the shadow stack starts, so a report can rewind the pointer to it. */
+  readonly stackBase: number
+  /**
+   * The first address the shadow stack may not reach, or `undefined` when this module has no heap
+   * for it to run into and only the wrap and `memory.grow` guards apply.
+   */
+  readonly stackLimit: number | undefined
   readonly heapPointer: Global.Global
   readonly frame: FramePlan
   readonly plan: LayoutPlan.Plan
@@ -4457,6 +4488,35 @@ const emitBody = (
     if (memory.frame.size === 0) {
       return [Instr.globalGet(memory.stackPointer), Instr.localSet(layout.frameBase)]
     }
+    /**
+     * Report a deliberate trap rather than just taking one: name the reason in the status word, and
+     * rewind the stack pointer to the base so the trap is a single legible event instead of a
+     * module that answers every later call with the same trap. Whatever the abandoned frames owned
+     * is leaked — no cleanup ran — but the allocator's own structures are untouched, so a host that
+     * catches this can still read the heap back and get true answers out of it.
+     */
+    const report = (reason: number): ReadonlyArray<Instr.Instr> => [
+      Instr.i32Const(statusAddress),
+      Instr.i32Const(reason),
+      Instr.memoryAccess('i32.store', memory.memory),
+      Instr.i32Const(memory.stackBase),
+      Instr.globalSet(memory.stackPointer),
+      Instr.op('unreachable'),
+    ]
+    /**
+     * One comparison against an address known at emission, on the path that already computed
+     * `frameEnd`. A reservation that would cross into the heap reports here, before the stack
+     * pointer moves, instead of being noticed downstream as corrupted memory.
+     */
+    const boundCheck =
+      memory.stackLimit === undefined
+        ? []
+        : [
+            Instr.localGet(layout.frameEnd),
+            Instr.i32Const(memory.stackLimit),
+            Instr.op('i32.gt_u'),
+            Instr.ifElse(Instr.emptyBlockType, report(statusStackOverflow), []),
+          ]
     return [
       Instr.globalGet(memory.stackPointer),
       Instr.localSet(layout.frameBase),
@@ -4467,6 +4527,7 @@ const emitBody = (
       Instr.localGet(layout.frameBase),
       Instr.op('i32.lt_u'),
       Instr.ifElse(Instr.emptyBlockType, [Instr.op('unreachable')], []),
+      ...boundCheck,
       Instr.localGet(layout.frameEnd),
       Instr.i32Const(1),
       Instr.op('i32.sub'),
@@ -4853,6 +4914,9 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
           : Object.freeze({
               memory: privateMemory,
               stackPointer,
+              stackBase: staticEnd,
+              // Only a module with a heap has something above the shadow stack to run into.
+              stackLimit: needsHeap ? stackLimit : undefined,
               heapPointer,
               frame,
               plan: program.layout,

--- a/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
+++ b/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
@@ -1,9 +1,10 @@
 import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
+import { statusAddress, statusStackOverflow } from '../src/WasmBackend.js'
 
 /**
- * Characterizes the premature Wasm `unreachable` of #134, and attributes it.
+ * Pins the shadow stack's bound against the heap — the fix for #134, and the mechanism it replaced.
  *
  * The Wasm backend keeps two bump regions in one linear memory, and they grow toward each other's
  * data rather than away from it:
@@ -13,38 +14,42 @@ import * as Analysis from '../src/Analysis.js'
  * - the heap starts at a **fixed** address — the free-list head table at `heapTableBase`, then
  *   blocks from `heapBase` — and grows up from there.
  *
- * `reserveFrame` guards the two ways a frame reservation can fail arithmetically: an `i32` wrap
- * (`frameEnd < frameBase`) and a refused `memory.grow`. It does not guard the reservation against
- * the heap, so a deep enough chain of frames walks straight over the allocator's table and then
- * over live blocks. Nothing traps at the moment of the overwrite — the corrupted value is read back
- * later, by whichever guard happens to see it first.
+ * `reserveFrame` used to guard only the two ways a reservation can fail arithmetically: an `i32`
+ * wrap (`frameEnd < frameBase`) and a refused `memory.grow`. Neither one looks at the heap, so a
+ * deep enough chain of frames walked straight over the allocator's table and then over live blocks.
+ * Nothing trapped at the moment of the overwrite — the corrupted value was read back later, by
+ * whichever guard happened to see it first, which for a borrowed `match` was the union-tag dispatch
+ * chain's impossible-state fallback. That guard was right; the memory beneath it was not. At other
+ * depths there was no trap at all and the walk simply returned a wrong answer.
  *
- * That is why the trap lands where it does: the union-tag dispatch chain a `match` on a borrowed
- * union lowers to (`WasmBackend.ts` `emitDecisions`) ends in `unreachable` for a tag that names no
- * member. It is an impossible-state guard doing exactly its job on a discriminant that was
- * overwritten by a shadow-stack frame. The guard is correct; the memory beneath it is not.
+ * `reserveFrame` now compares `frameEnd` against the heap's base before the stack pointer moves, so
+ * a reservation that would cross reports instead of writing. The report is deliberate: it names
+ * itself in the status word at `statusAddress` and rewinds the stack pointer, so the trap is one
+ * legible event rather than a module that answers every later call the same way.
  *
- * The three facts that make this a defect rather than ordinary stack exhaustion — each pinned below:
+ * The four facts that make this a bound rather than ordinary stack exhaustion — each pinned below:
  *
  * 1. **The budget is tiny and fixed.** The shadow stack has `heapTableBase - staticEnd` bytes,
- *    about 64 KiB, whatever the host offers. This fixture spends 68 bytes per level, so it dies
+ *    about 64 KiB, whatever the host offers. This fixture spends 68 bytes per level, so it stops
  *    just under a thousand levels deep.
- * 2. **The host is not involved.** A recursion that needs no shadow-stack frame carries ten times
+ * 2. **Crossing reports.** Past that depth the module traps at the reservation and names the reason,
+ *    and its frames never reach the heap page.
+ * 3. **The host is not involved.** A recursion that needs no shadow-stack frame carries ten times
  *    that depth on the same engine before V8 raises `RangeError`.
- * 3. **Only the walk pays.** Building and releasing the same chain iteratively reserves one frame,
+ * 4. **Only the walk pays.** Building and releasing the same chain iteratively reserves one frame,
  *    so it is unaffected at any depth.
  *
- * Because the collision depth is arithmetic over three module-determined constants — static end,
- * heap base, and frame bytes per level — it is the same on every host. The depths below are
- * *derived* from the emitted module rather than written down, so this test pins the mechanism and
- * not one machine's numbers.
+ * Because the bound is arithmetic over three module-determined constants — static end, heap base,
+ * and frame bytes per level — it is the same on every host. The depths below are *derived* from the
+ * emitted module rather than written down, so this test pins the mechanism and not one machine's
+ * numbers.
  *
- * This pins current, wrong behaviour on purpose: it is the tripwire #134 asked for. When the
- * backend gains a shadow-stack bound, the second case stops holding — a bounded stack should report
- * exhaustion, not corrupt the heap and trap somewhere downstream — and this test should be rewritten
- * to pin that instead. The #132/#133 characterization covers the ordinary, sanctioned boundary and
- * deliberately accepts either failure mode at these depths; this one is about the failure that
- * arrives *before* it.
+ * The last case is the one that matters most: hitting the bound must leave the allocator alone. It
+ * allocates, crosses, and then checks both that the heap's bytes are exactly what an uncrossed run
+ * leaves and that the allocator still answers correctly afterwards.
+ *
+ * The #132/#133 characterization covers the ordinary, sanctioned depth boundary; this one is about
+ * the budget that runs out before it.
  */
 
 const ascii = (value: string): Uint8Array =>
@@ -206,6 +211,8 @@ interface Run {
    * head table because the allocator writes that itself, and this must measure only the stack.
    */
   readonly stackReach: number | undefined
+  /** The status word a deliberate trap leaves behind, or `undefined` without a memory. */
+  readonly status: number | undefined
 }
 
 const globalInitializers = (wat: string): ReadonlyArray<number> =>
@@ -215,6 +222,22 @@ const globalInitializers = (wat: string): ReadonlyArray<number> =>
 
 /** The free-list head table opens the heap's page; blocks follow it in the same page. */
 const heapPageOf = (heapBase: number): number => heapBase - (heapBase % 65536)
+
+/**
+ * The shadow stack's high-water mark: the highest nonzero word between static data and the heap
+ * page, which is where its frames live and where they stay written after the run.
+ *
+ * The scan starts past the status word, which sits in the reserved hole at the bottom of memory and
+ * belongs to the trap report rather than to any frame.
+ */
+const reachOf = (memory: WebAssembly.Memory, heapBase: number): number => {
+  const words = new Int32Array(memory.buffer, 0, heapPageOf(heapBase) >> 2)
+  let stackReach = 0
+  for (let index = (statusAddress >> 2) + 1; index < words.length; index += 1) {
+    if (words[index] !== 0) stackReach = index * 4
+  }
+  return stackReach
+}
 
 const execute = (bytes: Uint8Array, heapBase: number): Run => {
   const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
@@ -227,13 +250,14 @@ const execute = (bytes: Uint8Array, heapBase: number): Run => {
     failure = `${caught.constructor.name}: ${caught.message}`
   }
   const memory = instance.exports.__silk_memory_v1 as WebAssembly.Memory | undefined
-  if (memory === undefined) return Object.freeze({ value, failure, stackReach: undefined })
-  const words = new Int32Array(memory.buffer, 0, heapPageOf(heapBase) >> 2)
-  let stackReach = 0
-  for (let index = 0; index < words.length; index += 1) {
-    if (words[index] !== 0) stackReach = index * 4
-  }
-  return Object.freeze({ value, failure, stackReach })
+  if (memory === undefined)
+    return Object.freeze({ value, failure, stackReach: undefined, status: undefined })
+  return Object.freeze({
+    value,
+    failure,
+    stackReach: reachOf(memory, heapBase),
+    status: new Int32Array(memory.buffer, statusAddress, 1)[0],
+  })
 }
 
 /**
@@ -257,23 +281,49 @@ const measure = (id: string, source: string) =>
     return Object.freeze({ heapBase, ...execute(artifact.bytes, heapBase) })
   })
 
-/** Bytes of shadow stack this fixture spends per level, and where its frames start, measured. */
-const growth = Effect.gen(function* () {
-  const shallow = yield* measure('shadow-stack-collision/growth/400', walk(400))
-  const deeper = yield* measure('shadow-stack-collision/growth/800', walk(800))
-  assert.strictEqual(shallow.value, 0, 'the walk must still be correct at 400')
-  assert.strictEqual(deeper.value, 0, 'the walk must still be correct at 800')
-  const shallowReach = shallow.stackReach ?? 0
-  const deeperReach = deeper.stackReach ?? 0
-  const perLevel = (deeperReach - shallowReach) / 400
-  return Object.freeze({
-    heapBase: shallow.heapBase,
-    perLevel,
-    base: shallowReach - perLevel * 400,
-    shallowReach,
-    deeperReach,
+/**
+ * Bytes of shadow stack a fixture spends per level, where its frames start, and the two depths that
+ * straddle the bound — all measured off the emitted module rather than written down.
+ *
+ * `perLevel` and `base` describe the highest byte the frames actually *wrote*, which sits a little
+ * below the frame end the bound compares, and by a different amount per fixture. That difference is
+ * at most one frame, and a level reserves at least one frame, so two levels of margin always covers
+ * it: `bounded` is deep enough that its frame end is certainly past the limit, and `clear` shallow
+ * enough that it is certainly short of it.
+ */
+const growthOf = (
+  id: string,
+  source: (depth: number) => string,
+  shallowDepth: number,
+  deeperDepth: number,
+) =>
+  Effect.gen(function* () {
+    const shallow = yield* measure(`${id}/growth/${shallowDepth}`, source(shallowDepth))
+    const deeper = yield* measure(`${id}/growth/${deeperDepth}`, source(deeperDepth))
+    assert.strictEqual(shallow.value, 0, `${id} must still be correct at ${shallowDepth}`)
+    assert.strictEqual(deeper.value, 0, `${id} must still be correct at ${deeperDepth}`)
+    const shallowReach = shallow.stackReach ?? 0
+    const deeperReach = deeper.stackReach ?? 0
+    const perLevel = (deeperReach - shallowReach) / (deeperDepth - shallowDepth)
+    const base = shallowReach - perLevel * shallowDepth
+    // The heap's page is the first address the shadow stack may not reach: the free-list head table
+    // opens it. The module's own heap global names it, so a backend that moves the heap moves this.
+    const limit = heapPageOf(shallow.heapBase)
+    const span = (limit - base) / perLevel
+    return Object.freeze({
+      heapBase: shallow.heapBase,
+      limit,
+      perLevel,
+      base,
+      shallowReach,
+      deeperReach,
+      span,
+      bounded: Math.ceil(span),
+      clear: Math.floor(span) - 2,
+    })
   })
-})
+
+const growth = growthOf('shadow-stack-collision', walk, 400, 800)
 
 it.effect(
   'grows a shadow-stack frame per borrowed level, straight at the heap',
@@ -287,57 +337,68 @@ it.effect(
       assert.isBelow(measured.base, measured.perLevel)
 
       // Both depths are still short of the heap, which is why both are still correct.
-      assert.isBelow(measured.deeperReach, heapPageOf(measured.heapBase))
+      assert.isBelow(measured.deeperReach, measured.limit)
 
       // And the budget is the gap between static data and a heap base that never moves: a fixed
       // ~64 KiB, which is what makes this arrive so early. Nothing about it scales with the host.
-      assert.isBelow(measured.heapBase - measured.base, 1 << 17)
+      assert.isBelow(measured.limit - measured.base, 1 << 17)
     }),
   120_000,
 )
 
 it.effect(
-  'corrupts the chain and traps the level after its frames reach the heap',
+  'reports the bound rather than writing its frames over the heap',
   () =>
     Effect.gen(function* () {
       const measured = yield* growth
-      // The first depth whose frames are written at or above the allocator's bump base.
-      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
 
       const before = yield* measure(
-        `shadow-stack-collision/crossing/${crossing - 1}`,
-        walk(crossing - 1),
+        `shadow-stack-collision/crossing/${measured.clear}`,
+        walk(measured.clear),
       )
       assert.strictEqual(
         before.value,
         0,
-        `depth ${crossing - 1} keeps its frames below the heap and stays correct`,
+        `depth ${measured.clear} keeps its frames below the heap and stays correct`,
       )
+      assert.strictEqual(before.status, 0, 'a run that stays inside its budget reports nothing')
 
-      const after = yield* measure(`shadow-stack-collision/crossing/${crossing}`, walk(crossing))
-      // #134 itself: one level further and the walk reads back a union tag that names no member,
-      // so the dispatch chain's impossible-state guard traps. The failure is a Wasm trap, not the
-      // host's `RangeError` — the engine still has stack to spare, as the next case shows.
-      assert.isDefined(after.failure, `depth ${crossing} must fail`)
+      // Past the budget the reservation itself refuses, before the stack pointer moves. What used
+      // to happen here — #134 — was that the frames kept climbing over the allocator, and the walk
+      // read back a union tag that named no member some levels later, or returned a wrong answer
+      // and raised nothing at all.
+      const after = yield* measure(
+        `shadow-stack-collision/crossing/${measured.bounded}`,
+        walk(measured.bounded),
+      )
+      assert.isDefined(after.failure, `depth ${measured.bounded} must report`)
+      // A deliberate Wasm trap, not the host's `RangeError`: the engine still has stack to spare,
+      // as the next case shows.
       assert.include(after.failure ?? '', 'RuntimeError', after.failure ?? '')
       assert.notInclude(after.failure ?? '', 'RangeError', after.failure ?? '')
+
+      // And it says which trap it was, which is what makes this diagnosable rather than one more
+      // indistinguishable `unreachable`.
+      assert.strictEqual(after.status, statusStackOverflow)
+
+      // The point of the bound: the frames stopped below the heap's page instead of writing into
+      // the allocator's table.
+      assert.isBelow(after.stackReach ?? Number.POSITIVE_INFINITY, measured.limit)
     }),
   120_000,
 )
 
 it.effect(
-  'has host stack to spare an order of magnitude past the depth that trapped',
+  'has host stack to spare an order of magnitude past the depth that reported',
   () =>
     Effect.gen(function* () {
       const measured = yield* growth
-      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
 
-      // Same engine, same call depth times ten, no shadow-stack frame: it returns. So the trap
-      // above is not the machine stack running out, and the guard that fired was not reporting a
-      // limit the host had reached.
+      // Same engine, same call depth times ten, no shadow-stack frame: it returns. So the report
+      // above is not the machine stack running out, and the bound that fired was not the host's.
       const deep = yield* measure(
-        `shadow-stack-collision/host-control/${crossing * 10}`,
-        plainRecursion(crossing * 10),
+        `shadow-stack-collision/host-control/${measured.bounded * 10}`,
+        plainRecursion(measured.bounded * 10),
       )
       assert.strictEqual(deep.value, 0)
       assert.isUndefined(deep.stackReach, 'a frameless recursion needs no linear memory at all')
@@ -350,7 +411,7 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const measured = yield* growth
-      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
+      const crossing = measured.bounded
 
       // The asymmetry that names the cause. Construction is a loop, so it reserves one frame no
       // matter how long the chain is; the allocations it makes are identical to the walking case's.
@@ -363,4 +424,159 @@ it.effect(
       }
     }),
   120_000,
+)
+
+/**
+ * The second fixture, for the question the first one cannot ask: what the heap looks like after the
+ * bound is hit.
+ *
+ * `probe` builds a short chain, walks it, and drains it. That leaves the allocator with exactly the
+ * bookkeeping the unbounded stack used to overwrite — a free-list head table with real addresses in
+ * it, and a bump pointer that has moved. It is exported on its own so a host can ask the allocator
+ * a question *after* the module has reported.
+ *
+ * `main` runs `probe` once and then recurses. The recursion carries a wide borrowed record so that
+ * a level costs enough shadow stack to reach the bound well short of the host's own limit, and it
+ * allocates nothing — so the heap's contents do not depend on the depth, and a run that crosses is
+ * directly comparable, byte for byte, against one that does not.
+ */
+const lanes = Object.freeze(Array.from({ length: 16 }, (_, index) => index))
+const allocatingCross = (depth: number): string => `${prelude}
+pub struct Wide {
+${lanes.map((lane) => `  lane${lane}: i32`).join('\n')}
+}
+
+fn spend(wide: &Wide, remaining: i32) -> i32 {
+  if remaining == 0 { return wide.lane0 }
+  let next = Wide {
+${lanes.map((lane) => `    lane${lane}: wide.lane${lane}`).join(',\n')}
+  }
+  return spend(&next, remaining - 1)
+}
+
+effect fn probing() -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(8) |> Effect.provideMut(&mut allocator)
+  let counted = stepDepth(&built.step)
+  let released = drain(move built)
+  if counted == released { return 0 }
+  return 2
+}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn probe() -> i32 { return run Effect.catch(probing(), recover) }
+
+pub fn main() -> i32 {
+  let seed = Wide { ${lanes.map((lane) => `lane${lane}: ${lane}`).join(', ')} }
+  return probe() + spend(&seed, ${depth})
+}`
+
+interface Crossing {
+  readonly failure: string | undefined
+  readonly value: number | undefined
+  readonly status: number
+  readonly stackReach: number
+  /** The allocator's free-list heads, read straight out of the table that opens the heap page. */
+  readonly heads: ReadonlyArray<number>
+  /** The heap page's bytes, as left by the run. */
+  readonly heap: string
+  /** What `probe` answered when it was called again after the run, and the heap it left behind. */
+  readonly after: number | string
+  readonly heapAfter: string
+}
+
+/**
+ * Runs the allocating fixture at one depth and reports the heap on both sides of a second `probe`.
+ *
+ * The two calls share one instance, so the second one sees whatever the first left in the
+ * allocator: this is the module answering a question after it has reported, not a fresh start.
+ */
+const cross = (id: string, depth: number) =>
+  Effect.gen(function* () {
+    const source = allocatingCross(depth)
+    const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      [],
+      id,
+    )
+    const artifact = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+    const heapBase = globalInitializers(artifact.wat).at(1) ?? 0
+    const page = heapPageOf(heapBase)
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(artifact.bytes.slice()), {})
+    const memory = instance.exports.__silk_memory_v1 as WebAssembly.Memory
+    // Non-entry functions carry a mangled symbol; the declaration's name survives inside it.
+    const probeExport = Object.keys(instance.exports).find((name) => name.includes('_probe__'))
+    assert.isDefined(probeExport, 'the fixture must export its probe')
+    const call = (name: string): number | string => {
+      try {
+        return (instance.exports[name] as () => number)()
+      } catch (error) {
+        const caught = error as Error
+        return `${caught.constructor.name}: ${caught.message}`
+      }
+    }
+    // A window wide enough for the free-list table and every block this fixture allocates.
+    const heapBytes = (): string =>
+      Array.from(new Uint8Array(memory.buffer, page, 2048), (byte) =>
+        byte.toString(16).padStart(2, '0'),
+      ).join('')
+    const outcome = call('silk_main')
+    const heap = heapBytes()
+    const status = new Int32Array(memory.buffer, statusAddress, 1)[0] ?? 0
+    const stackReach = reachOf(memory, heapBase)
+    const heads = Array.from(new Int32Array(memory.buffer, page, (heapBase - page) >> 2))
+    const after = call(probeExport ?? '')
+    return Object.freeze({
+      heapBase,
+      page,
+      failure: typeof outcome === 'string' ? outcome : undefined,
+      value: typeof outcome === 'number' ? outcome : undefined,
+      status,
+      stackReach,
+      heads,
+      heap,
+      after,
+      heapAfter: heapBytes(),
+    }) satisfies Crossing & { readonly heapBase: number; readonly page: number }
+  })
+
+it.effect(
+  'leaves the allocator intact and answering after the bound is hit',
+  () =>
+    Effect.gen(function* () {
+      const measured = yield* growthOf('shadow-stack-cross', allocatingCross, 200, 600)
+
+      // The control: the same allocations, a recursion that stays inside the budget.
+      const control = yield* cross(`shadow-stack-cross/clear/${measured.clear}`, measured.clear)
+      assert.strictEqual(control.value, 0, `depth ${measured.clear} stays inside the budget`)
+      assert.strictEqual(control.status, 0)
+      // The allocator really did leave bookkeeping behind for a crossing run to damage.
+      assert.isTrue(
+        control.heads.some((head) => head !== 0),
+        'the probe must leave blocks on a free list',
+      )
+
+      // The same allocations, then a recursion that crosses.
+      const crossed = yield* cross(
+        `shadow-stack-cross/bounded/${measured.bounded}`,
+        measured.bounded,
+      )
+      assert.isDefined(crossed.failure, `depth ${measured.bounded} must report`)
+      assert.strictEqual(crossed.status, statusStackOverflow)
+      assert.isBelow(crossed.stackReach, measured.limit)
+
+      // This is the criterion. Both runs allocated identically and only one of them crossed, so any
+      // difference in these bytes is a frame that reached the heap. Before the bound, the free-list
+      // heads at this depth read back as frame data rather than as block addresses.
+      assert.deepEqual(crossed.heads, control.heads, 'the free-list table must be untouched')
+      assert.strictEqual(crossed.heap, control.heap, 'the heap page must be untouched')
+
+      // And the allocator is not merely unwritten but still correct: asked again, on the same
+      // instance that just reported, it serves and reclaims the same chain and answers the same.
+      assert.strictEqual(crossed.after, 0, 'the allocator must still answer after the report')
+      assert.strictEqual(crossed.heapAfter, control.heapAfter)
+    }),
+  180_000,
 )

--- a/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
+++ b/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
@@ -1,0 +1,366 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+
+/**
+ * Characterizes the premature Wasm `unreachable` of #134, and attributes it.
+ *
+ * The Wasm backend keeps two bump regions in one linear memory, and they grow toward each other's
+ * data rather than away from it:
+ *
+ * - the shadow stack starts at the end of static data and grows **up**, reserved a frame at a time
+ *   by `reserveFrame` (`WasmBackend.ts`), and
+ * - the heap starts at a **fixed** address — the free-list head table at `heapTableBase`, then
+ *   blocks from `heapBase` — and grows up from there.
+ *
+ * `reserveFrame` guards the two ways a frame reservation can fail arithmetically: an `i32` wrap
+ * (`frameEnd < frameBase`) and a refused `memory.grow`. It does not guard the reservation against
+ * the heap, so a deep enough chain of frames walks straight over the allocator's table and then
+ * over live blocks. Nothing traps at the moment of the overwrite — the corrupted value is read back
+ * later, by whichever guard happens to see it first.
+ *
+ * That is why the trap lands where it does: the union-tag dispatch chain a `match` on a borrowed
+ * union lowers to (`WasmBackend.ts` `emitDecisions`) ends in `unreachable` for a tag that names no
+ * member. It is an impossible-state guard doing exactly its job on a discriminant that was
+ * overwritten by a shadow-stack frame. The guard is correct; the memory beneath it is not.
+ *
+ * The three facts that make this a defect rather than ordinary stack exhaustion — each pinned below:
+ *
+ * 1. **The budget is tiny and fixed.** The shadow stack has `heapTableBase - staticEnd` bytes,
+ *    about 64 KiB, whatever the host offers. This fixture spends 68 bytes per level, so it dies
+ *    just under a thousand levels deep.
+ * 2. **The host is not involved.** A recursion that needs no shadow-stack frame carries ten times
+ *    that depth on the same engine before V8 raises `RangeError`.
+ * 3. **Only the walk pays.** Building and releasing the same chain iteratively reserves one frame,
+ *    so it is unaffected at any depth.
+ *
+ * Because the collision depth is arithmetic over three module-determined constants — static end,
+ * heap base, and frame bytes per level — it is the same on every host. The depths below are
+ * *derived* from the emitted module rather than written down, so this test pins the mechanism and
+ * not one machine's numbers.
+ *
+ * This pins current, wrong behaviour on purpose: it is the tripwire #134 asked for. When the
+ * backend gains a shadow-stack bound, the second case stops holding — a bounded stack should report
+ * exhaustion, not corrupt the heap and trap somewhere downstream — and this test should be rewritten
+ * to pin that instead. The #132/#133 characterization covers the ordinary, sanctioned boundary and
+ * deliberately accepts either failure mode at these depths; this one is about the failure that
+ * arrives *before* it.
+ */
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+/**
+ * A chain of boxed nodes with three phases that can be measured apart: an iterative `build`, a
+ * recursive `stepDepth`/`viewDepth` walk, and an iterative `drain` teardown. Construction and
+ * teardown are loops so that neither contributes call depth, which leaves the walk as the only
+ * phase that can spend the stack — of either kind.
+ *
+ * The walk is the borrow-heavy half: each level spills the borrowed `Box` into its frame, hands
+ * the frame address to `box.get`, and reads the lanes back, which is what puts a frame on the
+ * shadow stack at every level. Automatic cleanup is avoided deliberately — `Box`'s drop hook
+ * descends into the box it holds, so releasing a deep chain is itself a recursion, and that is the
+ * separate, sanctioned boundary of #132/#133 rather than the defect under test here.
+ */
+const prelude = `import silk.box { Box, make as boxMake, get as boxGet, into as boxInto }
+
+pub struct End {}
+
+pub struct Link {
+  next: Box<Chain>
+}
+
+pub struct Step {
+  kind: End | Link
+}
+
+pub struct Chain {
+  step: Step
+}
+
+pub struct Drained {
+  chain: Chain
+  more: bool
+}
+
+fn stepDepth(step: &Step) -> i32 {
+  return match &step.kind {
+    End nothing => 0
+    Link { next } => viewDepth(boxGet<Chain>(&next))
+  }
+}
+
+fn viewDepth(view: &[Chain]) -> i32 {
+  return match &view[usize.ZERO] {
+    Chain { step } => 1 + stepDepth(&step)
+  }
+}
+
+fn unlink(chain: Chain) -> Drained {
+  return match move chain {
+    Chain { step } => unlinkStep(move step)
+  }
+}
+
+fn unlinkStep(step: Step) -> Drained {
+  return match move step {
+    Step { kind } => unlinkKind(move kind)
+  }
+}
+
+fn unlinkKind(kind: End | Link) -> Drained {
+  return match move kind {
+    End nothing => Drained { chain: Chain { step: Step { kind: End {} } }, more: false }
+    Link { next } => Drained { chain: boxInto<Chain>(move next), more: true }
+  }
+}
+
+fn drain(chain: Chain) -> i32 {
+  let mut current = move chain
+  let mut released = 0
+  let mut going = true
+  while going {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let mut stepped = unlink(move taken)
+    current = Intrinsic.replace(stepped.chain, Chain { step: Step { kind: End {} } })
+    going = stepped.more
+    if stepped.more { released = released + 1 }
+  }
+  return released
+}
+
+effect fn build(depth: i32) -> Chain ! OutOfMemory ? &mut Allocator {
+  let mut current = Chain { step: Step { kind: End {} } }
+  let mut remaining = depth
+  while remaining > 0 {
+    let taken = Intrinsic.replace(current, Chain { step: Step { kind: End {} } })
+    let boxed = run boxMake<Chain>(move taken)
+    current = Chain { step: Step { kind: Link { next: move boxed } } }
+    remaining = remaining - 1
+  }
+  return move current
+}
+`
+
+const program = (body: string, depth: number): string => `${prelude}
+${body}
+
+effect fn recover(error: OutOfMemory) -> i32 { return 1 }
+
+pub fn main() -> i32 { return run Effect.catch(measure(${depth}), recover) }`
+
+/** Build the chain, walk it recursively, drain it. The walk is the only recursion. */
+const walk = (depth: number): string =>
+  program(
+    `effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  let counted = stepDepth(&built.step)
+  let released = drain(move built)
+  if counted == released { return 0 }
+  return 2
+}`,
+    depth,
+  )
+
+/** The same allocations, the same teardown, no walk: this program never recurses at all. */
+const unwalked = (depth: number): string =>
+  program(
+    `effect fn measure(depth: i32) -> i32 ! OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let built = run build(depth) |> Effect.provideMut(&mut allocator)
+  let released = drain(move built)
+  if released == depth { return 0 }
+  return 2
+}`,
+    depth,
+  )
+
+/**
+ * Recursion with nothing to spill: no borrow, no aggregate, no frame. The backend gives this
+ * function no shadow-stack frame at all — the module has no linear memory — so its only limit is
+ * the engine's, which is the control this test needs.
+ */
+const plainRecursion = (depth: number): string => `fn count(n: i32) -> i32 {
+  if n == 0 { return 0 }
+  return 1 + count(n - 1)
+}
+
+pub fn main() -> i32 {
+  if count(${depth}) == ${depth} { return 0 }
+  return 2
+}`
+
+interface Run {
+  /** `silk_main`'s value, or `undefined` when the module failed instead of returning. */
+  readonly value: number | undefined
+  /** `Constructor: message` when it failed, so a failure names its kind and not just its presence. */
+  readonly failure: string | undefined
+  /**
+   * Highest address below the allocator's own region that the module ever wrote, or `undefined`
+   * without a memory.
+   *
+   * Between the end of static data and the heap page there is nothing but the shadow stack, so for
+   * this fixture — whose static data is a handful of bytes — this is the high-water mark of
+   * shadow-stack frames, and it stays written after the run. The window stops below the free-list
+   * head table because the allocator writes that itself, and this must measure only the stack.
+   */
+  readonly stackReach: number | undefined
+}
+
+const globalInitializers = (wat: string): ReadonlyArray<number> =>
+  Object.freeze(
+    [...wat.matchAll(/\(global \(mut i32\) i32\.const (\d+)\)/g)].map((match) => Number(match[1])),
+  )
+
+/** The free-list head table opens the heap's page; blocks follow it in the same page. */
+const heapPageOf = (heapBase: number): number => heapBase - (heapBase % 65536)
+
+const execute = (bytes: Uint8Array, heapBase: number): Run => {
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
+  let value: number | undefined
+  let failure: string | undefined
+  try {
+    value = (instance.exports.silk_main as () => number)()
+  } catch (error) {
+    const caught = error as Error
+    failure = `${caught.constructor.name}: ${caught.message}`
+  }
+  const memory = instance.exports.__silk_memory_v1 as WebAssembly.Memory | undefined
+  if (memory === undefined) return Object.freeze({ value, failure, stackReach: undefined })
+  const words = new Int32Array(memory.buffer, 0, heapPageOf(heapBase) >> 2)
+  let stackReach = 0
+  for (let index = 0; index < words.length; index += 1) {
+    if (words[index] !== 0) stackReach = index * 4
+  }
+  return Object.freeze({ value, failure, stackReach })
+}
+
+/**
+ * Emits the source and runs it, reporting both what the module did and how far its shadow stack
+ * climbed. The heap's bump base comes out of the module's own second global rather than a constant
+ * repeated here, so a backend that moves the heap moves every expectation below with it.
+ */
+const measure = (id: string, source: string) =>
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      [],
+      id,
+    )
+    const artifact = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+    const globals = globalInitializers(artifact.wat)
+    // The backend declares the shadow-stack pointer first and the heap pointer second; a module
+    // with neither has no linear memory and no shadow stack, which is the control case.
+    const heapBase = globals.at(1) ?? 0
+    return Object.freeze({ heapBase, ...execute(artifact.bytes, heapBase) })
+  })
+
+/** Bytes of shadow stack this fixture spends per level, and where its frames start, measured. */
+const growth = Effect.gen(function* () {
+  const shallow = yield* measure('shadow-stack-collision/growth/400', walk(400))
+  const deeper = yield* measure('shadow-stack-collision/growth/800', walk(800))
+  assert.strictEqual(shallow.value, 0, 'the walk must still be correct at 400')
+  assert.strictEqual(deeper.value, 0, 'the walk must still be correct at 800')
+  const shallowReach = shallow.stackReach ?? 0
+  const deeperReach = deeper.stackReach ?? 0
+  const perLevel = (deeperReach - shallowReach) / 400
+  return Object.freeze({
+    heapBase: shallow.heapBase,
+    perLevel,
+    base: shallowReach - perLevel * 400,
+    shallowReach,
+    deeperReach,
+  })
+})
+
+it.effect(
+  'grows a shadow-stack frame per borrowed level, straight at the heap',
+  () =>
+    Effect.gen(function* () {
+      const measured = yield* growth
+
+      // Linear in the depth, because every level reserves the same two frames.
+      assert.isAbove(measured.perLevel, 0)
+      assert.strictEqual(measured.perLevel, Math.trunc(measured.perLevel))
+      assert.isBelow(measured.base, measured.perLevel)
+
+      // Both depths are still short of the heap, which is why both are still correct.
+      assert.isBelow(measured.deeperReach, heapPageOf(measured.heapBase))
+
+      // And the budget is the gap between static data and a heap base that never moves: a fixed
+      // ~64 KiB, which is what makes this arrive so early. Nothing about it scales with the host.
+      assert.isBelow(measured.heapBase - measured.base, 1 << 17)
+    }),
+  120_000,
+)
+
+it.effect(
+  'corrupts the chain and traps the level after its frames reach the heap',
+  () =>
+    Effect.gen(function* () {
+      const measured = yield* growth
+      // The first depth whose frames are written at or above the allocator's bump base.
+      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
+
+      const before = yield* measure(
+        `shadow-stack-collision/crossing/${crossing - 1}`,
+        walk(crossing - 1),
+      )
+      assert.strictEqual(
+        before.value,
+        0,
+        `depth ${crossing - 1} keeps its frames below the heap and stays correct`,
+      )
+
+      const after = yield* measure(`shadow-stack-collision/crossing/${crossing}`, walk(crossing))
+      // #134 itself: one level further and the walk reads back a union tag that names no member,
+      // so the dispatch chain's impossible-state guard traps. The failure is a Wasm trap, not the
+      // host's `RangeError` — the engine still has stack to spare, as the next case shows.
+      assert.isDefined(after.failure, `depth ${crossing} must fail`)
+      assert.include(after.failure ?? '', 'RuntimeError', after.failure ?? '')
+      assert.notInclude(after.failure ?? '', 'RangeError', after.failure ?? '')
+    }),
+  120_000,
+)
+
+it.effect(
+  'has host stack to spare an order of magnitude past the depth that trapped',
+  () =>
+    Effect.gen(function* () {
+      const measured = yield* growth
+      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
+
+      // Same engine, same call depth times ten, no shadow-stack frame: it returns. So the trap
+      // above is not the machine stack running out, and the guard that fired was not reporting a
+      // limit the host had reached.
+      const deep = yield* measure(
+        `shadow-stack-collision/host-control/${crossing * 10}`,
+        plainRecursion(crossing * 10),
+      )
+      assert.strictEqual(deep.value, 0)
+      assert.isUndefined(deep.stackReach, 'a frameless recursion needs no linear memory at all')
+    }),
+  120_000,
+)
+
+it.effect(
+  'leaves the same chain alone when nothing walks it',
+  () =>
+    Effect.gen(function* () {
+      const measured = yield* growth
+      const crossing = Math.ceil((measured.heapBase - measured.base) / measured.perLevel)
+
+      // The asymmetry that names the cause. Construction is a loop, so it reserves one frame no
+      // matter how long the chain is; the allocations it makes are identical to the walking case's.
+      // Allocating the chain is fine at any depth. Walking it is what spends the shadow stack.
+      for (const depth of [crossing, crossing * 10]) {
+        const outcome = yield* measure(`shadow-stack-collision/unwalked/${depth}`, unwalked(depth))
+        assert.strictEqual(outcome.value, 0, `building ${depth} links without walking them`)
+        // One frame's worth, at any length: the loop reserves once and reuses it.
+        assert.isBelow(outcome.stackReach ?? 0, 1024)
+      }
+    }),
+  120_000,
+)


### PR DESCRIPTION
Diagnosis **and** fix for #134. No lowering or evaluator change; nothing here touches the suspension path, so it does not depend on #24 / PR #135, and it does not restructure the memory layout.

## The defect

`WasmBackend.ts` points two bump regions at each other in one linear memory. The shadow stack starts at the end of static data (`stackPointer`, initialized to `staticEnd`) and grows **up**, a frame per call; the heap's free-list head table sits at a fixed `heapTableBase = 65536` with blocks just above it. `reserveFrame` guarded a reservation against an `i32` wrap and against a refused `memory.grow`, and against nothing else.

`memory.grow` cannot stand in for a heap bound: growth appends pages *above* everything while the heap stays pinned at 65536, so the stack reaches the allocator long before a reservation runs past the mapped memory. That guard never fires.

So a recursion deep enough to spend the ~64 KiB between the regions wrote its frames over the allocator's table and then over live blocks — and **nothing trapped at the overwrite**. The corrupted value was read back later, by whichever guard saw it first; for a `match` on a borrowed union that is the tag-dispatch fallback in `emitDecisions`, confirmed by decoding the trapping byte offset out of V8's wasm stack trace. At other depths there was no trap at all and the walk returned a wrong answer. The trap was the lucky case.

This accounts for both things the issue found most telling:

- **Only the walk triggers it** because only the walk recurses. Building and draining the same chain are loops: one frame at any length.
- **It fires below the host limit** because the shadow stack's budget is a compile-time constant (~64 KiB), while this engine carries ten times that call depth for a recursion that needs no frame.

## The fix

`reserveFrame` now compares `frameEnd` against the heap's base **before the stack pointer moves**. One comparison against an address known at emission, on the path that already computed `frameEnd`.

Crossing **reports** rather than writes. The report names itself in a status word in the reserved 16-byte hole at the bottom of linear memory (`statusAddress` / `statusStackOverflow`, both exported) and rewinds the stack pointer to its base before trapping. Two consequences worth stating:

- The failure is diagnosable. Every one of the backend's `unreachable` sites is otherwise indistinguishable at runtime — which is why attributing this took a byte-offset decode. A host that catches the trap can now read the reason out of the exported memory.
- The trap is a single legible event. Without the rewind, the stack pointer stays parked at the limit and *every subsequent call* into the module traps at its first reservation, indistinguishable from a fresh overflow. Whatever the abandoned frames owned is leaked, since no cleanup ran, but the allocator's own structures are untouched — so the module still answers correctly afterwards, which the new test exercises directly.

The wrap and `memory.grow` guards stay. They cover a module with **no heap**, which has nothing above the shadow stack to run into; such a module gets no bound and no added instruction at all.

This deliberately does not try to make deep recursion *work* — #132/#133 settled that ordinary recursion carries no bounded-stack guarantee, and `packages/language/docs/recursion.md` documents it. The point is that exceeding the budget is now safe and legible.

## Instruction-count cost

Per frame-reserving function, **11 wasm instructions**, of which **4 execute on the reservation path**:

```wat
local.get $frameEnd     ;; hot
i32.const 65536         ;; hot
i32.gt_u                ;; hot
if                      ;; hot
  i32.const 0           ;; cold — the report, in the untaken branch
  i32.const 1
  i32.store
  i32.const 16
  global.set $silk_stack_pointer
  unreachable
end
```

Measured on release-mode modules, counting emitted instructions and binary bytes before and after:

| representative module | guard sites emitted | instructions | Δ | bytes | Δ |
|---|---|---|---|---|---|
| scalar arithmetic (no linear memory, no frames) | 0 | 42 → 42 | **0** | 287 → 287 | **0** |
| borrowed struct walk (1 frame-reserving fn, no heap) | 0 | 202 → 202 | **0** | 912 → 912 | **0** |
| boxed allocate / borrow / reclaim (40 fns, 3 reserve frames) | 3 | 1618 → 1651 | **+33 (+2.0%)** | 20902 → 20968 | **+66 (+0.3%)** |

33 = 3 sites × 11, exactly. Non-recursive code pays the four hot instructions once per frame-reserving call and nothing else; a module without a heap pays nothing.

## Tests

`packages/compiler/test/WasmShadowStackHeapCollision.test.ts` — five cases. Depths are **derived from the emitted module** (measured frame bytes per level against the module's own heap-base global), so a backend that changes frame layout or moves the heap moves every expectation with it. No depth is written down.

1. shadow-stack reach grows linearly with depth, straight at a heap base that never moves, and the budget between them is under 128 KiB;
2. **rewritten** — at `bounded` the module reports: a Wasm `RuntimeError` rather than the host's `RangeError`, the status word names the overflow, and the frames stopped below the heap page. At `clear` it is still correct and reports nothing. This case previously pinned the corruption;
3. the same engine carries `bounded * 10` levels of frameless recursion and returns, so the host stack was not the limit;
4. the same allocations with the walk removed return at `bounded` and at `bounded * 10`;
5. **new, and the one that matters** — allocate, cross the bound, and check the heap. A fixture whose recursion allocates nothing runs at `clear` and at `bounded` after identical allocations, so the two heaps are directly comparable. After the crossing run the free-list table and the heap page are **identical byte for byte** to the uncrossed run, and the allocator, asked again on the same instance that just reported, still serves and reclaims the same chain and answers the same.

Both rewritten cases fail on the unfixed backend (`depth 964 must report` / `depth 1023 must report` — the old code returns instead of reporting), so they pin the fix rather than merely accompanying it.

Measured on x86_64 Linux, Node 22.22.2: 68 shadow-stack bytes per level for the walk fixture, heap page 65536, first reporting depth **963**.

## Relationship to #169

No overlap and no contradiction. #169 characterizes the *ordinary* recursion boundary for #132/#133 and deliberately accepts either failure mode at these depths; this bounds the failure that arrives before it. This branch does not touch `recursion.md` or `RecursionStackBoundary.test.ts`.

## Verification

`pnpm check` — **green**, exit 0 (10/10 build tasks, 30/30 typecheck+test tasks, 8/8 script tests). Existing Wasm suites pass unchanged: `WasmBackend`, `WasmHeapReclaim`, `WasmShadowStackHeapCollision` — 58 tests. The wat goldens are untouched, since none of those fixtures reserves a frame.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NVgBA3RDocrJDfoAh7iUc