### PR TITLE
Reject stored bare callables at the construction site (SEM0103)

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -291,6 +291,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-node": "4.0.0-beta.103",
     "@effect/vitest": "catalog:",
     "@types/node": "^24.10.1"
   }

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -4570,11 +4570,7 @@ export const storedCallable = (
   const next = new Set(seen).add(key)
   for (const field of declaration.fields) {
     if (field.declaredType._tag !== 'Resolved' || field.name._tag !== 'Present') continue
-    const found = storedCallable(
-      self,
-      Type.substitute(field.declaredType.type, substitution),
-      next,
-    )
+    const found = storedCallable(self, Type.substitute(field.declaredType.type, substitution), next)
     if (found !== undefined)
       return Object.freeze({
         path: Object.freeze([field.name.spelling, ...found.path]),

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -4520,3 +4520,66 @@ export const containsLexicalBorrow = (
       containsLexicalBorrow(self, Type.substitute(field.declaredType.type, substitution), next),
   )
 }
+
+/** One stored bare-callable occurrence that denies an aggregate type a target layout. */
+export interface StoredCallable {
+  /** Field names from the aggregate down to the callable-typed position; empty for elements. */
+  readonly path: ReadonlyArray<string>
+  readonly callable: Type.Callable
+}
+
+/**
+ * Finds the first stored position at which a concrete type keeps a bare callable value.
+ *
+ * The walk mirrors what nominal layout planning can actually see: struct fields after
+ * substitution, fixed-array and slice elements, and union members. It deliberately does not
+ * descend through references (their layout is an address regardless of the target), intrinsic
+ * nominals (their layouts never depend on their type arguments), or Effect types (their hidden
+ * environments plan callables from concrete identities). A position this finds is exactly one
+ * `Layout.layoutType` would refuse with `callable environment layout is planned from its hidden
+ * concrete identity`, so a construction of the enclosing aggregate cannot receive a layout.
+ */
+export const storedCallable = (
+  self: Index,
+  type: Type.Type,
+  seen: ReadonlySet<string> = new Set(),
+): StoredCallable | undefined => {
+  if (Type.isCallable(type)) return Object.freeze({ path: Object.freeze([]), callable: type })
+  if (Type.isFixedArray(type) || Type.isSlice(type)) return storedCallable(self, type.element, seen)
+  if (Type.isUnion(type)) {
+    for (const member of type.members) {
+      const found = storedCallable(self, member, seen)
+      if (found !== undefined) return found
+    }
+    return undefined
+  }
+  if (!Type.isNominal(type) || Type.isIntrinsicNominal(type)) return undefined
+  const key = Type.key(type)
+  if (seen.has(key)) return undefined
+  const declaration = byCanonical(self, {
+    _tag: 'CanonicalDeclarationId',
+    module: type.module,
+    name: type.name,
+  })
+  if (declaration?._tag !== 'StructDeclaration') return undefined
+  const substitution =
+    Type.substitution(
+      declaration.typeParameters.map((parameter) => parameter.type),
+      type.arguments,
+    ) ?? new Map()
+  const next = new Set(seen).add(key)
+  for (const field of declaration.fields) {
+    if (field.declaredType._tag !== 'Resolved' || field.name._tag !== 'Present') continue
+    const found = storedCallable(
+      self,
+      Type.substitute(field.declaredType.type, substitution),
+      next,
+    )
+    if (found !== undefined)
+      return Object.freeze({
+        path: Object.freeze([field.name.spelling, ...found.path]),
+        callable: found.callable,
+      })
+  }
+  return undefined
+}

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -790,6 +790,17 @@ export const hasGenericSpecializationErrors = (diagnostics: ReadonlyArray<Diagno
       diagnostic.code === polymorphicRecursionCode,
   )
 
+/**
+ * Tests whether a reachable-instance fence diagnostic denies target realization.
+ *
+ * A stored-callable construction (#184) is exactly a program the layout planner cannot serve: the
+ * violating aggregates would receive unavailable layout entries and MIR validation would fail with
+ * `MissingTypeLayout`/`InvalidAggregateOperation`. Realization stops here so the source diagnostic
+ * is the only reported failure, instead of being followed by an `InvalidMir` echo of itself.
+ */
+export const hasInstanceFenceErrors = (diagnostics: ReadonlyArray<Diagnostic>): boolean =>
+  diagnostics.some((diagnostic) => diagnostic.code === storedCallableConstructionCode)
+
 /** Derives the identity of one diagnostic given its ordinal among equals. */
 export const identity = (self: Diagnostic, ordinal = 0): Identity =>
   Object.freeze({
@@ -1669,12 +1680,18 @@ export const suspendingContinuationAllocator = (
  * size the callable's environment (#184). Until nominal values can carry that identity — or stored
  * callables get a uniform runtime representation — the construction is reported here, at the source
  * site, instead of surfacing later as an `InvalidMir` failure with no user-facing diagnostic.
+ *
+ * When the aggregate stores a callable only because a generic specialization chose one — the
+ * declared field type is a bare type parameter — the primary span is the specializing call site,
+ * because that is where the concrete callable argument was written, and the generic body's
+ * construction is retained as `constructedAt` related provenance.
  */
 export const storedCallableConstruction = (
   aggregate: string,
   field: string | undefined,
   callable: string,
   span: SourceSpan.SourceSpan,
+  constructedAt?: SourceSpan.SourceSpan,
 ): Diagnostic => {
   const site = field === undefined ? 'its element' : `field ${field}`
   return Object.freeze({
@@ -1690,6 +1707,13 @@ export const storedCallableConstruction = (
       callable,
     }),
     span,
+    ...(constructedAt === undefined
+      ? {}
+      : {
+          relatedSpans: Object.freeze([
+            Object.freeze({ label: 'constructed here', span: constructedAt }),
+          ]),
+        }),
   })
 }
 

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -206,6 +206,8 @@ export const unlowerableBoundWitnessCode = 'SEM0101' as const
 export const analysisOnlyConstructCode = 'SEM0098' as const
 /** Stable code for selecting a suspending provider to allocate continuation storage. */
 export const suspendingContinuationAllocatorCode = 'SEM0102' as const
+/** Stable code for constructing an aggregate that stores a bare callable value. */
+export const storedCallableConstructionCode = 'SEM0103' as const
 
 /** Stable code for a use of a binding after its consuming move. */
 export const useAfterMoveCode = 'OWN0001' as const
@@ -342,6 +344,7 @@ export type Code =
   | typeof typeArgumentConflictCode
   | typeof unlowerableBoundWitnessCode
   | typeof suspendingContinuationAllocatorCode
+  | typeof storedCallableConstructionCode
   | typeof useAfterMoveCode
   | typeof partialMoveCode
   | typeof explicitMoveRequiredCode
@@ -451,6 +454,12 @@ export type Reason =
       readonly _tag: 'SuspendingContinuationAllocator'
       readonly provider: string
       readonly implementation: string
+    }
+  | {
+      readonly _tag: 'StoredCallableConstruction'
+      readonly aggregate: string
+      readonly field?: string
+      readonly callable: string
     }
   | { readonly _tag: 'InvalidConstant'; readonly detail: string }
   | { readonly _tag: 'ExpressionStatementResult'; readonly actual: string }
@@ -1651,6 +1660,38 @@ export const suspendingContinuationAllocator = (
     }),
     span,
   })
+
+/**
+ * Rejects a reachable construction that would store a bare callable value inside an aggregate.
+ *
+ * A direct callable value works because the compiler still holds its hidden concrete identity; an
+ * aggregate type such as `Parser` carries only the declared signature, so layout planning cannot
+ * size the callable's environment (#184). Until nominal values can carry that identity — or stored
+ * callables get a uniform runtime representation — the construction is reported here, at the source
+ * site, instead of surfacing later as an `InvalidMir` failure with no user-facing diagnostic.
+ */
+export const storedCallableConstruction = (
+  aggregate: string,
+  field: string | undefined,
+  callable: string,
+  span: SourceSpan.SourceSpan,
+): Diagnostic => {
+  const site = field === undefined ? 'its element' : `field ${field}`
+  return Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'semantic',
+    code: storedCallableConstructionCode,
+    severity: 'error',
+    message: `Cannot construct ${aggregate}: ${site} would store the callable ${callable}, whose environment layout depends on a hidden concrete identity that ${aggregate} does not carry`,
+    reason: Object.freeze({
+      _tag: 'StoredCallableConstruction',
+      aggregate,
+      ...(field === undefined ? {} : { field }),
+      callable,
+    }),
+    span,
+  })
+}
 
 export const invalidEffectHandler = (detail: string, span: SourceSpan.SourceSpan): Diagnostic =>
   Object.freeze({

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -288,11 +288,26 @@ export const unlowerableWitnessViolations = (
  *
  * Scoped to reachable instances on purpose: a callable-bearing struct that is only declared, or
  * only constructed in unreachable code, compiles and runs today and stays accepted.
+ *
+ * Provenance follows where the callable was written. A construction whose declared type already
+ * stores a callable — `Parser<A> { decode: fn(i32) -> A }` — names the fault itself, so its own
+ * span is primary. One that stores a callable only after substitution — `Holder<T> { value: T }`
+ * specialized at a callable — was decided at the call that chose the type arguments, so the
+ * earliest specializing call site (by source ID, then position) is primary and the generic body's
+ * construction is retained as related provenance. That keeps a stdlib-internal construction such
+ * as `Option.some(i32.add(1))` pointing at the user's call rather than into `silk/option`.
  */
 export const storedCallableViolations = (
   self: Discovery,
   index: DeclarationIndex.Index,
 ): ReadonlyArray<Diagnostic.Diagnostic> => {
+  const specializingCalls = new Map<string, CallInstance>()
+  for (const call of self.calls) {
+    const target = keyText(call.target)
+    const current = specializingCalls.get(target)
+    if (current === undefined || compareCallSites(call, current) < 0)
+      specializingCalls.set(target, call)
+  }
   const reported = new Set<string>()
   return Object.freeze(
     self.instances.flatMap((instance) =>
@@ -304,19 +319,48 @@ export const storedCallableViolations = (
           const aggregate = Type.substitute(expression.type, instance.substitution)
           const found = DeclarationIndex.storedCallable(index, aggregate)
           if (found === undefined) return []
+          const declared = DeclarationIndex.storedCallable(index, expression.type)
+          const specializing =
+            declared === undefined ? specializingCalls.get(keyText(instance.key)) : undefined
           const diagnostic = Diagnostic.storedCallableConstruction(
             Type.encode(aggregate),
             found.path.length === 0 ? undefined : found.path.join('.'),
             Type.encode(found.callable),
-            expression.span,
+            specializing?.span ?? expression.span,
+            specializing === undefined ? undefined : expression.span,
           )
-          const key = `${expression.span.sourceId}:${expression.span.start}:${expression.span.end} ${diagnostic.message}`
+          const key = storedCallableViolationKey(diagnostic)
           if (reported.has(key)) return []
           reported.add(key)
           return [diagnostic]
         }),
     ),
   )
+}
+
+/** Orders call sites by source ID, then position, for a deterministic primary origin. */
+const compareCallSites = (left: CallInstance, right: CallInstance): number =>
+  left.span.sourceId === right.span.sourceId
+    ? left.span.start - right.span.start || left.span.end - right.span.end
+    : left.span.sourceId < right.span.sourceId
+      ? -1
+      : 1
+
+/**
+ * The structural identity of one stored-callable violation: its stable diagnostic identity plus
+ * the reason facts, so two distinct callables reported at one span never collapse into one.
+ */
+const storedCallableViolationKey = (diagnostic: Diagnostic.Diagnostic): string => {
+  const reason = diagnostic.reason._tag === 'StoredCallableConstruction' ? diagnostic.reason : null
+  return JSON.stringify([
+    diagnostic.code,
+    diagnostic.span.sourceId,
+    diagnostic.span.start,
+    diagnostic.span.end,
+    reason?.aggregate ?? '',
+    reason?.field ?? '',
+    reason?.callable ?? '',
+  ])
 }
 
 /** Produces semantic diagnostics for every finite-discovery violation. */

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -4,6 +4,7 @@ import * as Elaboration from './Elaboration.js'
 import * as Hir from './Hir.js'
 import * as Intrinsic from './Intrinsic.js'
 import * as Ownership from './Ownership.js'
+import * as SourceSpan from './SourceSpan.js'
 import * as Type from './Type.js'
 
 /**
@@ -308,7 +309,7 @@ export const storedCallableViolations = (
     if (current === undefined || compareCallSites(call, current) < 0)
       specializingCalls.set(target, call)
   }
-  const reported = new Set<string>()
+  const reported: Array<StoredCallableViolationKey> = []
   return Object.freeze(
     self.instances.flatMap((instance) =>
       instance.function.statements
@@ -322,17 +323,27 @@ export const storedCallableViolations = (
           const declared = DeclarationIndex.storedCallable(index, expression.type)
           const specializing =
             declared === undefined ? specializingCalls.get(keyText(instance.key)) : undefined
-          const diagnostic = Diagnostic.storedCallableConstruction(
-            Type.encode(aggregate),
-            found.path.length === 0 ? undefined : found.path.join('.'),
-            Type.encode(found.callable),
-            specializing?.span ?? expression.span,
-            specializing === undefined ? undefined : expression.span,
-          )
-          const key = storedCallableViolationKey(diagnostic)
-          if (reported.has(key)) return []
-          reported.add(key)
-          return [diagnostic]
+          const span = specializing?.span ?? expression.span
+          const constructionSpan = expression.span
+          const key: StoredCallableViolationKey = {
+            aggregate,
+            path: found.path,
+            callable: found.callable,
+            span,
+            constructionSpan,
+          }
+          if (reported.some((candidate) => sameStoredCallableViolationKey(candidate, key)))
+            return []
+          reported.push(key)
+          return [
+            Diagnostic.storedCallableConstruction(
+              Type.encode(aggregate),
+              found.path.length === 0 ? undefined : found.path.join('.'),
+              Type.encode(found.callable),
+              span,
+              specializing === undefined ? undefined : expression.span,
+            ),
+          ]
         }),
     ),
   )
@@ -346,22 +357,25 @@ const compareCallSites = (left: CallInstance, right: CallInstance): number =>
       ? -1
       : 1
 
-/**
- * The structural identity of one stored-callable violation: its stable diagnostic identity plus
- * the reason facts, so two distinct callables reported at one span never collapse into one.
- */
-const storedCallableViolationKey = (diagnostic: Diagnostic.Diagnostic): string => {
-  const reason = diagnostic.reason._tag === 'StoredCallableConstruction' ? diagnostic.reason : null
-  return JSON.stringify([
-    diagnostic.code,
-    diagnostic.span.sourceId,
-    diagnostic.span.start,
-    diagnostic.span.end,
-    reason?.aggregate ?? '',
-    reason?.field ?? '',
-    reason?.callable ?? '',
-  ])
+/** Stable semantic identity of one stored-callable violation before presentation encoding. */
+interface StoredCallableViolationKey {
+  readonly aggregate: Type.Type
+  readonly path: ReadonlyArray<string>
+  readonly callable: Type.Callable
+  readonly span: SourceSpan.SourceSpan
+  readonly constructionSpan: SourceSpan.SourceSpan
 }
+
+const sameStoredCallableViolationKey = (
+  left: StoredCallableViolationKey,
+  right: StoredCallableViolationKey,
+): boolean =>
+  Type.equals(left.aggregate, right.aggregate) &&
+  left.path.length === right.path.length &&
+  left.path.every((part, index) => part === right.path[index]) &&
+  Type.equals(left.callable, right.callable) &&
+  SourceSpan.equals(left.span, right.span) &&
+  SourceSpan.equals(left.constructionSpan, right.constructionSpan)
 
 /** Produces semantic diagnostics for every finite-discovery violation. */
 export const violationDiagnostics = (self: Discovery): ReadonlyArray<Diagnostic.Diagnostic> =>

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -276,6 +276,49 @@ export const unlowerableWitnessViolations = (
     ),
   )
 
+/**
+ * Rejects reachable constructions that would store a bare callable value inside an aggregate.
+ *
+ * A direct callable value keeps its hidden concrete identity beside its structural type, so
+ * higher-order calls monomorphize; a `Construct` or `ArrayConstruct` result carries only the
+ * declared type, and nominal layout planning then meets a bare `fn(...) -> ...` field it refuses
+ * to size (#184). Lowering has no diagnostic channel and the program would otherwise pass a clean
+ * frontend and die in MIR validation, so the check runs here, where each instance's substitution
+ * is concrete and diagnostics are already reported.
+ *
+ * Scoped to reachable instances on purpose: a callable-bearing struct that is only declared, or
+ * only constructed in unreachable code, compiles and runs today and stays accepted.
+ */
+export const storedCallableViolations = (
+  self: Discovery,
+  index: DeclarationIndex.Index,
+): ReadonlyArray<Diagnostic.Diagnostic> => {
+  const reported = new Set<string>()
+  return Object.freeze(
+    self.instances.flatMap((instance) =>
+      instance.function.statements
+        .flatMap(Hir.statementExpressions)
+        .flatMap(Hir.expressionTree)
+        .flatMap((expression) => {
+          if (expression._tag !== 'Construct' && expression._tag !== 'ArrayConstruct') return []
+          const aggregate = Type.substitute(expression.type, instance.substitution)
+          const found = DeclarationIndex.storedCallable(index, aggregate)
+          if (found === undefined) return []
+          const diagnostic = Diagnostic.storedCallableConstruction(
+            Type.encode(aggregate),
+            found.path.length === 0 ? undefined : found.path.join('.'),
+            Type.encode(found.callable),
+            expression.span,
+          )
+          const key = `${expression.span.sourceId}:${expression.span.start}:${expression.span.end} ${diagnostic.message}`
+          if (reported.has(key)) return []
+          reported.add(key)
+          return [diagnostic]
+        }),
+    ),
+  )
+}
+
 /** Produces semantic diagnostics for every finite-discovery violation. */
 export const violationDiagnostics = (self: Discovery): ReadonlyArray<Diagnostic.Diagnostic> =>
   Object.freeze(

--- a/packages/compiler/src/Pipeline.ts
+++ b/packages/compiler/src/Pipeline.ts
@@ -510,6 +510,7 @@ export const realize = (
     Instances.copyDropViolations(instances, self.index),
     Instances.requirementBindingViolations(instances, self.index),
     Instances.unlowerableWitnessViolations(instances, self.index),
+    Instances.storedCallableViolations(instances, self.index),
     Instances.continuationAllocatorViolations(instances, self.index, self.results),
   )
   const specializationError =
@@ -620,6 +621,7 @@ export const prepare = (
     Instances.copyDropViolations(discovery, self.index),
     Instances.requirementBindingViolations(discovery, self.index),
     Instances.unlowerableWitnessViolations(discovery, self.index),
+    Instances.storedCallableViolations(discovery, self.index),
     Instances.continuationAllocatorViolations(discovery, self.index, self.results),
   )
   if (Diagnostic.hasErrors(diagnostics))

--- a/packages/compiler/src/Pipeline.ts
+++ b/packages/compiler/src/Pipeline.ts
@@ -482,6 +482,23 @@ export const frontendProject = Effect.fn('Pipeline.frontendProject')(function* (
   })
 })
 
+/**
+ * Every diagnostic family judged against reachable concrete instances, collected once so that
+ * `realize` and `prepare` cannot drift apart on which checks a specialized program must pass.
+ */
+const instanceViolationDiagnostics = (
+  self: Frontend,
+  discovery: Instances.Discovery,
+): ReadonlyArray<Diagnostic.Diagnostic> =>
+  Diagnostic.merge(
+    Instances.violationDiagnostics(discovery),
+    Instances.copyDropViolations(discovery, self.index),
+    Instances.requirementBindingViolations(discovery, self.index),
+    Instances.unlowerableWitnessViolations(discovery, self.index),
+    Instances.storedCallableViolations(discovery, self.index),
+    Instances.continuationAllocatorViolations(discovery, self.index, self.results),
+  )
+
 /** Derives immutable target/runtime facts from one completed frontend. */
 export const realize = (
   self: Frontend,
@@ -506,12 +523,7 @@ export const realize = (
   )
   const baseDiagnostics = Diagnostic.merge(
     self.diagnostics,
-    Instances.violationDiagnostics(instances),
-    Instances.copyDropViolations(instances, self.index),
-    Instances.requirementBindingViolations(instances, self.index),
-    Instances.unlowerableWitnessViolations(instances, self.index),
-    Instances.storedCallableViolations(instances, self.index),
-    Instances.continuationAllocatorViolations(instances, self.index, self.results),
+    instanceViolationDiagnostics(self, instances),
   )
   const specializationError =
     specializationInvalid || Diagnostic.hasGenericSpecializationErrors(baseDiagnostics)
@@ -520,6 +532,17 @@ export const realize = (
           message: 'Target-dependent phases are unavailable for invalid source specialization',
         })
       : undefined
+  // A stored-callable construction (SEM0103) names a program the layout planner cannot serve, so
+  // realization stops at the source diagnostic instead of producing an InvalidMir echo of it.
+  const instanceFenceError =
+    specializationError === undefined && Diagnostic.hasInstanceFenceErrors(baseDiagnostics)
+      ? new AnalysisUnavailable({
+          operation: 'Analysis.realize',
+          message:
+            'Target-dependent phases are unavailable while a reachable construction stores a bare callable',
+        })
+      : undefined
+  const realizationError = specializationError ?? instanceFenceError
   const targetLayout = measured(
     report,
     'target-layout',
@@ -527,8 +550,8 @@ export const realize = (
     () => {
       const target = Target.select(targetId)
       const layoutCatalog: Targeted<Layout.Catalog> =
-        specializationError !== undefined
-          ? Object.freeze({ _tag: 'Unavailable', error: specializationError })
+        realizationError !== undefined
+          ? Object.freeze({ _tag: 'Unavailable', error: realizationError })
           : target._tag === 'Resolved'
             ? Object.freeze({
                 _tag: 'Available',
@@ -617,12 +640,7 @@ export const prepare = (
   )
   const diagnostics = Diagnostic.merge(
     self.diagnostics,
-    Instances.violationDiagnostics(discovery),
-    Instances.copyDropViolations(discovery, self.index),
-    Instances.requirementBindingViolations(discovery, self.index),
-    Instances.unlowerableWitnessViolations(discovery, self.index),
-    Instances.storedCallableViolations(discovery, self.index),
-    Instances.continuationAllocatorViolations(discovery, self.index, self.results),
+    instanceViolationDiagnostics(self, discovery),
   )
   if (Diagnostic.hasErrors(diagnostics))
     return Object.freeze({

--- a/packages/compiler/test/StoredCallableDeterminism.test.ts
+++ b/packages/compiler/test/StoredCallableDeterminism.test.ts
@@ -1,0 +1,68 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+
+/**
+ * SEM0103 is part of the frontend's stable contract, so its reports must be byte-identical across
+ * fresh processes: same codes, messages, spans, related provenance, and ordering. The fixture
+ * covers a nested callable-bearing aggregate and one generic wrapper specialized twice, which is
+ * where an unstable iteration order or presentation-dependent key would first show up.
+ */
+
+interface Report {
+  readonly diagnostics: ReadonlyArray<{
+    readonly code: string
+    readonly message: string
+    readonly span: { readonly sourceId: string; readonly start: number; readonly end: number }
+    readonly related: ReadonlyArray<{
+      readonly label: string
+      readonly sourceId: string
+      readonly start: number
+      readonly end: number
+    }>
+  }>
+  readonly layout: string
+  readonly mir: string
+}
+
+it.effect('keeps SEM0103 reports byte-identical across fresh processes', () =>
+  Effect.gen(function* () {
+    const fixture = fileURLToPath(
+      new URL('./fixtures/stored-callable-determinism.mjs', import.meta.url),
+    )
+    const run = Effect.try(() => spawnSync(process.execPath, [fixture], { encoding: 'utf8' }))
+    const first = yield* run
+    const second = yield* run
+
+    assert.strictEqual(first.status, 0, first.stderr)
+    assert.strictEqual(second.status, 0, second.stderr)
+    assert.strictEqual(first.stdout, second.stdout)
+
+    const report = JSON.parse(first.stdout) as Report
+    // Two declared-field violations and two specializations of one generic wrapper.
+    assert.deepEqual(
+      report.diagnostics.map((diagnostic) => diagnostic.code),
+      ['SEM0103', 'SEM0103', 'SEM0103', 'SEM0103'],
+      report.diagnostics.map((diagnostic) => diagnostic.message).join('\n'),
+    )
+    // Merge order is span order: report ordering is a published fact, not an accident.
+    const positions = report.diagnostics.map((diagnostic) => diagnostic.span.start)
+    assert.deepEqual(
+      [...positions].sort((left, right) => left - right),
+      positions,
+    )
+    // Both wrapper specializations report at their own call sites in the user source.
+    for (const diagnostic of report.diagnostics) {
+      assert.strictEqual(diagnostic.span.sourceId, 'fixture/StoredCallable')
+    }
+    const related = report.diagnostics.flatMap((diagnostic) => diagnostic.related)
+    assert.deepEqual(
+      related.map((span) => span.label),
+      ['constructed here', 'constructed here'],
+    )
+    // The fence holds in the same breath: no layout or MIR is realized for the rejected program.
+    assert.strictEqual(report.layout, 'Unavailable')
+    assert.strictEqual(report.mir, 'Unavailable')
+  }),
+)

--- a/packages/compiler/test/StoredCallableDeterminism.test.ts
+++ b/packages/compiler/test/StoredCallableDeterminism.test.ts
@@ -1,7 +1,9 @@
-import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
+import { NodeServices } from '@effect/platform-node'
 import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
+import * as Path from 'effect/Path'
+import * as Stream from 'effect/Stream'
+import { ChildProcess } from 'effect/unstable/process'
 
 /**
  * SEM0103 is part of the frontend's stable contract, so its reports must be byte-identical across
@@ -26,17 +28,35 @@ interface Report {
   readonly mir: string
 }
 
+const collectText = Stream.runFold(
+  () => '',
+  (text: string, chunk: string) => text + chunk,
+)
+
+const runFixture = Effect.fnUntraced(function* (fixture: string) {
+  const handle = yield* ChildProcess.make(process.execPath, [fixture], { stdin: 'ignore' })
+  const [code, stdout, stderr] = yield* Effect.all(
+    [
+      handle.exitCode,
+      handle.stdout.pipe(Stream.decodeText(), collectText),
+      handle.stderr.pipe(Stream.decodeText(), collectText),
+    ],
+    { concurrency: 'unbounded' },
+  )
+  return { code, stdout, stderr }
+})
+
 it.effect('keeps SEM0103 reports byte-identical across fresh processes', () =>
   Effect.gen(function* () {
-    const fixture = fileURLToPath(
+    const path = yield* Path.Path
+    const fixture = yield* path.fromFileUrl(
       new URL('./fixtures/stored-callable-determinism.mjs', import.meta.url),
     )
-    const run = Effect.try(() => spawnSync(process.execPath, [fixture], { encoding: 'utf8' }))
-    const first = yield* run
-    const second = yield* run
+    const first = yield* runFixture(fixture)
+    const second = yield* runFixture(fixture)
 
-    assert.strictEqual(first.status, 0, first.stderr)
-    assert.strictEqual(second.status, 0, second.stderr)
+    assert.strictEqual(first.code, 0, first.stderr)
+    assert.strictEqual(second.code, 0, second.stderr)
     assert.strictEqual(first.stdout, second.stdout)
 
     const report = JSON.parse(first.stdout) as Report
@@ -64,5 +84,5 @@ it.effect('keeps SEM0103 reports byte-identical across fresh processes', () =>
     // The fence holds in the same breath: no layout or MIR is realized for the rejected program.
     assert.strictEqual(report.layout, 'Unavailable')
     assert.strictEqual(report.mir, 'Unavailable')
-  }),
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 )

--- a/packages/compiler/test/StoredCallableDeterminism.test.ts
+++ b/packages/compiler/test/StoredCallableDeterminism.test.ts
@@ -2,8 +2,7 @@ import { NodeServices } from '@effect/platform-node'
 import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Path from 'effect/Path'
-import * as Stream from 'effect/Stream'
-import { ChildProcess } from 'effect/unstable/process'
+import * as Process from './support/Process.js'
 
 /**
  * SEM0103 is part of the frontend's stable contract, so its reports must be byte-identical across
@@ -28,35 +27,17 @@ interface Report {
   readonly mir: string
 }
 
-const collectText = Stream.runFold(
-  () => '',
-  (text: string, chunk: string) => text + chunk,
-)
-
-const runFixture = Effect.fnUntraced(function* (fixture: string) {
-  const handle = yield* ChildProcess.make(process.execPath, [fixture], { stdin: 'ignore' })
-  const [code, stdout, stderr] = yield* Effect.all(
-    [
-      handle.exitCode,
-      handle.stdout.pipe(Stream.decodeText(), collectText),
-      handle.stderr.pipe(Stream.decodeText(), collectText),
-    ],
-    { concurrency: 'unbounded' },
-  )
-  return { code, stdout, stderr }
-})
-
 it.effect('keeps SEM0103 reports byte-identical across fresh processes', () =>
   Effect.gen(function* () {
     const path = yield* Path.Path
     const fixture = yield* path.fromFileUrl(
       new URL('./fixtures/stored-callable-determinism.mjs', import.meta.url),
     )
-    const first = yield* runFixture(fixture)
-    const second = yield* runFixture(fixture)
+    const first = yield* Process.run(process.execPath, [fixture])
+    const second = yield* Process.run(process.execPath, [fixture])
 
-    assert.strictEqual(first.code, 0, first.stderr)
-    assert.strictEqual(second.code, 0, second.stderr)
+    assert.strictEqual(first.exitCode, 0, first.stderr)
+    assert.strictEqual(second.exitCode, 0, second.stderr)
     assert.strictEqual(first.stdout, second.stdout)
 
     const report = JSON.parse(first.stdout) as Report

--- a/packages/compiler/test/StoredCallableDiagnostic.test.ts
+++ b/packages/compiler/test/StoredCallableDiagnostic.test.ts
@@ -2,7 +2,8 @@ import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, assert, it } from '@effect/vitest'
+import { assert, it } from '@effect/vitest'
+import type * as Cause from 'effect/Cause'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
 import * as Driver from '../src/Driver.js'
@@ -39,6 +40,21 @@ const messages = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
 /** Evaluated scalars can be BigInt, which plain JSON serialization refuses. */
 const describe = (outcome: unknown): string =>
   JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value))
+
+/** A scoped temporary directory: acquisition and cleanup stay inside the test's Effect. */
+const withTemporaryDirectory = <A, E, R>(
+  use: (directory: string) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | Cause.UnknownError, R> =>
+  Effect.acquireUseRelease(
+    Effect.try(() => mkdtempSync(join(tmpdir(), 'silk-stored-callable-'))),
+    use,
+    (directory) =>
+      Effect.try(() => rmSync(directory, { recursive: true, force: true })).pipe(Effect.ignore),
+  )
+
+/** One synchronous child execution behind an Effect boundary. */
+const runExecutable = (path: string) =>
+  Effect.try(() => spawnSync(path, [], { encoding: 'utf8' as const }))
 
 /** The minimal reproducer from #184, repaired so declaration and semantic analysis accept it. */
 const reproducer = `struct Parser<A> {
@@ -84,6 +100,19 @@ it.effect('rejects the #184 reproducer at both construction sites', () =>
   }),
 )
 
+it.effect('fences realization: SEM0103 leaves layout and MIR unavailable, not InvalidMir', () =>
+  Effect.gen(function* () {
+    // The diagnostic is only a real fence if nothing downstream of it is built: a snapshot that
+    // still carried a layout and MIR would reproduce the InvalidMir failure the diagnostic exists
+    // to replace.
+    const snapshot = yield* analyzed('stored-callable/fence', reproducer)
+    assert.include(codes(snapshot), 'SEM0103')
+    assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+    assert.strictEqual(snapshot.layout._tag, 'Unavailable')
+    assert.strictEqual(snapshot.mir._tag, 'Unavailable')
+  }),
+)
+
 it.effect('rejects a monomorphic construction that stores a partial application', () =>
   Effect.gen(function* () {
     const source = `struct Parser { decode: fn(i32) -> i32 }
@@ -96,10 +125,11 @@ pub fn main() -> i32 {
   }),
 )
 
-it.effect('rejects a generic wrapper whose inferred argument is a callable', () =>
+it.effect('points a generic wrapper violation at the specializing call site', () =>
   Effect.gen(function* () {
-    // The declared field type is `T`; only instance substitution makes it a callable, so the
-    // check has to run against specialized instances rather than declared field types.
+    // The declared field type is `T`; only instance substitution makes it a callable. The concrete
+    // callable was written at the call, so that is the primary origin, and the generic body's
+    // construction is retained as related provenance.
     const source = `struct Holder<T> { value: T }
 fn wrap<T>(value: T) -> Holder<T> { return Holder<T> { value: move value } }
 pub fn main() -> i32 {
@@ -108,6 +138,21 @@ pub fn main() -> i32 {
 }`
     const snapshot = yield* analyzed('stored-callable/generic-inferred', source)
     assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
+    const diagnostic = Analysis.diagnostics(snapshot).at(0)
+    assert.strictEqual(diagnostic?.span.sourceId, 'stored-callable/generic-inferred')
+    assert.strictEqual(
+      diagnostic === undefined
+        ? undefined
+        : source.slice(diagnostic.span.start, diagnostic.span.end).trim(),
+      'wrap(i32.add(1))',
+    )
+    assert.deepEqual(
+      diagnostic?.relatedSpans?.map((related) => [
+        related.label,
+        source.slice(related.span.start, related.span.end).trim(),
+      ]),
+      [['constructed here', 'Holder<T> { value: move value }']],
+    )
   }),
 )
 
@@ -160,11 +205,12 @@ pub fn main() -> i32 {
   }),
 )
 
-it.effect('rejects a stdlib construction reached only through inference', () =>
+it.effect('points a stdlib construction reached through inference at the user call', () =>
   Effect.gen(function* () {
-    // `Option.some(i32.add(1))` specializes `Some<T>` with a callable argument; the construction
-    // that cannot receive a layout is the one inside silk/option, so that is where the span
-    // points. Imperfect provenance, but a named source diagnostic rather than `InvalidMir`.
+    // `Option.some(i32.add(1))` specializes `Some<T>` with a callable argument. The construction
+    // that cannot receive a layout lives inside silk/option, but the callable was written at the
+    // user's call, so the primary span is the user source and the stdlib construction is related
+    // provenance.
     const source = `pub fn main() -> i32 {
   let optional = Option.some(i32.add(1))
   return 42
@@ -172,12 +218,13 @@ it.effect('rejects a stdlib construction reached only through inference', () =>
     const snapshot = yield* analyzed('stored-callable/stdlib-inference', source)
     assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
     const diagnostic = Analysis.diagnostics(snapshot).at(0)
-    assert.strictEqual(diagnostic?.span.sourceId, 'silk/option')
+    assert.strictEqual(diagnostic?.span.sourceId, 'stored-callable/stdlib-inference')
+    assert.deepEqual(
+      diagnostic?.relatedSpans?.map((related) => [related.label, related.span.sourceId]),
+      [['constructed here', 'silk/option']],
+    )
   }),
 )
-
-const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-stored-callable-'))
-afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
 
 /**
  * Callable-bearing declarations that never reach a live construction keep compiling, and the
@@ -211,18 +258,22 @@ it.effect(
       const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
       assert.strictEqual((instance.exports.silk_main as () => number)(), 42, 'wasm')
 
-      const compiled = yield* Driver.compile({
-        compilation: {
-          root: SourceFile.make('stored-callable/accepted', ascii(accepted)),
-        },
-        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-        profile: 'release',
-        destination: join(destinationRoot, 'accepted'),
-      }).pipe(Effect.provide(SourceResolver.empty))
-      assert.strictEqual(compiled._tag, 'Compiled')
-      if (compiled._tag !== 'Compiled') return
-      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
-      assert.strictEqual(run.status, 42, `native: ${run.stderr}`)
+      yield* withTemporaryDirectory((directory) =>
+        Effect.gen(function* () {
+          const compiled = yield* Driver.compile({
+            compilation: {
+              root: SourceFile.make('stored-callable/accepted', ascii(accepted)),
+            },
+            toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+            profile: 'release',
+            destination: join(directory, 'accepted'),
+          }).pipe(Effect.provide(SourceResolver.empty))
+          assert.strictEqual(compiled._tag, 'Compiled')
+          if (compiled._tag !== 'Compiled') return
+          const run = yield* runExecutable(compiled.path)
+          assert.strictEqual(run.status, 42, `native: ${run.stderr}`)
+        }),
+      )
     }),
   180_000,
 )

--- a/packages/compiler/test/StoredCallableDiagnostic.test.ts
+++ b/packages/compiler/test/StoredCallableDiagnostic.test.ts
@@ -1,0 +1,241 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Driver from '../src/Driver.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as SourceResolver from '../src/SourceResolver.js'
+
+/**
+ * The frontend/MIR contract at a stored callable (#184).
+ *
+ * A direct callable value works because the compiler still holds its hidden concrete identity;
+ * a struct field declared `fn(i32) -> i32` carries only the signature, so nominal layout planning
+ * cannot size the callable's environment. Until nominal values can carry that identity, a
+ * reachable construction that stores a bare callable is rejected with SEM0103 at the source site
+ * instead of passing a clean frontend and dying in MIR validation as `InvalidMir`.
+ *
+ * The boundary matters as much as the rejection: programs that work today keep working. That is
+ * why the check is scoped to reachable instances — a callable-bearing struct that is merely
+ * declared, named in a signature, or constructed only in unreachable code compiles and runs now,
+ * and stays accepted.
+ */
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const analyzed = (name: string, source: string) =>
+  Analysis.ofSourceRealized(name, ascii(source), 'wasm32-unknown-unknown')
+
+const codes = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code)
+
+const messages = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.message)
+
+/** Evaluated scalars can be BigInt, which plain JSON serialization refuses. */
+const describe = (outcome: unknown): string =>
+  JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value))
+
+/** The minimal reproducer from #184, repaired so declaration and semantic analysis accept it. */
+const reproducer = `struct Parser<A> {
+  decode: fn(i32) -> A
+}
+
+struct Nested<A> {
+  parser: Parser<A>
+}
+
+fn make<A>(decoder: fn(i32) -> A) -> Parser<A> {
+  return Parser<A> { decode: decoder }
+}
+
+fn nest<A>(parser: Parser<A>) -> Nested<A> {
+  return Nested<A> { parser: move parser }
+}
+
+fn parse<A>(self: &Parser<A>, input: i32) -> A {
+  return self.decode(input)
+}
+
+fn parseNested<A>(self: &Nested<A>, input: i32) -> A {
+  return self.parser.decode(input)
+}
+
+pub fn main() -> i32 {
+  let parser = make<i32>(i32.add(1))
+  let nested = nest<i32>(move parser)
+  let first = parseNested<i32>(&nested, 40)
+  return parse<i32>(&nested.parser, first)
+}`
+
+it.effect('rejects the #184 reproducer at both construction sites', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* analyzed('stored-callable/reproducer', reproducer)
+    assert.deepEqual(codes(snapshot), ['SEM0103', 'SEM0103'], messages(snapshot).join('\n'))
+    // The direct field and the nested aggregate each name the exact stored position.
+    assert.deepEqual(messages(snapshot), [
+      'Cannot construct stored-callable/reproducer.Parser<i32>: field decode would store the callable fn(i32) -> i32, whose environment layout depends on a hidden concrete identity that stored-callable/reproducer.Parser<i32> does not carry',
+      'Cannot construct stored-callable/reproducer.Nested<i32>: field parser.decode would store the callable fn(i32) -> i32, whose environment layout depends on a hidden concrete identity that stored-callable/reproducer.Nested<i32> does not carry',
+    ])
+  }),
+)
+
+it.effect('rejects a monomorphic construction that stores a partial application', () =>
+  Effect.gen(function* () {
+    const source = `struct Parser { decode: fn(i32) -> i32 }
+pub fn main() -> i32 {
+  let parser = Parser { decode: i32.add(1) }
+  return parser.decode(41)
+}`
+    const snapshot = yield* analyzed('stored-callable/monomorphic', source)
+    assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
+  }),
+)
+
+it.effect('rejects a generic wrapper whose inferred argument is a callable', () =>
+  Effect.gen(function* () {
+    // The declared field type is `T`; only instance substitution makes it a callable, so the
+    // check has to run against specialized instances rather than declared field types.
+    const source = `struct Holder<T> { value: T }
+fn wrap<T>(value: T) -> Holder<T> { return Holder<T> { value: move value } }
+pub fn main() -> i32 {
+  let held = wrap(i32.add(1))
+  return 42
+}`
+    const snapshot = yield* analyzed('stored-callable/generic-inferred', source)
+    assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
+  }),
+)
+
+it.effect('rejects a callable stored through an array field and a bare array literal', () =>
+  Effect.gen(function* () {
+    const throughField = `struct Parser { decode: [fn(i32) -> i32; 2] }
+pub fn main() -> i32 {
+  let parser = Parser { decode: [i32.add(1), i32.add(2)] }
+  return 42
+}`
+    const fieldSnapshot = yield* analyzed('stored-callable/array-field', throughField)
+    // Both the array literal and the enclosing struct construction are stored-callable sites.
+    assert.deepEqual(
+      codes(fieldSnapshot),
+      ['SEM0103', 'SEM0103'],
+      messages(fieldSnapshot).join('\n'),
+    )
+
+    const bare = `pub fn main() -> i32 {
+  let transforms = [i32.add(1), i32.add(2)]
+  return 42
+}`
+    const bareSnapshot = yield* analyzed('stored-callable/bare-array', bare)
+    assert.deepEqual(codes(bareSnapshot), ['SEM0103'], messages(bareSnapshot).join('\n'))
+  }),
+)
+
+it.effect('rejects a capturing closure stored in a nominal field', () =>
+  Effect.gen(function* () {
+    const source = `struct Parser { decode: fn(i32) -> i32 }
+pub fn main() -> i32 {
+  let offset = 1
+  let parser = Parser { decode: i32.add(offset) }
+  return 42
+}`
+    const snapshot = yield* analyzed('stored-callable/capturing', source)
+    assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
+  }),
+)
+
+it.effect('reports the stored callable alongside ownership findings for a once field', () =>
+  Effect.gen(function* () {
+    const source = `struct Parser { decode: once fn(i32) -> i32 }
+pub fn main() -> i32 {
+  let parser = Parser { decode: i32.add(1) }
+  return parser.decode(41)
+}`
+    const snapshot = yield* analyzed('stored-callable/once-field', source)
+    assert.include(codes(snapshot), 'SEM0103', messages(snapshot).join('\n'))
+  }),
+)
+
+it.effect('rejects a stdlib construction reached only through inference', () =>
+  Effect.gen(function* () {
+    // `Option.some(i32.add(1))` specializes `Some<T>` with a callable argument; the construction
+    // that cannot receive a layout is the one inside silk/option, so that is where the span
+    // points. Imperfect provenance, but a named source diagnostic rather than `InvalidMir`.
+    const source = `pub fn main() -> i32 {
+  let optional = Option.some(i32.add(1))
+  return 42
+}`
+    const snapshot = yield* analyzed('stored-callable/stdlib-inference', source)
+    assert.deepEqual(codes(snapshot), ['SEM0103'], messages(snapshot).join('\n'))
+    const diagnostic = Analysis.diagnostics(snapshot).at(0)
+    assert.strictEqual(diagnostic?.span.sourceId, 'silk/option')
+  }),
+)
+
+const destinationRoot = mkdtempSync(join(tmpdir(), 'silk-stored-callable-'))
+afterAll(() => rmSync(destinationRoot, { recursive: true, force: true }))
+
+/**
+ * Callable-bearing declarations that never reach a live construction keep compiling, and the
+ * asserted value — not compilation success — is the evidence on all three engines.
+ */
+const accepted = `struct Parser { decode: fn(i32) -> i32 }
+struct Nested { parser: Parser }
+
+fn size(self: &Parser) -> i32 { return 1 }
+
+fn unreachableConstruction() -> i32 {
+  let parser = Parser { decode: i32.add(1) }
+  return parser.decode(41)
+}
+
+pub fn main() -> i32 { return 42 }`
+
+it.effect(
+  'keeps declaration-only and unreachable callable fields compiling on all three engines',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyzed('stored-callable/accepted', accepted)
+      assert.deepEqual(messages(snapshot), [])
+
+      const evaluated = Analysis.evaluate(snapshot)
+      assert.strictEqual(evaluated._tag, 'Completed', describe(evaluated))
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42, 'evaluator')
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42, 'wasm')
+
+      const compiled = yield* Driver.compile({
+        compilation: {
+          root: SourceFile.make('stored-callable/accepted', ascii(accepted)),
+        },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'accepted'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 42, `native: ${run.stderr}`)
+    }),
+  180_000,
+)
+
+it.effect('leaves direct callable parameters and calls unchanged', () =>
+  Effect.gen(function* () {
+    const source = `fn apply(transform: once fn(i32) -> i32, value: i32) -> i32 { return transform(value) }
+pub fn main() -> i32 { return apply(i32.add(40), 2) }`
+    const snapshot = yield* analyzed('stored-callable/direct-call', source)
+    assert.deepEqual(messages(snapshot), [])
+    const evaluated = Analysis.evaluate(snapshot)
+    assert.strictEqual(evaluated._tag, 'Completed', describe(evaluated))
+    if (evaluated._tag !== 'Completed') return
+    assert.strictEqual(evaluated.result.value, 42)
+  }),
+)

--- a/packages/compiler/test/StoredCallableDiagnostic.test.ts
+++ b/packages/compiler/test/StoredCallableDiagnostic.test.ts
@@ -3,12 +3,11 @@ import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
 import * as Path from 'effect/Path'
-import * as Stream from 'effect/Stream'
-import { ChildProcess } from 'effect/unstable/process'
 import * as Analysis from '../src/Analysis.js'
 import * as Driver from '../src/Driver.js'
 import * as SourceFile from '../src/SourceFile.js'
 import * as SourceResolver from '../src/SourceResolver.js'
+import * as Process from './support/Process.js'
 
 /**
  * The frontend/MIR contract at a stored callable (#184).
@@ -40,24 +39,6 @@ const messages = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
 /** Evaluated scalars can be BigInt, which plain JSON serialization refuses. */
 const describe = (outcome: unknown): string =>
   JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value))
-
-const collectText = Stream.runFold(
-  () => '',
-  (text: string, chunk: string) => text + chunk,
-)
-
-const runExecutable = Effect.fnUntraced(function* (path: string) {
-  const process = yield* ChildProcess.make(path, [], { stdin: 'ignore' })
-  const [code, , stderr] = yield* Effect.all(
-    [
-      process.exitCode,
-      process.stdout.pipe(Stream.decodeText(), collectText),
-      process.stderr.pipe(Stream.decodeText(), collectText),
-    ],
-    { concurrency: 'unbounded' },
-  )
-  return { code, stderr }
-})
 
 /** The minimal reproducer from #184, repaired so declaration and semantic analysis accept it. */
 const reproducer = `struct Parser<A> {
@@ -274,8 +255,8 @@ it.effect(
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled')
       if (compiled._tag !== 'Compiled') return
-      const run = yield* runExecutable(compiled.path)
-      assert.strictEqual(run.code, 42, `native: ${run.stderr}`)
+      const run = yield* Process.run(compiled.path, [])
+      assert.strictEqual(run.exitCode, 42, `native: ${run.stderr}`)
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   180_000,
 )

--- a/packages/compiler/test/StoredCallableDiagnostic.test.ts
+++ b/packages/compiler/test/StoredCallableDiagnostic.test.ts
@@ -1,10 +1,10 @@
-import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { NodeServices } from '@effect/platform-node'
 import { assert, it } from '@effect/vitest'
-import type * as Cause from 'effect/Cause'
 import * as Effect from 'effect/Effect'
+import * as FileSystem from 'effect/FileSystem'
+import * as Path from 'effect/Path'
+import * as Stream from 'effect/Stream'
+import { ChildProcess } from 'effect/unstable/process'
 import * as Analysis from '../src/Analysis.js'
 import * as Driver from '../src/Driver.js'
 import * as SourceFile from '../src/SourceFile.js'
@@ -41,20 +41,23 @@ const messages = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
 const describe = (outcome: unknown): string =>
   JSON.stringify(outcome, (_, value) => (typeof value === 'bigint' ? value.toString() : value))
 
-/** A scoped temporary directory: acquisition and cleanup stay inside the test's Effect. */
-const withTemporaryDirectory = <A, E, R>(
-  use: (directory: string) => Effect.Effect<A, E, R>,
-): Effect.Effect<A, E | Cause.UnknownError, R> =>
-  Effect.acquireUseRelease(
-    Effect.try(() => mkdtempSync(join(tmpdir(), 'silk-stored-callable-'))),
-    use,
-    (directory) =>
-      Effect.try(() => rmSync(directory, { recursive: true, force: true })).pipe(Effect.ignore),
-  )
+const collectText = Stream.runFold(
+  () => '',
+  (text: string, chunk: string) => text + chunk,
+)
 
-/** One synchronous child execution behind an Effect boundary. */
-const runExecutable = (path: string) =>
-  Effect.try(() => spawnSync(path, [], { encoding: 'utf8' as const }))
+const runExecutable = Effect.fnUntraced(function* (path: string) {
+  const process = yield* ChildProcess.make(path, [], { stdin: 'ignore' })
+  const [code, , stderr] = yield* Effect.all(
+    [
+      process.exitCode,
+      process.stdout.pipe(Stream.decodeText(), collectText),
+      process.stderr.pipe(Stream.decodeText(), collectText),
+    ],
+    { concurrency: 'unbounded' },
+  )
+  return { code, stderr }
+})
 
 /** The minimal reproducer from #184, repaired so declaration and semantic analysis accept it. */
 const reproducer = `struct Parser<A> {
@@ -246,6 +249,9 @@ it.effect(
   'keeps declaration-only and unreachable callable fields compiling on all three engines',
   () =>
     Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
+      const directory = yield* fileSystem.makeTempDirectoryScoped()
       const snapshot = yield* analyzed('stored-callable/accepted', accepted)
       assert.deepEqual(messages(snapshot), [])
 
@@ -258,23 +264,19 @@ it.effect(
       const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
       assert.strictEqual((instance.exports.silk_main as () => number)(), 42, 'wasm')
 
-      yield* withTemporaryDirectory((directory) =>
-        Effect.gen(function* () {
-          const compiled = yield* Driver.compile({
-            compilation: {
-              root: SourceFile.make('stored-callable/accepted', ascii(accepted)),
-            },
-            toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-            profile: 'release',
-            destination: join(directory, 'accepted'),
-          }).pipe(Effect.provide(SourceResolver.empty))
-          assert.strictEqual(compiled._tag, 'Compiled')
-          if (compiled._tag !== 'Compiled') return
-          const run = yield* runExecutable(compiled.path)
-          assert.strictEqual(run.status, 42, `native: ${run.stderr}`)
-        }),
-      )
-    }),
+      const compiled = yield* Driver.compile({
+        compilation: {
+          root: SourceFile.make('stored-callable/accepted', ascii(accepted)),
+        },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: path.join(directory, 'accepted'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled')
+      if (compiled._tag !== 'Compiled') return
+      const run = yield* runExecutable(compiled.path)
+      assert.strictEqual(run.code, 42, `native: ${run.stderr}`)
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   180_000,
 )
 

--- a/packages/compiler/test/fixtures/stored-callable-determinism.mjs
+++ b/packages/compiler/test/fixtures/stored-callable-determinism.mjs
@@ -1,3 +1,4 @@
+import * as NodeRuntime from '@effect/platform-node/NodeRuntime'
 import * as Console from 'effect/Console'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../../dist/Analysis.js'
@@ -32,7 +33,7 @@ pub fn main() -> i32 {
   return 42
 }`
 
-await Effect.runPromise(
+NodeRuntime.runMain(
   Effect.gen(function* () {
     const snapshot = yield* Analysis.ofSourceRealized(
       'fixture/StoredCallable',

--- a/packages/compiler/test/fixtures/stored-callable-determinism.mjs
+++ b/packages/compiler/test/fixtures/stored-callable-determinism.mjs
@@ -1,3 +1,4 @@
+import * as Console from 'effect/Console'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../../dist/Analysis.js'
 
@@ -31,32 +32,33 @@ pub fn main() -> i32 {
   return 42
 }`
 
-const snapshot = await Effect.runPromise(
-  Analysis.ofSourceRealized(
-    'fixture/StoredCallable',
-    new TextEncoder().encode(source),
-    'wasm32-unknown-unknown',
-  ),
-)
-
-process.stdout.write(
-  JSON.stringify({
-    diagnostics: Analysis.diagnostics(snapshot).map((diagnostic) => ({
-      code: diagnostic.code,
-      message: diagnostic.message,
-      span: {
-        sourceId: diagnostic.span.sourceId,
-        start: diagnostic.span.start,
-        end: diagnostic.span.end,
-      },
-      related: (diagnostic.relatedSpans ?? []).map((related) => ({
-        label: related.label,
-        sourceId: related.span.sourceId,
-        start: related.span.start,
-        end: related.span.end,
-      })),
-    })),
-    layout: snapshot.layout._tag,
-    mir: snapshot.mir._tag,
+await Effect.runPromise(
+  Effect.gen(function* () {
+    const snapshot = yield* Analysis.ofSourceRealized(
+      'fixture/StoredCallable',
+      new TextEncoder().encode(source),
+      'wasm32-unknown-unknown',
+    )
+    yield* Console.log(
+      JSON.stringify({
+        diagnostics: Analysis.diagnostics(snapshot).map((diagnostic) => ({
+          code: diagnostic.code,
+          message: diagnostic.message,
+          span: {
+            sourceId: diagnostic.span.sourceId,
+            start: diagnostic.span.start,
+            end: diagnostic.span.end,
+          },
+          related: (diagnostic.relatedSpans ?? []).map((related) => ({
+            label: related.label,
+            sourceId: related.span.sourceId,
+            start: related.span.start,
+            end: related.span.end,
+          })),
+        })),
+        layout: snapshot.layout._tag,
+        mir: snapshot.mir._tag,
+      }),
+    )
   }),
 )

--- a/packages/compiler/test/fixtures/stored-callable-determinism.mjs
+++ b/packages/compiler/test/fixtures/stored-callable-determinism.mjs
@@ -1,0 +1,62 @@
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../../dist/Analysis.js'
+
+/**
+ * Nested and multiply-specialized stored-callable constructions: `Parser`/`Nested` violate through
+ * their declared fields, and `Holder<T>` violates twice through two distinct specializations, so
+ * the printed report exercises both provenance modes and the deterministic ordering between them.
+ */
+const source = `struct Parser<A> { decode: fn(i32) -> A }
+struct Nested<A> { parser: Parser<A> }
+struct Holder<T> { value: T }
+
+fn double(value: i32) -> i32 { return value * 2 }
+fn flag(value: i32) -> bool { return value > 0 }
+
+fn make<A>(decoder: fn(i32) -> A) -> Parser<A> {
+  return Parser<A> { decode: decoder }
+}
+
+fn nest<A>(parser: Parser<A>) -> Nested<A> {
+  return Nested<A> { parser: move parser }
+}
+
+fn wrap<T>(value: T) -> Holder<T> { return Holder<T> { value: move value } }
+
+pub fn main() -> i32 {
+  let parser = make<i32>(i32.add(1))
+  let nested = nest<i32>(move parser)
+  let doubled = wrap(double)
+  let flagged = wrap(flag)
+  return 42
+}`
+
+const snapshot = await Effect.runPromise(
+  Analysis.ofSourceRealized(
+    'fixture/StoredCallable',
+    new TextEncoder().encode(source),
+    'wasm32-unknown-unknown',
+  ),
+)
+
+process.stdout.write(
+  JSON.stringify({
+    diagnostics: Analysis.diagnostics(snapshot).map((diagnostic) => ({
+      code: diagnostic.code,
+      message: diagnostic.message,
+      span: {
+        sourceId: diagnostic.span.sourceId,
+        start: diagnostic.span.start,
+        end: diagnostic.span.end,
+      },
+      related: (diagnostic.relatedSpans ?? []).map((related) => ({
+        label: related.label,
+        sourceId: related.span.sourceId,
+        start: related.span.start,
+        end: related.span.end,
+      })),
+    })),
+    layout: snapshot.layout._tag,
+    mir: snapshot.mir._tag,
+  }),
+)

--- a/packages/compiler/test/support/Process.ts
+++ b/packages/compiler/test/support/Process.ts
@@ -1,0 +1,29 @@
+import * as Effect from 'effect/Effect'
+import * as Stream from 'effect/Stream'
+import { ChildProcess } from 'effect/unstable/process'
+
+/** The captured result of one scoped test process. */
+export interface Result {
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+const collectText = Stream.runFold(
+  () => '',
+  (text: string, chunk: string) => text + chunk,
+)
+
+/** Runs one command while concurrently draining both output streams. */
+export const run = Effect.fnUntraced(function* (command: string, args: ReadonlyArray<string>) {
+  const process = yield* ChildProcess.make(command, args, { stdin: 'ignore' })
+  const [exitCode, stdout, stderr] = yield* Effect.all(
+    [
+      process.exitCode,
+      process.stdout.pipe(Stream.decodeText(), collectText),
+      process.stderr.pipe(Stream.decodeText(), collectText),
+    ],
+    { concurrency: 'unbounded' },
+  )
+  return Object.freeze({ exitCode, stdout, stderr })
+})

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -16,11 +16,11 @@ $ pnpm --filter @silk-effect/compiler documentation:generate
 | `LEX` | Lexical | 7 |
 | `PAR` | Parser | 4 |
 | `MOD` | Module | 4 |
-| `SEM` | Semantic | 101 |
+| `SEM` | Semantic | 102 |
 | `OWN` | Ownership | 12 |
 | `LAY` | Layout | 1 |
 
-There are 129 codes in total.
+There are 130 codes in total.
 
 ## Lexical (`LEX`)
 
@@ -157,6 +157,7 @@ There are 129 codes in total.
 | `SEM0100` | Stable code for an explicit type argument contradicting the type its value arguments imply. | `Type argument <parameter> of <target> is <written>, but the supplied values imply <implied>` |
 | `SEM0101` | Stable code for a bound operation whose selected witness has no lowering. | `<spelling> has no witness that can be lowered for <provider>` |
 | `SEM0102` | Stable code for selecting a suspending provider to allocate continuation storage. | `Allocator <provider> cannot provide continuation storage because <implementation> can suspend` |
+| `SEM0103` | Stable code for constructing an aggregate that stores a bare callable value. | `Cannot construct <aggregate>: <site> would store the callable <callable>, whose environment layout depends on a hidden concrete identity that <aggregate> does not carry` |
 
 ## Ownership (`OWN`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-beta.102
     devDependencies:
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.103
+        version: 4.0.0-beta.103(effect@4.0.0-beta.102)(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)


### PR DESCRIPTION
The diagnostic prerequisite for #184's design decision: a program that stores a bare callable in a nominal struct field used to pass semantic analysis with zero diagnostics and then die in MIR construction (`MissingTypeLayout`, `InvalidAggregateOperation`, downstream loan/call-shape violations) — or, for the monomorphic construct-and-call shape, as a `Trap: unavailable body` from `Lower.ts:4584`. Now every such construction gets a precise semantic diagnostic at the source site, and realization stops there. This does **not** implement callable storage itself; the representation choice between the issue's strategies 1 and 2 is left open, with a full strategy evaluation posted as a comment on #184.

## Reproducer characterization

The issue's reproducer references an undeclared type `A` and omits `pub` on `main`. Repaired (made `Parser`/`Nested` and the four functions generic over `A`, instantiated at `i32`; added `pub`, explicit `return`s, and the `move`s ownership requires), it fails exactly as the issue describes: empty frontend diagnostics, then `InvalidMir` with `MissingTypeLayout` for `Parser`/`Nested` (from `layoutType`'s callable refusal propagating through `layoutNominal`'s field walk), `InvalidAggregateOperation` at both constructions, and `InvalidCallShape`/`InvalidLoan` downstream. The issue's `layoutNominal` → `layoutType` account is confirmed.

One additional failure mode not in the issue: a monomorphic `Parser { decode: i32.add(1) }` followed by `parser.decode(41)` dies as an evaluator `Trap: unavailable body` rather than `InvalidMir`, because lowering the projection call produces an undefined region and `Lower.ts` substitutes a trap function. Same root cause, same fix.

## What changed

- **`Diagnostic.ts`** — `SEM0103` (`storedCallableConstructionCode`), the next free code after `SEM0102`. Message names the aggregate, the field path down to the callable (`field parser.decode` for the nested case), and the callable type. `hasInstanceFenceErrors` is the dedicated instance-fence predicate.
- **Realization fence** — `Pipeline.realize` stops target-dependent phases on SEM0103: layout catalog, layout plan, and MIR are all `Unavailable` behind an `AnalysisUnavailable` naming the stored callable, so the source diagnostic is the only reported failure rather than being echoed by `InvalidMir`. `prepare` already rejected on any error diagnostic; both paths now share one `instanceViolationDiagnostics` collector so they cannot drift.
- **`DeclarationIndex.storedCallable`** — a target-independent predicate mirroring what `Layout.layoutType` refuses: struct fields after substitution, fixed-array and slice elements, union members. It deliberately does not descend through references (address-only layout), intrinsic nominals, or Effect types (hidden environments plan callables from concrete identities).
- **`Instances.storedCallableViolations`** — walks each reachable instance's `Construct`/`ArrayConstruct` expressions with the instance's concrete substitution. Provenance follows where the callable was written: a construction whose declared type already stores a callable (`Parser<A> { decode: fn(i32) -> A }`) reports at its own span; one that stores a callable only through substitution (`Holder<T> { value: T }` specialized at a callable) reports at the deterministic earliest specializing call site (ordered by source ID, then position), with the generic body's construction retained as `constructed here` related provenance. `Option.some(i32.add(1))` therefore points at the user's call, not into `silk/option`. Deduplication uses a named structural key over the diagnostic identity and reason facts (the previous key was a presentation-dependent string with a raw NUL delimiter).
- **`packages/language/docs/diagnostics.md`** — regenerated via `pnpm --filter @silk-effect/compiler documentation:generate`.

## Scope: what still compiles

The check is scoped to **reachable instances**, because characterization showed these all work today (verified by returned values, not compilation success):

- callable-bearing structs that are only declared, or named in signatures;
- constructions inside unreachable (never-called) functions — pinned by a three-engine value-asserting test;
- direct callable locals, parameters, partial applications, and higher-order monomorphization (`IndirectCallAcceptance` untouched);
- all stdlib Effect machinery (callable *parameters*, hidden environments).

## Tests

`StoredCallableDiagnostic.test.ts`: the repaired #184 reproducer (both construction sites, exact messages), a realization-fence regression asserting layout catalog, layout plan, and MIR are all `Unavailable` for the reproducer, monomorphic construct+call, generic-inferred wrapper with call-site span and related-provenance assertions, stdlib-inference case asserting the user source ID as primary span and `silk/option` as related provenance, array field + bare array literal, capturing closure field, `once` field, a three-engine (evaluator/Wasm/native) value-asserting acceptance test, and a direct-call regression baseline. Temporary-directory acquisition/cleanup and child execution sit behind scoped Effect boundaries (`Effect.acquireUseRelease` + `Effect.try`), with assertions inside the Effect tests.

`StoredCallableDeterminism.test.ts` + `fixtures/stored-callable-determinism.mjs`: a fresh-process fixture spawned twice, asserting byte-identical stdout and pinning SEM0103 codes, messages, spans, related provenance, ordering (span order), and the realization fence for nested and multiply-specialized constructions.

`pnpm check` run before handoff; result reported in the PR thread.

Refs #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2i2LLZBYb1aiWcKd4MsVs