### PR TITLE
docs: propose static composition support

### DIFF
--- a/openspec/changes/add-opaque-representation-results/.openspec.yaml
+++ b/openspec/changes/add-opaque-representation-results/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/add-opaque-representation-results/design.md
+++ b/openspec/changes/add-opaque-representation-results/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Representation parameters make concrete identities part of complete nominal contracts. Named
+callable items can sometimes expose an exact identity, but capturing sections and Effects are
+construction-site values whose implementation must remain private across public result boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide exact and opaque source contracts for representation-dependent results.
+- Keep opaque equality stable across body-only edits while invalidating changed realizations.
+- Support generic producers without runtime existential packaging.
+
+**Non-Goals:**
+
+- Hide multiple runtime representations behind one result.
+- Add uniform closures, allocation, reflection, or indirect calls.
+- Make local construction-site identities directly source-nameable.
+
+## Decisions
+
+### Restrict `typeof` to exact named callable items
+
+Resolve `typeof(item)` during declaration analysis only after overload and generic specialization are
+complete. The item must be sufficiently visible for the containing contract. Sections, locals,
+Effect sites, partial generics, and private leaks use an opaque result or fail. This keeps exact
+source identity deterministic and navigable.
+
+### Make `some` a contextual scoped result binder
+
+Parse `some<F: Contract> Result` only in result-binder position. The binder scopes over the entire
+result so one opaque representation can occur multiple times. `some` hides one static family, not a
+runtime package.
+
+### Separate family key, public signature, instance, and realization
+
+Use `(producer canonical identity, binder ordinal)` as the stable family key. Add normalized public
+bound, result occurrences, and enclosing binder kinds to the public semantic signature. Apply every
+enclosing concrete type, row, and representation argument to obtain a family instance. The private
+realization then records target or runner, captures, access, cleanup, and suspendability.
+
+This separates source equality from body invalidation. Changing only a captured value preserves the
+public instance; changing the bound changes the public signature; changing target or capture shape
+changes private fingerprints and invalidates lowering.
+
+### Publish private realization dependencies across modules
+
+Export compiler-internal opaque definition records separately from public module semantic surfaces.
+Importers may specialize and invalidate from these records but tooling outside the producer reveals
+only the opaque origin and bound.
+
+### Require one finite realization per producer specialization
+
+Analyze every reachable return for one opaque binder and specialization. They must unify to one
+representation. Recursive returns may reuse a realization established by a local construction;
+realization-only recursion and inline self-layout cycles fail.
+
+## Risks / Trade-offs
+
+- [Stable public key can leave stale layout caches] → Track body/target and layout/access/cleanup
+  fingerprints as separate mandatory dependencies.
+- [Opaque privacy can impede debugging] → Present producer origin and public bound while keeping
+  captures and private target hidden.
+- [Generic families multiply instances] → Key them by normalized enclosing arguments and reuse
+  identical specializations deterministically.
+
+## Migration Plan
+
+1. Add parsing, formatting, and damaged recovery for `typeof` and contextual `some`.
+2. Add family/public-signature facts and visibility validation.
+3. Add producer-body realization unification and recursion checks.
+4. Publish private realization dependency records and invalidation fingerprints.
+5. Add inspector, navigation, and fresh-process invalidation fixtures.
+
+The feature can be rolled back by rejecting the new result forms; no runtime ABI is introduced.

--- a/openspec/changes/add-opaque-representation-results/proposal.md
+++ b/openspec/changes/add-opaque-representation-results/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Public functions that construct capturing callables or Effects need a stable result contract even
+when their concrete representation has no source-nameable item. Inferred public results and exposed
+construction-site identities both make library boundaries unstable.
+
+## What Changes
+
+- Add exact `typeof(item)` representation arguments for fully specialized, sufficiently visible
+  named callable items.
+- Add contextual scoped `some<F: Contract> Result` binders for one declaration-owned opaque
+  representation family.
+- Separate the stable family key, versioned public signature, specialized family instance, and
+  private realization/invalidation fingerprints.
+- Require one realization per producer specialization and reject divergent returns, recursive
+  realization cycles, private exact-identity leaks, and unresolved items.
+- Keep opaque results static and monomorphic; they do not introduce existential packaging, runtime
+  dispatch, or implicit allocation.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-opaque-representation-results`: Exact and opaque result syntax, visibility, equality,
+  realization, privacy, recursion, and incremental invalidation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Depends on `introduce-representation-parameters`. Affects parsing/formatting, public declaration
+contracts, module dependency surfaces, HIR, specialization, layout dependencies, tooling, and
+incremental invalidation.

--- a/openspec/changes/add-opaque-representation-results/specs/bootstrap-opaque-representation-results/spec.md
+++ b/openspec/changes/add-opaque-representation-results/specs/bootstrap-opaque-representation-results/spec.md
@@ -1,0 +1,77 @@
+## Purpose
+
+Define stable exact and opaque source contracts for functions that return representation-dependent
+values while keeping every realization static, private, and monomorphic.
+
+## ADDED Requirements
+
+### Requirement: Exact identities name resolved visible callable items
+
+`typeof(item)` SHALL name the exact representation of one fully specialized named callable item.
+The item MUST be at least as visible as the exposing contract; local bindings, sections, Effect
+construction sites, private leaks, overloaded items, and partially specialized generic items MUST
+be rejected with a diagnostic directing source to an opaque result when appropriate.
+
+#### Scenario: Name a specialized public function
+- **WHEN** a public result contains `typeof(identity<i32>)` and that item is sufficiently visible
+- **THEN** the result contract records the exact named-item representation
+
+#### Scenario: Reject a private exact identity leak
+- **WHEN** a public result names a private function through `typeof`
+- **THEN** analysis rejects the public contract and suggests an opaque representation result
+
+### Requirement: Opaque results bind one static representation family
+
+The contextual result syntax `some<F: Contract> Result` SHALL bind one declaration-owned opaque
+representation over the complete result. Its stable family key SHALL use producer identity and
+binder ordinal; its public signature SHALL also include the normalized bound, result occurrences,
+and enclosing binder kinds.
+
+#### Scenario: Return one capturing parser family
+- **WHEN** repeated calls to one producer capture different runtime values at the same specialization
+- **THEN** callers observe one opaque family instance and one layout while the captures remain data
+
+#### Scenario: Keep producers distinct
+- **WHEN** two declarations expose equivalent opaque bounds and result shapes
+- **THEN** their family keys remain distinct and their results do not join implicitly
+
+### Requirement: Opaque families specialize over enclosing arguments
+
+An opaque family instance SHALL include every enclosing concrete type, row, and representation
+argument that can affect its realization. All reachable returns for one producer specialization and
+opaque binder MUST resolve to one concrete representation; divergent return identities MUST fail in
+the producer.
+
+#### Scenario: Specialize a generic opaque producer
+- **WHEN** one opaque producer is called at `i32` and `Token`
+- **THEN** each specialization receives its own family instance and may realize a different layout
+
+#### Scenario: Reject divergent opaque branches
+- **WHEN** one opaque producer branch returns a hex parser and another returns a decimal parser
+- **THEN** the producer is rejected because one family instance cannot have two realizations
+
+### Requirement: Private realizations drive invalidation
+
+Each externally used opaque family SHALL publish a compiler-private realization definition with
+target or runner, concrete arguments, capture layout, access, cleanup, and deterministic body and
+layout fingerprints. Fingerprints SHALL drive dependent invalidation without participating in
+source type equality or revealing private representation details.
+
+#### Scenario: Preserve identity across a value-only edit
+- **WHEN** a producer changes captured data without changing target or capture shape
+- **THEN** its public opaque identity and reusable layout remain stable while the producer body invalidates
+
+#### Scenario: Invalidate a capture-shape edit
+- **WHEN** a hidden realization adds an owned capture
+- **THEN** dependent ownership, layout, MIR, and emitted artifacts invalidate even though the public
+  opaque signature is unchanged
+
+### Requirement: Opaque realization is finite and non-existential
+
+An opaque result SHALL NOT package a runtime type, choose a representation per execution, allocate
+implicitly, or dispatch indirectly. A recursive producer MUST establish its realization from a local
+construction before recursive use; realization-only cycles and inline layout cycles MUST be rejected.
+
+#### Scenario: Reject a realization-only recursion
+- **WHEN** an opaque producer's only representation evidence is a recursive call to itself
+- **THEN** analysis reports an opaque-realization cycle before instance discovery

--- a/openspec/changes/add-opaque-representation-results/tasks.md
+++ b/openspec/changes/add-opaque-representation-results/tasks.md
@@ -1,0 +1,30 @@
+## 1. Prerequisite and Syntax
+
+- [ ] 1.1 Confirm `introduce-representation-parameters` is complete and its runtime storage fences remain active.
+- [ ] 1.2 Add fully specialized `typeof(item)` parsing, formatting, syntax correspondence, and damaged recovery.
+- [ ] 1.3 Add contextual scoped `some<F: Contract> Result` parsing, formatting, and binder resolution.
+
+## 2. Exact Identity Contracts
+
+- [ ] 2.1 Resolve exact named callable identities only after overload and generic specialization are complete.
+- [ ] 2.2 Enforce public-contract visibility and reject locals, sections, Effects, private leaks, and partial generic items.
+- [ ] 2.3 Add navigation and diagnostics for valid and invalid exact identity contracts.
+
+## 3. Opaque Families and Realizations
+
+- [ ] 3.1 Add stable family keys, normalized public signatures, and family instances over enclosing kinded arguments.
+- [ ] 3.2 Unify every reachable producer return to one realization per opaque binder and specialization.
+- [ ] 3.3 Reject divergent returns, realization-only recursion, and inline opaque layout cycles.
+- [ ] 3.4 Publish privacy-preserving compiler-internal realization definitions for cross-module specialization.
+
+## 4. Invalidation
+
+- [ ] 4.1 Add separate target/body and layout/access/cleanup/suspendability fingerprints as incremental dependencies.
+- [ ] 4.2 Implement the bounded opaque invalidation slice for value-only, target-only, capture-shape, suspendability, bound, and binder-order edits.
+- [ ] 4.3 Add fresh-process equality, privacy, and invalidation assertions for generic opaque producers.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 5.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 5.3 Verify opaque results introduce no runtime descriptor, allocation, indirect call, or existential join.

--- a/openspec/changes/admit-conditional-generic-conformances/.openspec.yaml
+++ b/openspec/changes/admit-conditional-generic-conformances/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/admit-conditional-generic-conformances/design.md
+++ b/openspec/changes/admit-conditional-generic-conformances/design.md
@@ -1,0 +1,69 @@
+## Context
+
+Silk indexes parametric conformances and can specialize existing witnesses, but generic wrappers
+cannot declare that their own conformance depends on a parameter's conformance. Arbitrary recursive
+proof search would threaten coherence and termination, so the admitted form is deliberately
+conservative.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Admit bounded generic conformances with deterministic static witnesses.
+- Make overlap decidable at declaration time and proof search structurally terminating.
+- Produce useful proof and cycle diagnostics.
+
+**Non-Goals:**
+
+- Specialization by negative bounds, overlapping instances, interface inheritance, runtime
+  dictionaries, coinductive proofs, or compiler-configurable semantic fuel.
+- Implicit `Self` or `where` syntax.
+
+## Decisions
+
+### Put requirements in `impl<...>`
+
+Reuse the generic parameter list for type, row, representation, and interface-bound parameters.
+Interface applications continue to state the provider explicitly and the provider must equal the
+`for` type in the conformance head.
+
+### Reject possible overlap by head unification
+
+At indexing, alpha-normalize and conservatively ask whether provider/interface heads may unify.
+Ignore bounds. Types use first-order unification; normalized closed rows compare canonically; open
+rows use finite row unification or conservatively overlap; representation variables overlap when a
+common admissible concrete representation cannot be disproved. False-positive rejection is preferred
+to runtime-dependent coherence.
+
+### Enforce strict provider descent
+
+For every requirement, its provider must be a strict structural subterm of the `for` provider,
+generic-variable occurrences across the goal cannot increase, and ground non-provider arguments may
+only remain unchanged. This accepts `MappedSchema<S>` requiring `S` and nested `OptionalSchema<S>`
+while rejecting peer, equal, and growing providers. Active-goal cycle detection is defensive recovery,
+not the termination proof.
+
+### Prove at concrete specialization
+
+HIR retains a canonical interface goal and conformance candidates. Reachable instance discovery
+substitutes all concrete arguments, follows requirements to base witnesses, memoizes completed proofs,
+and emits one direct witness target. In-progress goals cannot satisfy themselves.
+
+## Risks / Trade-offs
+
+- [Conservative overlap rejects useful disjoint cases] → Require distinct wrapper heads rather than
+  making coherence depend on an evolving proof graph.
+- [Structural descent is less expressive than general logic programming] → Keep the first feature
+  finite and explain rejected sizes in diagnostics.
+- [Damaged facts create spurious cycles] → Preserve unavailable states and use active-stack traces for
+  recovery without treating them as valid witnesses.
+
+## Migration Plan
+
+1. Parse/index bounded impl headers and explicit requirements.
+2. Add kind-aware may-overlap and termination validation.
+3. Add canonical proof goals, memoization, and diagnostics.
+4. Integrate HIR questions and concrete witness discovery.
+5. Verify no MIR/runtime dictionary is introduced.
+
+Rollback rejects bounded impl declarations while existing unconditional conformances remain unchanged.

--- a/openspec/changes/admit-conditional-generic-conformances/proposal.md
+++ b/openspec/changes/admit-conditional-generic-conformances/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Generic wrappers cannot currently preserve the compile-time capabilities of the values they wrap.
+Static schema and command composition needs a conformance such as `MappedSchema<S, F>: Decoder`
+whenever `S: Decoder`, without runtime dictionaries or compiler-known actor names.
+
+## What Changes
+
+- Add bounded `impl<...>` declarations whose requirements are proved at concrete specialization.
+- Index generic conformance heads and reject possible overlap at declaration time using conservative,
+  kind-aware unification that ignores bounds.
+- Require strict structural descent of the provider, non-increasing variable occurrences, and
+  unchanged-only ground non-provider arguments so proof search terminates.
+- Emit finite requirement and active-cycle traces for failed proofs.
+- Preserve one statically selected witness per concrete provider/interface specialization with no
+  runtime dictionary or interface dispatch.
+- **BREAKING**: reject overlapping conditional heads even when their bounds appear mutually
+  exclusive.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-conditional-interface-conformance`: Bounded conformance syntax, coherence,
+  termination, proof search, specialization, and diagnostics.
+
+### Modified Capabilities
+
+- `bootstrap-declaration-index`: Index conditional generic heads, requirements, overlap state, and
+  termination facts.
+- `bootstrap-instances`: Discover and key concrete conditional witnesses and their transitive proof
+  requirements.
+
+## Impact
+
+Builds on existing user-interface witnesses and multi-operation bounds; representation-bounded
+impls additionally depend on `introduce-representation-parameters`. Affects parsing, declaration
+indexing, semantic proof search, HIR witness questions, instances, diagnostics, and determinism.

--- a/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-conditional-interface-conformance/spec.md
+++ b/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-conditional-interface-conformance/spec.md
@@ -1,0 +1,66 @@
+## Purpose
+
+Define bounded generic interface conformances with coherent, terminating compile-time proof search
+and statically specialized witnesses.
+
+## ADDED Requirements
+
+### Requirement: Conformance declarations bind requirements inline
+
+`impl<...>` SHALL bind ordinary, row, and representation parameters plus interface requirements in
+its parameter list. Every interface application SHALL explicitly include a provider equal to the
+`for` type; this capability SHALL NOT add implicit `Self` or `where` syntax.
+
+#### Scenario: Declare a mapped conformance
+- **WHEN** `MappedSchema<A, B, S, F>` declares a decoder conformance requiring a decoder for `S`
+- **THEN** the index records the generic head and required provider relationship
+
+### Requirement: Conditional heads are coherent at declaration time
+
+The declaration index SHALL reject any two provider/interface heads that may overlap after
+alpha-normalization and kind-aware conservative unification, without consulting their bounds.
+Ordinary types SHALL use first-order unification; normalized rows and representation bounds SHALL
+conservatively overlap whenever a common admissible argument cannot be disproved.
+
+#### Scenario: Reject bound-distinguished overlap
+- **WHEN** two wrapper conformances have unifying heads but different `Left` and `Right` requirements
+- **THEN** declaration analysis rejects the overlap even if no current type satisfies both bounds
+
+#### Scenario: Reject open-row overlap
+- **WHEN** one head contains row variable `!E` and another contains a compatible closed failure row
+- **THEN** kind-aware overlap treats the heads as potentially ambiguous
+
+### Requirement: Conditional proof search terminates structurally
+
+Every required provider SHALL be a strict structural subterm of the current `for` provider, generic
+variable occurrences across the complete goal SHALL not increase, and ground non-provider interface
+arguments SHALL remain unchanged. Requirements that construct an equal provider, peer, or superterm
+MUST be rejected at declaration time.
+
+#### Scenario: Accept nested optional schemas
+- **WHEN** proving `Decoder` for nested `OptionalSchema<S>` repeatedly requires the immediate inner provider
+- **THEN** proof search descends to the base witness and terminates
+
+#### Scenario: Reject a growing provider
+- **WHEN** a requirement replaces provider `S` with `Wrap<S>`
+- **THEN** declaration analysis reports the non-decreasing provider sizes
+
+### Requirement: Concrete specialization proves every requirement
+
+At each reachable concrete interface goal, analysis SHALL prove all conditional requirements before
+admitting one witness. Missing, unavailable, non-terminating, or cyclic proofs MUST retain a finite
+requirement trace and MUST NOT create runtime dictionaries or provisional witnesses.
+
+#### Scenario: Report a missing base witness
+- **WHEN** one mapped provider's source type lacks the required decoder conformance
+- **THEN** the call is rejected with the conditional requirement chain
+
+### Requirement: Conditional witnesses remain static and deterministic
+
+Each admitted concrete provider/interface pair SHALL select one canonical witness instance and
+deterministic proof. HIR and instance discovery SHALL retain the unresolved goal until concrete
+specialization, then MIR SHALL contain only the selected static target.
+
+#### Scenario: Specialize one conditional conformance twice
+- **WHEN** two concrete mapped schemas satisfy the same generic conformance declaration
+- **THEN** discovery records two deterministic concrete witness keys and no runtime interface lookup

--- a/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-declaration-index/spec.md
+++ b/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-declaration-index/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Parametric conformances join the canonical index
+
+The declaration index SHALL record parametric conformances with their complete kinded parameter
+lists, conditional interface requirements, canonical provider/interface heads, mapped operations,
+visibility, overlap state, and structural-termination facts. It SHALL validate restricted Drop hook
+shape against the generic target and SHALL conservatively reject possibly overlapping conditional
+heads without consulting their bounds. Validation that depends on a concrete instantiation SHALL be
+deferred to specialization.
+
+#### Scenario: Index a parametric Drop hook
+- **WHEN** the index processes `impl<T> Drop for Vector<T>` whose hook is `fn drop(self: &mut Vector<T>) -> ()`
+- **THEN** the hook validates with `T` in scope and the conformance fact records the parameter list and generic target
+
+#### Scenario: Index a conditional user conformance
+- **WHEN** a wrapper conformance declares one strict-subterm provider requirement
+- **THEN** the canonical header records that requirement and its finite structural measure
+
+#### Scenario: Reject overlapping conditional heads
+- **WHEN** two declarations have provider/interface heads that may unify despite different bounds
+- **THEN** indexing reports deterministic overlap before either bound is proved
+
+#### Scenario: Header validation still rejects malformed hooks
+- **WHEN** a parametric Drop hook declares extra parameters, a failure row, or a mismatched self type
+- **THEN** the index reports the existing invalid-Drop-hook diagnostic without waiting for an instantiation

--- a/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-instances/spec.md
+++ b/openspec/changes/admit-conditional-generic-conformances/specs/bootstrap-instances/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Parametric conformances monomorphize per instantiation
+
+Instance discovery SHALL resolve capability dispatch and Drop cleanup for generic nominal types
+through parametric and conditional conformances, substituting the instantiation's concrete kinded
+arguments into the conformance head and proving every strict-subterm requirement. Each reachable
+provider/interface instantiation SHALL produce exactly one concrete witness or hook instance with a
+canonical normalized key, and the worklist SHALL remain finite without runtime dictionaries.
+
+#### Scenario: One parametric Drop serves two element types
+- **WHEN** a program makes `Vector<Token>` and `Vector<i32>` reachable under one `impl<T> Drop for Vector<T>`
+- **THEN** discovery yields exactly two concrete Drop hook instances whose keys carry the normalized concrete arguments, and no third instance for the unsubstituted form
+
+#### Scenario: Parametric witnesses dispatch like concrete ones
+- **WHEN** a capability requirement is satisfied by a provider whose conformance is parametric
+- **THEN** the run site dispatches to the substituted concrete operation identically to an equivalent hand-written concrete conformance
+
+#### Scenario: Conditional witness follows its proof dependencies
+- **WHEN** a reachable mapped provider requires and finds one concrete source-provider witness
+- **THEN** discovery records the source witness and one mapped witness before lowering the static target

--- a/openspec/changes/admit-conditional-generic-conformances/tasks.md
+++ b/openspec/changes/admit-conditional-generic-conformances/tasks.md
@@ -1,0 +1,31 @@
+## 1. Syntax and Indexing
+
+- [ ] 1.1 Add bounded `impl<...>` syntax with explicit provider applications and no `where` or implicit `Self`.
+- [ ] 1.2 Index complete kinded binders, requirements, provider/interface heads, mapped operations, and unavailable states.
+- [ ] 1.3 Add formatter, syntax-correspondence, duplicate, damaged, and wrong-provider fixtures.
+
+## 2. Coherence and Termination
+
+- [ ] 2.1 Implement alpha-normalized conservative may-overlap for ordinary types, normalized rows, and representation bounds.
+- [ ] 2.2 Reject overlapping heads at declaration time without proving or comparing their bounds.
+- [ ] 2.3 Implement strict provider-subterm, non-increasing-variable, and unchanged-ground-argument termination checks.
+- [ ] 2.4 Add accepted `MappedSchema`/`OptionalSchema` and rejected equal/growing provider size fixtures.
+
+## 3. Proof Search and Diagnostics
+
+- [ ] 3.1 Add canonical concrete conformance goals, completed-proof memoization, and finite strict-subterm traversal.
+- [ ] 3.2 Preserve active-goal cycle detection as defensive recovery without admitting coinductive proof.
+- [ ] 3.3 Emit deterministic missing-base, overlap, termination, and cycle requirement traces.
+
+## 4. HIR and Instance Discovery
+
+- [ ] 4.1 Retain unresolved conditional witness questions in generic HIR.
+- [ ] 4.2 Substitute concrete kinded arguments and discover every transitive base and wrapper witness.
+- [ ] 4.3 Key one deterministic witness per concrete provider/interface pair and lower only direct targets.
+- [ ] 4.4 Assert that no runtime witness dictionary, interface tag, or standard-library actor lookup is emitted.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 5.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 5.3 Repeat conformance proof and instance artifacts in fresh processes to verify determinism.

--- a/openspec/changes/introduce-representation-parameters/.openspec.yaml
+++ b/openspec/changes/introduce-representation-parameters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/introduce-representation-parameters/design.md
+++ b/openspec/changes/introduce-representation-parameters/design.md
@@ -1,0 +1,83 @@
+## Context
+
+Callable and Effect values already carry compiler-private construction identities through direct
+higher-order specialization. Nominal applications, however, store only ordinary type arguments, so
+placing the same values behind fields loses the identity before ownership and layout can act. This
+change builds the static semantic substrate while leaving all runtime storage diagnostics intact.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a first-class generic kind for callable and Effect representations.
+- Give nominal applications one deterministic vector of kinded generic arguments.
+- Preserve representation facts to the concrete specialization boundary.
+- Make incompatible joins and missing representations fail before MIR.
+
+**Non-Goals:**
+
+- Layout or execute stored callable or Effect fields.
+- Add opaque result binders, runtime erasure, interface dictionaries, or compiler-known library actors.
+- Make representation-bearing nominals structurally Copy.
+
+## Decisions
+
+### Separate representation identity, required bound, and admissibility
+
+Model a representation parameter as a declaration-owned binder plus a callable or Effect bound.
+Model a concrete argument as an exact identity, an opaque family instance supplied by a later
+change, or an open parameter reference. A represented field use combines the argument with its
+substituted required bound and an admissibility proof. The raw identity never substitutes into an
+ordinary `Type` slot.
+
+This preserves one equality identity when a reusable function is admitted under `fn` and `once fn`.
+Embedding the use bound into identity was rejected because contextual weakening would create two
+representations for one target and environment.
+
+### Generalize nominal applications to kinded argument vectors
+
+Replace the type-only nominal argument collection with an ordered generic-argument vector whose
+entries are checked against declaration binders. Type, failure-row, requirement-row, and
+representation arguments retain distinct tagged forms, equality, ordering, substitution, and
+encoding. Existing type-only consumers receive a filtered ordinary-type substitution only where
+their contract genuinely excludes other kinds.
+
+### Infer representation arguments at construction
+
+Each representation-bearing initializer contributes one candidate argument. Repeated uses of the
+same binder unify; disagreement is a source error at the first conflicting field. Nested nominals
+forward their complete arguments rather than re-deriving identities from syntax.
+
+### Resolve before layout and MIR
+
+Syntax, semantic facts, and generic HIR may retain open representation parameters. Reachable
+instance specialization must resolve every open argument and attach a resolved field representation
+or explicit unavailable reason. Layout and MIR reject any residue. Runtime fences remain active in
+this proposal, so the new substrate can land without accidental partial execution.
+
+### Use canonical structure, never presentation text
+
+Equality and keys use tagged structural data and stable declaration or HIR-site identities. Source
+paths and spans are diagnostic presentation only. Encoders use deterministic definition ordering and
+back-references; digest-based symbols must verify structural equality rather than trust collisions.
+
+## Risks / Trade-offs
+
+- [Generic-argument changes touch many consumers] → Audit every nominal argument traversal and add
+  wrong-kind recovery fixtures before changing runtime behavior.
+- [Deep nested identities amplify key size] → Preserve a DAG-shaped logical model and characterize
+  growth before requiring hash-consing.
+- [Frontend support can appear more complete than it is] → Keep callable and Effect storage fences
+  unchanged until their dedicated proposals pass every engine.
+- [Diagnostics expose enormous types] → Show the first divergent representation and make full
+  canonical detail secondary.
+
+## Migration Plan
+
+1. Add syntax and declaration facts behind unavailable recovery.
+2. Introduce tagged generic arguments and adapt equality, encoding, inspectors, and semantic surfaces.
+3. Add represented-value substitution and construction inference.
+4. Preserve arguments through generic HIR and instance discovery.
+5. Assert that every layout/MIR path still rejects representation-bearing fields until later changes.
+
+Rollback removes the new syntax/facts while existing storage fences continue to protect execution.

--- a/openspec/changes/introduce-representation-parameters/proposal.md
+++ b/openspec/changes/introduce-representation-parameters/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Silk preserves callable and Effect construction identities through direct higher-order calls, but
+ordinary nominal applications can carry only type arguments. The compiler needs one explicit,
+kinded representation-argument model before any nominal field may retain executable values safely.
+
+## What Changes
+
+- Add callable- and Effect-bounded representation parameters to generic declarations.
+- Generalize complete nominal applications from type-only arguments to ordered, kind-checked type,
+  row, and representation arguments.
+- Separate concrete representation identity and intrinsic contract from the parameter's required
+  bound and per-use admissibility proof.
+- Preserve open and concrete representation arguments through analysis, HIR, instance keys,
+  diagnostics, deterministic encoding, and tooling.
+- Keep callable and Effect storage fences active; this change introduces the source and
+  specialization substrate but does not yet admit runtime nominal storage.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-representation-parameters`: Representation kinds, arguments, substitution, equality,
+  inference, joins, presentation, and specialization boundaries.
+
+### Modified Capabilities
+
+- `bootstrap-type-generics`: Generic declarations and nominal applications are no longer limited to
+  ordinary types and contract rows.
+
+## Impact
+
+Touches syntax, declaration facts, semantic types, generic inference/substitution, module semantic
+surfaces, HIR, instance keys, diagnostics, inspectors, and deterministic encoders. This is the
+prerequisite for every other static-composition proposal and deliberately retires no runtime fence.

--- a/openspec/changes/introduce-representation-parameters/specs/bootstrap-representation-parameters/spec.md
+++ b/openspec/changes/introduce-representation-parameters/specs/bootstrap-representation-parameters/spec.md
@@ -1,0 +1,85 @@
+## Purpose
+
+Define kinded callable and Effect representation parameters that let nominal identities preserve
+statically known executable representations without runtime erasure or dispatch.
+
+## ADDED Requirements
+
+### Requirement: Declarations bind representation parameters
+
+Generic declarations SHALL accept `F: CallableContract` and `F: EffectContract` as representation
+parameters distinct from ordinary types, failure rows, and requirement rows. Duplicate, unbound,
+wrong-kind, or incompatible representation uses MUST produce deterministic source diagnostics.
+
+#### Scenario: Bind a callable representation
+- **WHEN** `struct Mapper<A, B, F: fn(A) -> B> { transform: F }` is analyzed
+- **THEN** `F` is a representation parameter whose value contract is the declared callable bound
+
+#### Scenario: Reject a representation as an ordinary type
+- **WHEN** source supplies a failure row, requirement row, or unrelated value type for `F`
+- **THEN** analysis reports the kind mismatch before specialization
+
+### Requirement: Representation identity is separate from use bounds
+
+A concrete representation SHALL retain one intrinsic identity and intrinsic callable or Effect
+contract. A represented use SHALL separately retain the parameter's required bound and an
+admissibility proof; exact representation equality MUST NOT change when one reusable callable is
+admitted under both `fn` and `once fn` bounds.
+
+#### Scenario: Admit one function under two access bounds
+- **WHEN** the same named reusable function initializes fields bounded by `fn(A) -> B` and
+  `once fn(A) -> B`
+- **THEN** both uses retain the same exact representation identity and distinct admissibility proofs
+
+### Requirement: Nominal applications carry kinded arguments
+
+A complete nominal application SHALL carry one ordered, kind-checked argument vector containing its
+declared ordinary type, failure-row, requirement-row, and representation arguments. Construction
+SHALL infer representation arguments from field initializers, and every repeated use of one binder
+MUST unify to one representation.
+
+#### Scenario: Infer one representation through repeated fields
+- **WHEN** two fields declared with the same `F` are initialized from values with one concrete
+  callable identity
+- **THEN** construction records one canonical `F` argument for the complete nominal type
+
+#### Scenario: Reject two identities for one binder
+- **WHEN** repeated `F` fields are initialized from distinct callable identities
+- **THEN** construction fails at the conflicting initializer instead of erasing either identity
+
+### Requirement: Representation arguments survive specialization
+
+Representation arguments SHALL survive inference, substitution, nested nominal applications,
+borrows, non-owning field projection, function parameters and results, HIR, and instance discovery.
+Every reachable layout and MIR boundary MUST receive a concrete representation or an explicit
+unavailable fact; no backend may recover an identity from source syntax.
+
+#### Scenario: Forward a nested representation generically
+- **WHEN** a generic wrapper receives and returns a nominal carrying open representation `F`
+- **THEN** reachable specialization substitutes one concrete representation through both nesting
+  levels before layout and MIR
+
+### Requirement: Representation joins remain static
+
+Assignment, branch, result, and aggregate joins SHALL accept representation-dependent nominal values
+only when their complete arguments are equal. A failed join MUST identify the first deterministic
+divergent representation origin and MUST NOT insert allocation, existential packaging, or erasure.
+
+#### Scenario: Converge after consuming distinct representations
+- **WHEN** two branches consume different parsers internally and each returns `i32`
+- **THEN** the `i32` results join even though the parser representations never do
+
+#### Scenario: Reject a parser join before consumption
+- **WHEN** the branches return parsers containing two distinct callable identities
+- **THEN** analysis reports the divergent representation before MIR
+
+### Requirement: Representation facts are deterministic and non-runtime
+
+Canonical equality, ordering, hashing, encoding, presentation, and diagnostics SHALL be deterministic
+across fresh processes. Representation arguments SHALL produce no runtime type descriptor,
+dictionary, actor-name lookup, or standard-library spelling dependency.
+
+#### Scenario: Repeat representation analysis
+- **WHEN** equivalent source is analyzed in separate fresh processes
+- **THEN** its representation facts, nominal keys, HIR, instance ordering, and diagnostics are
+  byte-identical

--- a/openspec/changes/introduce-representation-parameters/specs/bootstrap-type-generics/spec.md
+++ b/openspec/changes/introduce-representation-parameters/specs/bootstrap-type-generics/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Declarations bind canonical type parameters
+
+Struct and function declarations SHALL accept ordered ordinary type parameters, failure-row
+parameters, requirement-row parameters, callable representation parameters, and Effect
+representation parameters. Every parameter identity SHALL be local to its declaration and distinct
+from nominal types and parameters with the same spelling elsewhere. A parameter SHALL be available
+only in positions admitted by its kind, and duplicate or unbound parameters MUST produce
+deterministic diagnostics.
+
+#### Scenario: Bind one generic struct parameter
+- **WHEN** `pub struct Box<T> { pub value: T }` is analyzed
+- **THEN** the field type refers to the canonical `T` parameter owned by `Box`, not to a nominal type named `T`
+
+#### Scenario: Bind a representation parameter
+- **WHEN** `pub struct Mapper<A, B, F: fn(A) -> B> { transform: F }` is analyzed
+- **THEN** `F` is canonical to `Mapper` and can appear only as a represented callable value
+
+#### Scenario: Reject a duplicate parameter
+- **WHEN** a declaration introduces `<T, T>`
+- **THEN** analysis reports the second parameter as a deterministic duplicate without fabricating another identity
+
+### Requirement: Generic applications are explicit canonical types
+
+Applying a generic nominal declaration SHALL require exactly one kind-correct argument per declared
+parameter and SHALL produce a canonical applied type identified by the declaration plus normalized
+ordered arguments. Construction MAY infer concrete representation arguments from corresponding
+field initializers. Applying arguments to a non-generic declaration, omitting arguments in a required
+type position, supplying the wrong arity, or supplying the wrong kind MUST remain explicit semantic
+failures.
+
+#### Scenario: Reuse one applied type identity
+- **WHEN** independent declarations refer to `Box<Token>`
+- **THEN** both references resolve to the same canonical applied type identity
+
+#### Scenario: Infer a construction representation
+- **WHEN** `Mapper` construction supplies a named function for field `F`
+- **THEN** the complete applied type includes that exact representation argument
+
+#### Scenario: Reject the wrong arity
+- **WHEN** `Pair<i32>` refers to a declaration with two parameters
+- **THEN** analysis reports the expected and actual argument counts and produces no available applied type

--- a/openspec/changes/introduce-representation-parameters/tasks.md
+++ b/openspec/changes/introduce-representation-parameters/tasks.md
@@ -1,0 +1,32 @@
+## 1. Syntax and Declaration Facts
+
+- [ ] 1.1 Add callable- and Effect-bounded representation parameter syntax with damaged recovery and formatter correspondence.
+- [ ] 1.2 Extend declaration indexing to record ordered generic parameter kinds and representation bounds.
+- [ ] 1.3 Add positive, duplicate, unbound, and wrong-kind `RepresentationSyntax` fixtures.
+
+## 2. Canonical Representation Algebra
+
+- [ ] 2.1 Introduce canonical representation parameters, exact arguments, open references, required bounds, and admissibility proofs.
+- [ ] 2.2 Generalize nominal applications to ordered kinded generic arguments while preserving ordinary type substitutions.
+- [ ] 2.3 Implement equality, ordering, hashing, deterministic encoding, and unavailable recovery for every argument kind.
+- [ ] 2.4 Add same-identity/different-bound and repeated-`F` unification/mismatch tests.
+
+## 3. Inference and Propagation
+
+- [ ] 3.1 Infer representation arguments from nominal field initializers and diagnose the first conflicting occurrence.
+- [ ] 3.2 Propagate representation arguments through nested nominals, parameters, results, borrows, non-owning projection, and joins.
+- [ ] 3.3 Preserve open and concrete representation arguments in generic HIR and instance keys.
+- [ ] 3.4 Reject every unresolved representation before layout and MIR while retaining existing runtime storage fences.
+
+## 4. Diagnostics and Tooling
+
+- [ ] 4.1 Implement first-divergent-representation join diagnostics with deterministic origin ordering and consumption guidance.
+- [ ] 4.2 Expose complete representation-dependent nominal types and navigation in analysis inspectors and tooling facts.
+- [ ] 4.3 Add fresh-process determinism fixtures for semantic facts, HIR, instance keys, presentation, and diagnostics.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and repair every type error caused by the generic-argument migration.
+- [ ] 5.2 Run `pnpm exec biome check .` and repair formatting or lint failures.
+- [ ] 5.3 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; record any pre-existing failure separately.
+- [ ] 5.4 Validate that `SEM0103` and Effect-layout fences still reject all runtime nominal storage paths.

--- a/openspec/changes/store-callables-in-nominals/.openspec.yaml
+++ b/openspec/changes/store-callables-in-nominals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/store-callables-in-nominals/design.md
+++ b/openspec/changes/store-callables-in-nominals/design.md
@@ -1,0 +1,74 @@
+## Context
+
+After representation parameters exist, a complete nominal identity can name one callable target and
+capture environment. Existing ownership, layout, and lowering still treat only direct callable
+parameters and environments specially; nominal fields need one shared resolved representation fact.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Store named and capturing callables inline in move-only nominals.
+- Preserve invocation access, capture loans, layout, cleanup, and static targets through all engines.
+- Narrow `SEM0103` only for complete, proven paths.
+
+**Non-Goals:**
+
+- Structural nominal Copy, partial owned field extraction, heterogeneous callable collections, or
+  uniform closure allocation.
+- Runtime interface dispatch or WebAssembly tables.
+
+## Decisions
+
+### Resolve one field representation per specialized nominal
+
+Generic analysis records a symbolic field plan keyed by representation binder and field ordinal.
+Instance specialization resolves it to target, concrete generic arguments, ordered capture slots,
+invocation access, loan dependencies, liveness, and cleanup. Ownership, layout, MIR, and engines must
+consume this shared fact rather than rediscovering callable construction from syntax.
+
+The first task is a vertical slice for one named callable and one affine capturing section. Work
+stops if any phase needs a parallel representation model.
+
+### Keep representation-bearing nominals move-only
+
+This milestone does not generalize nominal Copy. Shared and exclusive borrows preserve field access;
+whole-value moves transfer the complete environment. Direct owned extraction of a representation
+field is rejected, avoiding path-sensitive residual cleanup. `once fn` invocation consumes the whole
+aggregate.
+
+### Derive invocation from receiver access
+
+Shared receiver access admits `fn`; exclusive access also admits `mut fn`; whole-owner take access
+also admits `once fn`. The callable argument's own parameter ownership remains independent.
+
+### Store capture environments inline
+
+The structural callable contract remains unlayoutable. A concrete resolved field contributes its
+capture slots to the enclosing build-internal nominal ABI. MIR carries aggregate paths plus one
+static target and cleanup plan. Evaluator, LLVM, and direct Wasm consume the same MIR decision.
+
+### Retire diagnostics case by case
+
+Remove `SEM0103` only when analysis, ownership, layout, MIR, evaluator, LLVM, and Wasm support the
+concrete path. Unknown identity remains an identity-loss error; known inequality uses the join
+diagnostic. No evaluator-only support counts as completion.
+
+## Risks / Trade-offs
+
+- [Capture cleanup can double-run] → Forbid field extraction and test uncalled, called, moved, and
+  typed-failure exits with exact traces.
+- [Borrowed captures escape through aggregates] → Carry loan dependencies on the resolved field and
+  reuse scoped-escape checking.
+- [Backend layouts diverge] → Derive all engines from canonical target layout and compare traces and
+  emitted static targets.
+
+## Migration Plan
+
+1. Implement the field-representation vertical slice while all public fences remain.
+2. Integrate ownership, loan, liveness, and cleanup facts.
+3. Add target layout and MIR aggregate callable operations.
+4. Add evaluator, LLVM, and direct-Wasm parity.
+5. Narrow `SEM0103` only for the accepted matrix and add negative fences for every other path.
+
+Rollback re-enables the fence; source syntax remains owned by the prerequisite representation change.

--- a/openspec/changes/store-callables-in-nominals/proposal.md
+++ b/openspec/changes/store-callables-in-nominals/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Nominal values cannot currently own named functions or capturing sections because their complete
+types lose the callable identity needed for layout, invocation, ownership, and cleanup. This blocks
+ordinary source from composing inspectable data with executable transformations.
+
+## What Changes
+
+- Admit callable-bounded representation parameters as nominal field value types after concrete
+  specialization resolves one target and capture layout.
+- Carry resolved callable field representations through construction, nesting, borrowing,
+  invocation, whole-value moves, cleanup, HIR, layout, MIR, evaluation, native LLVM, and direct
+  WebAssembly.
+- Preserve shared `fn`, exclusive `mut fn`, and consuming `once fn` access rules through aggregate
+  receivers.
+- Keep representation-bearing nominals move-only for this milestone and reject direct owned field
+  extraction; consuming invocation takes the whole aggregate.
+- Retire `SEM0103` only for paths proven end to end through all three engines.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-nominal-callable-storage`: Static inline storage, access, ownership, cleanup, layout,
+  lowering, and engine parity for callable fields.
+
+### Modified Capabilities
+
+- `bootstrap-callable-values`: Concrete callable environments may contribute inline layout through
+  a representation-dependent nominal even though the structural callable contract has no standalone
+  target layout.
+
+## Impact
+
+Depends on `introduce-representation-parameters`. Affects ownership, loans, cleanup planning,
+target layout, HIR/MIR, evaluator, LLVM, direct Wasm, diagnostics, determinism, and differential
+acceptance.

--- a/openspec/changes/store-callables-in-nominals/specs/bootstrap-callable-values/spec.md
+++ b/openspec/changes/store-callables-in-nominals/specs/bootstrap-callable-values/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Callable arguments monomorphize their target
+
+A call passing a callable value SHALL specialize its target on that callable's hidden concrete
+identity, exactly as a call passing an Effect value does. Structural callable and Effect contracts
+have no standalone target layout. A concrete callable representation stored through a complete
+representation-dependent nominal MAY contribute its environment to that enclosing nominal's inline
+layout while retaining static monomorphization. Discovery SHALL route every open callable parameter
+off the executable path and require one finite concrete instance before layout or MIR.
+
+#### Scenario: Distinguish two callables behind one signature
+- **WHEN** one function taking a `once fn(i32) -> i32` is called with two different named functions
+- **THEN** each call reaches its own specialized instance naming its target statically, and neither
+  instance drops the callable parameter from its lowered contract
+
+#### Scenario: Keep a structural callable unlayoutable
+- **WHEN** layout receives only `fn(i32) -> i32` without a concrete representation argument
+- **THEN** it reports the existing unavailable layout rather than choosing a uniform closure shape
+
+#### Scenario: Layout a represented callable field
+- **WHEN** a complete nominal specialization identifies one callable target and capture environment
+- **THEN** layout includes that environment inline without giving the structural callable contract a standalone ABI

--- a/openspec/changes/store-callables-in-nominals/specs/bootstrap-nominal-callable-storage/spec.md
+++ b/openspec/changes/store-callables-in-nominals/specs/bootstrap-nominal-callable-storage/spec.md
@@ -1,0 +1,72 @@
+## Purpose
+
+Define statically specialized nominal storage for named and capturing callable values across
+ownership, layout, lowering, cleanup, and all executable engines.
+
+## ADDED Requirements
+
+### Requirement: Nominals store concrete callable representations inline
+
+A callable-bounded representation field SHALL become layoutable when the complete nominal identity
+contains one concrete callable representation. Layout and lowering SHALL use that representation's
+target, ordered capture environment, access, and cleanup rather than the structural callable contract.
+
+#### Scenario: Store a capturing section
+- **WHEN** a nominal construction stores a section with a Copy capture
+- **THEN** the complete nominal has one finite inline capture layout and one static call target
+
+### Requirement: Aggregate access preserves callable invocation modes
+
+Shared aggregate access SHALL permit only `fn`, exclusive aggregate access SHALL permit `fn` and
+`mut fn`, and consuming whole-owner access SHALL permit `fn`, `mut fn`, and `once fn`. A weaker
+aggregate access MUST NOT invoke a stronger callable mode.
+
+#### Scenario: Reuse a shared callable through a borrow
+- **WHEN** a shared-borrowed parser stores reusable `fn(Arguments) -> A`
+- **THEN** repeated parsing invokes the static target without consuming the parser
+
+#### Scenario: Reject take-only invocation through a shared borrow
+- **WHEN** a shared-borrowed parser stores `once fn(Arguments) -> A`
+- **THEN** ownership rejects invocation and identifies the required whole-owner take access
+
+### Requirement: Representation-bearing nominals remain move-only
+
+Nominals containing callable representation fields SHALL remain move-only in this milestone.
+Whole-value moves and borrows SHALL preserve capture loans and liveness; direct owned extraction of
+a representation-bearing field MUST be rejected, and take-once invocation SHALL consume the whole
+aggregate.
+
+#### Scenario: Reject direct callable field extraction
+- **WHEN** source attempts `move parser.decode`
+- **THEN** ownership rejects the extraction before residual aggregate cleanup can double-drop captures
+
+### Requirement: Callable captures clean exactly once
+
+Uninvoked, shared-invoked, exclusively invoked, and consuming callable environments SHALL clean each
+live owned capture exactly once across success, typed failure, whole-value movement, and scope exit.
+Scoped captures MUST NOT escape through an enclosing nominal.
+
+#### Scenario: Drop an uncalled stored callable
+- **WHEN** a move-only nominal containing an uncalled owned-capture section leaves scope
+- **THEN** every live capture is cleaned exactly once
+
+### Requirement: Callable storage has cross-engine static parity
+
+HIR, MIR, evaluator, native LLVM, and direct WebAssembly SHALL preserve the same aggregate field
+paths, concrete target, capture layout, access checks, result, and cleanup trace. Direct Wasm MUST
+NOT add a function table or `call_indirect` for this capability.
+
+#### Scenario: Execute one stored callable through every engine
+- **WHEN** the same stored-callable acceptance program is evaluated, compiled natively, and emitted
+  as direct WebAssembly
+- **THEN** all engines agree and structural inspection finds only direct targets
+
+### Requirement: Storage fences retire only for proven paths
+
+`SEM0103` SHALL remain for every reachable stored-callable path whose representation is unknown or
+unsupported by ownership, layout, MIR, or any executable engine. A known unequal join SHALL use the
+representation-join diagnostic instead of pretending the field has no layout.
+
+#### Scenario: Keep an unsupported path fenced
+- **WHEN** frontend analysis knows a callable identity but one backend cannot realize its environment
+- **THEN** compilation retains the pre-MIR fence rather than producing partial support

--- a/openspec/changes/store-callables-in-nominals/tasks.md
+++ b/openspec/changes/store-callables-in-nominals/tasks.md
@@ -1,0 +1,31 @@
+## 1. Vertical Slice
+
+- [ ] 1.1 Confirm `introduce-representation-parameters` is complete and identify the existing callable storage fences.
+- [ ] 1.2 Build one named-callable and one affine-capturing nominal field slice through symbolic and resolved field representations.
+- [ ] 1.3 Stop and revise the design if any phase rediscovers callable construction from syntax instead of consuming the shared resolved fact.
+
+## 2. Ownership and Cleanup
+
+- [ ] 2.1 Derive shared, exclusive, and consuming invocation access from aggregate receivers.
+- [ ] 2.2 Carry capture loans, liveness, whole-value moves, and cleanup through nested representation-bearing nominals.
+- [ ] 2.3 Keep representation-bearing nominals move-only and reject direct owned field extraction with a dedicated diagnostic.
+- [ ] 2.4 Add uncalled, called, consuming, moved, typed-failure, and scoped-borrow cleanup traces.
+
+## 3. Layout and MIR
+
+- [ ] 3.1 Plan concrete callable capture fields inline from the resolved representation while keeping structural callable contracts unlayoutable.
+- [ ] 3.2 Extend HIR/MIR aggregate construction, borrow, projection, invocation, movement, and cleanup with static callable facts.
+- [ ] 3.3 Add deterministic layouts, instance keys, symbols, and MIR text for nested callable storage.
+
+## 4. Engine Parity and Fences
+
+- [ ] 4.1 Execute the callable storage matrix in the evaluator.
+- [ ] 4.2 Lower the same matrix through native LLVM with equal target and cleanup behavior.
+- [ ] 4.3 Lower the same matrix through direct Wasm and assert no table or `call_indirect`.
+- [ ] 4.4 Narrow `SEM0103` only for all-engine-proven construction paths and retain it everywhere else.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 5.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 5.3 Repeat cross-engine callable acceptance in fresh processes and compare deterministic facts and artifacts.

--- a/openspec/changes/store-effects-in-nominals/.openspec.yaml
+++ b/openspec/changes/store-effects-in-nominals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/store-effects-in-nominals/design.md
+++ b/openspec/changes/store-effects-in-nominals/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Effect values already have construction-site identities, runner functions, captured environments,
+typed rows, run access, and optional suspension state. Their structural contracts are deliberately
+not standalone ABI values. The callable-storage substrate provides the nominal field path that Effect
+storage must reuse.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Store one concrete Effect realization inline without running it.
+- Preserve rows, run access, suspension, loans, and cleanup through all engines.
+- Retire Effect layout fences only for proven cases.
+
+**Non-Goals:**
+
+- Give `Effect<A ! E ? R>` a uniform standalone ABI.
+- Run an Effect during storage, hide multiple runners, or add backend-specific representations.
+- Add runtime row dictionaries or service behavior to interfaces.
+
+## Decisions
+
+### Add explicit Effect access bounds
+
+Use `Effect`, `mut Effect`, and `once Effect` parallel to callable access. Shared realizations satisfy
+all weaker-use bounds; exclusive realizations satisfy consuming bounds; reverse substitutions fail.
+Generic-body admissibility follows the aggregate receiver access.
+
+### Reuse the resolved field representation
+
+Extend the callable field fact with a tagged Effect realization containing runner, concrete generic
+arguments, ordered environment slots, run access, rows, cleanup, and suspendability. Ownership,
+layout, MIR, and engines consume the same fact. Work stops if a backend requires a separate Effect
+field model or reconstructs runner behavior.
+
+### Keep Effects lazy and inline
+
+Construction transfers or borrows captures into the nominal but never enters the runner. The
+concrete environment contributes lanes to the enclosing build-internal ABI; the structural Effect
+contract remains lane-less. Whole-owner moves and run access transport the entire realization.
+
+### Include suspendability in realization invalidation
+
+Runner target, capture shape, access, cleanup, and suspendability are independent invalidation
+inputs. A suspendability change must rebuild affected MIR and engine artifacts even if ordinary
+capture lanes stay equal.
+
+### Require cross-engine cleanup parity
+
+An unrun Effect, successful run, typed failure, suspension/resume, and scope exit must clean each
+live capture once in evaluator, LLVM, and Wasm. Direct owned field extraction remains forbidden.
+
+## Risks / Trade-offs
+
+- [A backend tries to materialize a standalone Effect ABI] → Gate the vertical slice on consuming
+  the enclosing resolved representation only.
+- [Suspension state silently changes layout] → Fingerprint suspendability and compare fresh-process
+  realization facts.
+- [Rows leak into runtime] → Keep rows in specialization keys and contracts, never layout lanes.
+
+## Migration Plan
+
+1. Add Effect access-bound syntax and kind checking.
+2. Complete the stored-Effect vertical slice for unrun cleanup and one suspension.
+3. Integrate ownership, layout, MIR, and evaluator.
+4. Add LLVM/direct-Wasm parity and invalidation fixtures.
+5. Narrow the Effect-layout fence only for passing shapes.
+
+Rollback re-enables the fence without changing ordinary direct Effect behavior.

--- a/openspec/changes/store-effects-in-nominals/proposal.md
+++ b/openspec/changes/store-effects-in-nominals/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Effect values have the same representation-loss boundary as callables: a structural success,
+failure, requirement, and run-access contract does not determine the runner or captured environment
+needed by an enclosing nominal value.
+
+## What Changes
+
+- Add shared `Effect`, exclusive `mut Effect`, and consuming `once Effect` representation bounds.
+- Store one concretely realized Effect runner and environment inline in a representation-dependent
+  nominal without running it.
+- Preserve exact rows, run access, captures, suspension state, nesting, loans, whole-value moves,
+  and cleanup through evaluation, LLVM, and direct Wasm.
+- Keep the structural Effect contract outside the standalone executable ABI while making the
+  concrete environment part of the enclosing build-internal nominal ABI.
+- Retire the unavailable-Effect-layout fence only for cross-engine-proven paths.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-nominal-effect-storage`: Static inline Effect storage, access, ownership, cleanup,
+  suspension-aware invalidation, layout, lowering, and engine parity.
+
+### Modified Capabilities
+
+- `bootstrap-callable-values`: Effect identity and environment preservation extends through
+  representation-dependent nominal fields.
+
+## Impact
+
+Depends on `introduce-representation-parameters` and reuses the field-representation substrate
+proven by `store-callables-in-nominals`. Affects flow typing, ownership, layout, HIR/MIR, suspension
+lowering, evaluator, LLVM, direct Wasm, and deterministic invalidation.

--- a/openspec/changes/store-effects-in-nominals/specs/bootstrap-callable-values/spec.md
+++ b/openspec/changes/store-effects-in-nominals/specs/bootstrap-callable-values/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Effect values cross ordinary higher-order boundaries
+
+Closed Effect values SHALL be valid ordinary parameter, result, local-binding, capture, generic-
+argument, and concretely represented nominal-field values without exposing or erasing their hidden
+construction-site identity. Passing, capturing, or storing an Effect SHALL preserve its success,
+failure, requirement, and run-access contracts and the ownership of every hidden environment field.
+A structural Effect contract has no standalone target layout; a concrete represented environment MAY
+contribute inline lanes only through its complete enclosing nominal realization.
+
+#### Scenario: Implement map as an ordinary function
+- **WHEN** a generic source function accepts one Effect and one unary callable and returns an Effect that runs the input later
+- **THEN** its returned Effect retains both hidden environments and derives the strongest required shared, exclusive, or consuming run access
+
+#### Scenario: Preserve a take-once input
+- **WHEN** a source combinator captures an Effect that owns an affine value consumed during execution
+- **THEN** the composition remains take-once and ownership rejects a second run without requiring compiler knowledge of the combinator's name
+
+#### Scenario: Store a concrete Effect realization
+- **WHEN** a complete nominal specialization stores one Effect representation in a field
+- **THEN** its runner and environment remain lazy, inline, statically targeted, and unavailable through the structural contract alone

--- a/openspec/changes/store-effects-in-nominals/specs/bootstrap-nominal-effect-storage/spec.md
+++ b/openspec/changes/store-effects-in-nominals/specs/bootstrap-nominal-effect-storage/spec.md
@@ -1,0 +1,67 @@
+## Purpose
+
+Define static inline storage and execution of concretely represented Effect environments inside
+move-only nominal values across ownership, suspension, cleanup, and every engine.
+
+## ADDED Requirements
+
+### Requirement: Effect representation bounds declare run access
+
+Representation bounds SHALL distinguish shared `Effect<A ! E ? R>`, exclusive
+`mut Effect<A ! E ? R>`, and consuming `once Effect<A ! E ? R>`. Shared realizations MAY satisfy
+exclusive or consuming bounds, and exclusive realizations MAY satisfy consuming bounds; reverse
+admission MUST be rejected.
+
+#### Scenario: Reject a take-only Effect through shared access
+- **WHEN** a generic body attempts to run `once Effect<A ! E ? R>` through `&Deferred`
+- **THEN** ownership reports that the whole owner must be consumed
+
+### Requirement: Nominals store concrete Effect environments lazily
+
+A specialized Effect representation field SHALL store one concrete runner and environment inline in
+the enclosing nominal without running it. The structural Effect contract SHALL retain no standalone
+target ABI; only the complete nominal realization contributes build-internal lanes.
+
+#### Scenario: Construct without running
+- **WHEN** source constructs `Deferred` from an Effect with owned captures
+- **THEN** the captures enter the nominal environment and no Effect body executes
+
+### Requirement: Stored Effects preserve complete contracts
+
+Stored Effects SHALL preserve success type, exact failure and requirement rows, run access, ordered
+captures, loans, cleanup, and suspension state through nesting, parameters, results, borrowing, and
+whole-value moves. Rows SHALL remain compile-time only.
+
+#### Scenario: Run a stored Effect with exact rows
+- **WHEN** `Deferred<A, !E, ?R, F>` is executed under access admitted by `F`
+- **THEN** its source-observable result remains `A ! E ? R` with no runtime row dictionary
+
+### Requirement: Stored Effect cleanup is exact
+
+An unrun stored Effect, a successful or failed run, and a suspending run SHALL clean every live
+environment field exactly once. Direct owned extraction of the representation-bearing field MUST be
+rejected, and scoped captures MUST NOT escape through the nominal.
+
+#### Scenario: Drop an unrun Effect
+- **WHEN** a `Deferred` containing an owned environment leaves scope without execution
+- **THEN** its live captures are cleaned once without entering the runner
+
+### Requirement: Effect storage has suspension-aware cross-engine parity
+
+Evaluator, LLVM, and direct WebAssembly SHALL consume one shared concrete realization containing
+runner, layout, cleanup, access, and suspendability. A suspendability or capture-shape edit MUST
+invalidate dependent layouts and emitted code. No backend may reconstruct Effect semantics or use a
+standalone structural Effect ABI.
+
+#### Scenario: Resume one stored suspending Effect
+- **WHEN** a stored Effect suspends and resumes in each engine
+- **THEN** result, failure behavior, cleanup trace, and static runner identity agree
+
+### Requirement: Effect layout fences retire case by case
+
+The unavailable-Effect-layout fence SHALL remain for any nominal storage path not proven through
+ownership, layout, MIR, evaluator, LLVM, and direct WebAssembly.
+
+#### Scenario: Preserve the fence during partial backend support
+- **WHEN** evaluation supports one stored Effect shape but direct WebAssembly does not
+- **THEN** compilation rejects that shape before MIR instead of claiming the capability complete

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -1,0 +1,30 @@
+## 1. Access Contracts and Prerequisites
+
+- [ ] 1.1 Confirm representation parameters and callable field representation infrastructure are complete.
+- [ ] 1.2 Add shared `Effect`, exclusive `mut Effect`, and consuming `once Effect` bound syntax, formatting, and kind checking.
+- [ ] 1.3 Add admissibility and negative aggregate-access fixtures for every run mode.
+
+## 2. Stored-Effect Vertical Slice
+
+- [ ] 2.1 Extend resolved field representations with runner, concrete arguments, rows, access, environment, cleanup, and suspendability.
+- [ ] 2.2 Implement one unrun cleanup case and one suspending run case without a standalone structural Effect ABI.
+- [ ] 2.3 Stop and revise the design if any backend reconstructs runner semantics or requires a parallel field model.
+
+## 3. Ownership, Layout, and MIR
+
+- [ ] 3.1 Preserve Effect loans, exact rows, whole-value moves, nesting, and direct-field-extraction rejection.
+- [ ] 3.2 Plan inline concrete environments and suspendability dependencies in the enclosing build-internal nominal ABI.
+- [ ] 3.3 Carry lazy construction, run, suspension/resume, typed failure, and cleanup through HIR and MIR.
+
+## 4. Engine Parity and Invalidation
+
+- [ ] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
+- [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
+- [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
+- [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 5.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 5.3 Verify rows create no runtime lanes and direct Wasm introduces no indirect dispatch.

--- a/openspec/changes/support-complete-interface-contracts/.openspec.yaml
+++ b/openspec/changes/support-complete-interface-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/support-complete-interface-contracts/design.md
+++ b/openspec/changes/support-complete-interface-contracts/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Existing user-interface witness machinery is deliberately narrow: operations are pure, target
+generic arguments are absent, and value operands are adapted to shared borrows. General decoders and
+representation-dependent wrappers require literal ownership and complete flow contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve literal parameter ownership and complete rows in interface operations.
+- Infer and specialize generic mapped witness functions.
+- Keep generic call contracts exact while admitting smaller witnesses by subsumption.
+
+**Non-Goals:**
+
+- Runtime interface dispatch, service slots, associated output rows, implicit `Self`, or interface
+  inheritance.
+- Provider-specific source contract narrowing after generic type checking.
+
+## Decisions
+
+### Make source ownership literal
+
+Interface parameter syntax has ordinary Silk meaning: `T` transfers, `&T` shares, and `&mut T`
+grants exclusive access. Remove blanket by-value-to-borrow adaptation for user interfaces. A target
+must match parameter shapes and cannot demand stronger receiver access than the interface promises.
+Any temporary adapter for compiler-sealed operators remains inside intrinsic lowering only.
+
+### Treat interface rows as exact caller contracts
+
+Generic bodies type-check against the instantiated interface rows. A witness with fewer failures,
+fewer requirements, or weaker required access may satisfy that contract through explicit subsumption;
+its contract widens at the interface boundary. Specialization may optimize unreachable machinery but
+does not change source-visible caller types.
+
+### Infer mapped target binders from one substituted contract
+
+Substitute the conformance head and specialized interface arguments, then unify the target function's
+receiver, ordinary parameters, success, rows, and representation contracts in declaration order.
+Every target binder must resolve uniquely. Record the resulting arguments in the HIR witness question
+and concrete instance key; reject missing or conflicting inference before MIR.
+
+### Migrate ordinary operator interfaces explicitly
+
+Update `Order` and `HashKey` declarations and witnesses so their intended borrows appear in source.
+Do not preserve old source spelling through hidden general adaptation, because that would make Decoder
+ownership ambiguous and perpetuate two interface calling conventions.
+
+## Risks / Trade-offs
+
+- [Migration breaks pre-stable interface source] → Update the standard library and acceptance corpus
+  atomically; backward compatibility is not a goal at this stage.
+- [Row subsumption accidentally narrows generic callers] → Assert source contracts before and after
+  specialization and compare HIR/MIR-facing rows.
+- [Generic witness inference becomes ambiguous] → Require every binder to be determined by the
+  substituted operation/conformance contract and diagnose the first unresolved binder.
+
+## Migration Plan
+
+1. Extend interface operation and application facts with literal operands and rows.
+2. Add contract substitution, variance, and subsumption checking.
+3. Add mapped target generic inference and witness instance arguments.
+4. Migrate `Order`, `HashKey`, and their ordinary witnesses.
+5. Confine or remove legacy intrinsic operand adapters and add negative ownership fixtures.
+
+Rollback would require restoring the old standard-library declarations and blanket adaptation
+together; mixed conventions are not supported.

--- a/openspec/changes/support-complete-interface-contracts/proposal.md
+++ b/openspec/changes/support-complete-interface-contracts/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Current user-interface witnesses cover narrow pure operations and blanket-adapt value operands to
+shared borrows. Static decoders and other ordinary abstractions need literal ownership plus complete
+success, failure, requirement, and access contracts.
+
+## What Changes
+
+- Allow interface declarations, applications, conformances, and witness targets to bind and
+  specialize failure-row and requirement-row parameters.
+- Interpret interface operand ownership literally: `&T` borrows, `&mut T` borrows exclusively, and
+  `T` transfers ownership.
+- Admit witnesses with smaller rows or weaker required access through explicit subsumption while
+  keeping the instantiated interface contract source-observable at generic call sites.
+- Infer generic type, row, and representation arguments for mapped witness functions and include
+  them in concrete witness instance keys.
+- **BREAKING**: remove blanket source-witness value-to-borrow adaptation; migrate ordinary `Order`
+  and `HashKey` interfaces, confining any legacy adapter to sealed intrinsic lowering.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-complete-interface-contracts`: Literal operands, complete rows, access/row variance,
+  generic witness inference, HIR questions, and static lowering.
+
+### Modified Capabilities
+
+- `bootstrap-instances`: Witness instance discovery includes inferred type, row, and representation
+  arguments and mapped generic target instances.
+
+## Impact
+
+Depends on `admit-conditional-generic-conformances`; representation-bearing witnesses also depend
+on `introduce-representation-parameters`. Affects interface analysis, conformance mapping, HIR,
+instance discovery, ownership, row checking, `Order`/`HashKey` source, diagnostics, and lowering.

--- a/openspec/changes/support-complete-interface-contracts/specs/bootstrap-complete-interface-contracts/spec.md
+++ b/openspec/changes/support-complete-interface-contracts/specs/bootstrap-complete-interface-contracts/spec.md
@@ -1,0 +1,64 @@
+## Purpose
+
+Define ordinary user interfaces whose operations retain literal operand ownership and complete
+success, failure, requirement, access, and generic witness contracts.
+
+## ADDED Requirements
+
+### Requirement: Interface operations use complete contracts
+
+Interface declarations and applications SHALL bind ordinary type, failure-row, and requirement-row
+arguments and SHALL describe each operation's flow kind, literal operand types and ownership,
+success type, failure row, requirement row, and receiver access. Interfaces SHALL remain compile-time
+contracts and MUST NOT create service slots or runtime dispatch.
+
+#### Scenario: Declare an effectful decoder
+- **WHEN** `Decoder<S, Arguments, A, !E, ?R>` declares an effectful operation
+- **THEN** its complete operation contract retains provider, consumed arguments, success, exact rows, and access
+
+### Requirement: Interface operands retain literal ownership
+
+Ordinary source interface operands SHALL use their declared ownership literally. A value operand
+transfers ownership, `&T` observes through a shared borrow, and `&mut T` grants exclusive access.
+General witness mapping MUST NOT blanket-adapt value operands to shared borrows.
+
+#### Scenario: Consume decoder input
+- **WHEN** an interface declares `decode(self: &S, encoded: Arguments)`
+- **THEN** a mapped witness receives `&S` and owns `Arguments`, not `&&S` and `&Arguments`
+
+#### Scenario: Reject a stronger receiver demand
+- **WHEN** a witness requires `&mut S` for an interface operation declaring `&S`
+- **THEN** mapping fails because a generic caller promises only shared access
+
+### Requirement: Witness rows use explicit subsumption
+
+At a generic call site, instantiated interface failure and requirement rows SHALL remain exact and
+source-observable. A witness with smaller failure or requirement rows MAY satisfy the interface by
+subsumption; its local rows SHALL be widened to the interface contract for type checking, while
+specialization MAY optimize unobservable dead machinery.
+
+#### Scenario: Admit a pure decoder under a fallible contract
+- **WHEN** a pure witness satisfies `Decoder<S, Arguments, A, !DecodeError, ?R>`
+- **THEN** the generic call retains the interface rows while lowering may omit unreachable failure work
+
+### Requirement: Generic mapped witnesses infer complete binders
+
+Conformance mapping SHALL infer a target function's type, row, and representation arguments from the
+specialized interface operation, provider, and conformance binders. Unresolved, conflicting, or
+incompatible access arguments MUST produce deterministic diagnostics. Concrete witness instance keys
+SHALL include every inferred argument.
+
+#### Scenario: Specialize one generic mapped decoder twice
+- **WHEN** two mapped schemas select the same generic witness declaration with distinct source and
+  transform representations
+- **THEN** instance discovery records two concrete static witness targets
+
+### Requirement: Existing interfaces migrate to literal operands
+
+Ordinary `Order` and `HashKey` source interfaces SHALL declare the borrows they intend explicitly.
+Any transitional operand adapter MUST remain confined to sealed intrinsic witness lowering and MUST
+NOT affect general user interfaces.
+
+#### Scenario: Inspect a migrated order interface
+- **WHEN** ordinary source maps an `Order` operation after migration
+- **THEN** its declared borrow shapes match the witness directly without blanket adaptation

--- a/openspec/changes/support-complete-interface-contracts/specs/bootstrap-instances/spec.md
+++ b/openspec/changes/support-complete-interface-contracts/specs/bootstrap-instances/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Generic interface witnesses specialize mapped targets
+
+Instance discovery SHALL retain mapped generic witness functions with their inferred ordinary type,
+failure-row, requirement-row, and representation arguments. The canonical witness key SHALL include
+the concrete provider/interface application and mapped target arguments, and MIR SHALL receive one
+direct target with no runtime dictionary.
+
+#### Scenario: Discover two mapped target specializations
+- **WHEN** two concrete providers select one generic witness declaration with different kinded arguments
+- **THEN** discovery records two concrete witness target instances in deterministic order
+
+#### Scenario: Reject an unresolved target binder
+- **WHEN** a mapped witness target has a generic binder not inferable from its conformance and operation contract
+- **THEN** analysis rejects the mapping before instance discovery can create an open key

--- a/openspec/changes/support-complete-interface-contracts/tasks.md
+++ b/openspec/changes/support-complete-interface-contracts/tasks.md
@@ -1,0 +1,31 @@
+## 1. Contract Facts
+
+- [ ] 1.1 Confirm conditional generic conformances are complete and representation parameters are available for witness binders.
+- [ ] 1.2 Extend interface declarations, applications, and mapped operations with literal operand shapes, flow kind, success, failure rows, requirement rows, and access.
+- [ ] 1.3 Add syntax, kind, provider-equality, damaged, and visibility fixtures for complete contracts.
+
+## 2. Literal Ownership and Subsumption
+
+- [ ] 2.1 Replace general value-to-shared-borrow witness adaptation with literal source operand matching.
+- [ ] 2.2 Implement receiver/parameter access compatibility and deterministic stronger-demand diagnostics.
+- [ ] 2.3 Implement failure-row, requirement-row, and access subsumption while preserving exact generic caller contracts.
+- [ ] 2.4 Add pure/smaller witness positives and stronger-row/access negatives.
+
+## 3. Generic Witness Targets
+
+- [ ] 3.1 Infer mapped target type, row, and representation binders from substituted conformance and operation contracts.
+- [ ] 3.2 Preserve inferred target arguments in HIR witness questions and concrete instance keys.
+- [ ] 3.3 Add two-specialization acceptance plus unresolved and conflicting binder diagnostics.
+- [ ] 3.4 Lower every admitted witness to one static target with no runtime dictionary or service slot.
+
+## 4. Interface Migration
+
+- [ ] 4.1 Rewrite ordinary `Order` and `HashKey` interface operands and witnesses with explicit intended borrows.
+- [ ] 4.2 Confine any transitional operand adapter to sealed intrinsic witness lowering.
+- [ ] 4.3 Update standard-library, operator, collection, and compiler acceptance fixtures for the breaking ownership convention.
+
+## 5. Verification
+
+- [ ] 5.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 5.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 5.3 Inspect specialized HIR/MIR to confirm caller rows stay exact while dead witness machinery may optimize away.

--- a/openspec/changes/validate-static-composition-pressure-program/.openspec.yaml
+++ b/openspec/changes/validate-static-composition-pressure-program/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/validate-static-composition-pressure-program/design.md
+++ b/openspec/changes/validate-static-composition-pressure-program/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Six enabling changes can each pass locally while their composition still fails through tooling,
+joins, cleanup, determinism, or one backend. This change is an integration and characterization gate,
+not a proposal for a CLI standard library.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prove the complete capability set in one ordinary-source, formatter-stable fixture.
+- Enforce evaluator/native/Wasm parity and zero indirect dispatch.
+- Establish deterministic static-tree growth baselines before numerical limits.
+
+**Non-Goals:**
+
+- Finalize `Command`, `Cli`, `Schema`, `Decoder`, or `Encoder` APIs.
+- Add a production CLI library, shell grammar, help policy, or heterogeneous executable storage.
+- Treat performance concerns as permission for erasure or compiler-known actors.
+
+## Decisions
+
+### Make one executable fixture the integration contract
+
+Create `static-composition-acceptance.silk` with complete definitions, not pseudocode. It uses final
+syntax, named callables, reusable borrowed decoding, explicit providers/rows, static nested command
+fields, help traversal, branch-local consumption, one application union, and handler once/never
+assertions. Formatting the fixture twice must be idempotent.
+
+### Keep the library shape replaceable
+
+The fixture's actors are pressure vocabulary only. Add a renamed equivalent control and inspect HIR,
+MIR, and backend artifacts for forbidden actor-name branches. The compiler may know only sealed
+intrinsics, never standard-library declarations by spelling.
+
+### Require differential engine traces
+
+Run success, help, selection failure, decode failure, uncalled cleanup, called cleanup, and suspended
+Effect cases through evaluator, LLVM, and direct Wasm. Compare result/failure fingerprints, handler
+counts, selected direct target, and cleanup trace. Inspect Wasm for zero tables and `call_indirect`.
+
+### Characterize two static-tree shapes
+
+Generate left-associated and balanced trees at 1, 8, 32, 64, and 128 leaves. Record canonical byte
+size, semantic/representation/instance/layout/MIR counts, phase time, peak heap, native text/data, and
+Wasm bytes twice in fresh processes. Counts and artifacts are hard deterministic gates; timing,
+memory, and size trends establish the first measured baseline. Any unexplained superlinear semantic
+growth fails and returns to implementation analysis.
+
+### Keep evidence failures scoped
+
+The four prerequisite vertical/characterization spikes and this separate fixture gate can return a
+change to design review. They cannot silently weaken settled semantics or introduce runtime erasure,
+dictionaries, allocation, or actor-specific compiler privilege.
+
+## Risks / Trade-offs
+
+- [Fixture accidentally defines the public CLI API] → Keep names explicitly non-normative and use a
+  renamed equivalent control.
+- [Stress results vary with host noise] → Hard-gate deterministic structural outputs first and record
+  environment metadata for empirical timing/memory baselines.
+- [Integration change hides prerequisite failures] → State all six required changes and refuse to
+  duplicate unfinished feature implementation here.
+
+## Migration Plan
+
+1. Land only after every prerequisite change is complete and its fences are correctly narrowed.
+2. Add and format the executable fixture plus renamed control.
+3. Add cross-engine trace and structural artifact assertions.
+4. Add generated growth inputs and checked-in baseline report.
+5. Run the complete release matrix and classify every finding.
+
+The fixture and reports can be removed without changing language semantics; failing them blocks release.

--- a/openspec/changes/validate-static-composition-pressure-program/proposal.md
+++ b/openspec/changes/validate-static-composition-pressure-program/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The enabling language changes are not complete until one ordinary-source program composes
+inspectable data, stored callables, stored Effects, conditional conformances, and complete interface
+contracts through every engine. A dedicated integration gate prevents isolated milestones from
+claiming the static-composition goal prematurely.
+
+## What Changes
+
+- Add a formatter-stable `static-composition-acceptance.silk` fixture implementing the complete
+  CLI-shaped pressure program without compiler-known library spelling.
+- Exercise reusable mapped leaves, static subcommands, help traversal, common-union normalization,
+  handler once/never behavior, join diagnostics, and cross-engine cleanup parity.
+- Generate left-associated and balanced static trees at `1`, `8`, `32`, `64`, and `128` leaves and
+  record deterministic semantic, layout, MIR, timing, memory, native-size, and Wasm-size metrics.
+- Require zero WebAssembly tables and indirect calls; establish measured performance baselines before
+  choosing numerical regression thresholds.
+- Treat failure of any bounded vertical slice or integration gate as a return to design review, not
+  permission for erasure, runtime dictionaries, or compiler-known actor names.
+
+## Capabilities
+
+### New Capabilities
+
+- `bootstrap-static-composition-pressure-program`: End-to-end source fixture, differential engine
+  gates, deterministic growth characterization, and tooling acceptance.
+
+### Modified Capabilities
+
+- `bootstrap-language-pressure-programs`: Add static representation-dependent composition as a
+  required cross-layer pressure program.
+
+## Impact
+
+Depends on all six enabling proposals. Adds compiler-driver fixtures, evaluator/native/Wasm
+differential gates, deterministic artifact comparisons, generated stress inputs, metric reporting,
+diagnostic assertions, and tooling assertions.

--- a/openspec/changes/validate-static-composition-pressure-program/specs/bootstrap-language-pressure-programs/spec.md
+++ b/openspec/changes/validate-static-composition-pressure-program/specs/bootstrap-language-pressure-programs/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Static composition pressures representation-dependent values
+
+The repository SHALL maintain a complete ordinary-Silk pressure program that composes inspectable
+nominal data with statically represented callable and Effect behavior, conditional compile-time
+interfaces, and complete operation contracts. The program SHALL normalize different leaf results
+before convergence and SHALL run equivalently through evaluation, native LLVM, and direct
+WebAssembly without compiler-known library actor names.
+
+#### Scenario: Pressure the complete capability set
+- **WHEN** the static-composition program is compiled and executed through every engine
+- **THEN** it exercises each enabling language capability in one connected source flow with equal results and cleanup
+
+#### Scenario: Keep the CLI shape non-normative
+- **WHEN** the example command and schema actor modules are renamed or replaced by equivalent ordinary source
+- **THEN** the compiler continues to accept the program without actor-specific behavior

--- a/openspec/changes/validate-static-composition-pressure-program/specs/bootstrap-static-composition-pressure-program/spec.md
+++ b/openspec/changes/validate-static-composition-pressure-program/specs/bootstrap-static-composition-pressure-program/spec.md
@@ -1,0 +1,63 @@
+## Purpose
+
+Define the executable ordinary-source integration and characterization gates that prove static
+representation-dependent composition works across the complete Silk compiler.
+
+## ADDED Requirements
+
+### Requirement: A complete static-composition fixture uses final syntax
+
+The repository SHALL contain one formatter-stable `static-composition-acceptance.silk` program using
+final representation, opaque-result, conditional-conformance, and complete-interface syntax. It
+SHALL define mapped reusable schemas, static subcommands, help traversal, branch normalization to one
+application union, and handler invocation without compiler-known CLI or schema spelling.
+
+#### Scenario: Decode one selected leaf
+- **WHEN** the fixture selects and decodes one valid subcommand
+- **THEN** only that leaf executes and the common application handler runs exactly once
+
+#### Scenario: Avoid the handler on non-success paths
+- **WHEN** the fixture requests help or encounters selection or decode failure
+- **THEN** it traverses inspectable data as required and never invokes the application handler
+
+### Requirement: Branch normalization precedes convergence
+
+The fixture SHALL use supported named callables or sections so different representation-dependent
+branch values are consumed before their common result joins. It MUST NOT rely on anonymous functions,
+implicit erasure, heterogeneous executable collections, or runtime interface dispatch.
+
+#### Scenario: Converge on an application action
+- **WHEN** distinct leaf decoders produce different domain actions
+- **THEN** each branch maps to the shared application union before the following pipeline node
+
+### Requirement: Every engine agrees on static composition
+
+Evaluator, native LLVM, and direct WebAssembly SHALL produce equal results, typed failures, handler
+counts, target selection, and cleanup traces. WebAssembly output MUST contain no function table or
+`call_indirect` introduced by this capability.
+
+#### Scenario: Run the acceptance matrix
+- **WHEN** success, help, selection failure, decode failure, uncalled cleanup, and called cleanup
+  cases run through all engines
+- **THEN** their observable traces and static targets agree exactly
+
+### Requirement: Static-tree growth is characterized deterministically
+
+Generated left-associated and balanced command trees at `1`, `8`, `32`, `64`, and `128` leaves SHALL
+record semantic, representation, instance, layout, MIR, canonical-byte, phase-time, peak-heap, native-
+size, and Wasm-size metrics in two fresh processes. Counts and artifacts MUST be deterministic, and
+every unexplained superlinear semantic expansion MUST fail the characterization.
+
+#### Scenario: Establish a baseline before thresholds
+- **WHEN** the generated suite completes for both shapes and every size
+- **THEN** it publishes measured trends and recommendations without inventing a pre-baseline language limit
+
+### Requirement: Integration findings preserve language boundaries
+
+A failed vertical slice or pressure gate SHALL return the relevant proposal to design review. It MUST
+NOT authorize compiler recognition of `Command`, `Cli`, `Schema`, `Decoder`, or `Encoder`, implicit
+allocation or erasure, a runtime interface dictionary, or weaker ownership.
+
+#### Scenario: Detect a compiler-known actor dependency
+- **WHEN** source spelling changes while its ordinary contracts remain equivalent
+- **THEN** compiler behavior remains unchanged or the gate fails as a release-blocking violation

--- a/openspec/changes/validate-static-composition-pressure-program/tasks.md
+++ b/openspec/changes/validate-static-composition-pressure-program/tasks.md
@@ -1,0 +1,38 @@
+## 1. Prerequisite Gates
+
+- [ ] 1.1 Confirm all six enabling changes are complete and document the exact diagnostics each one retired or retained.
+- [ ] 1.2 Run and attach the callable-field, stored-Effect, opaque-invalidation, and static-tree bounded spike evidence.
+- [ ] 1.3 Return any failed spike to its owning change instead of implementing a local workaround.
+
+## 2. Executable Pressure Fixture
+
+- [ ] 2.1 Implement formatter-stable `static-composition-acceptance.silk` with final syntax and complete definitions.
+- [ ] 2.2 Add reusable mapped leaves, static nested subcommands, help traversal, branch normalization, one application union, and handler once/never assertions.
+- [ ] 2.3 Add a renamed equivalent fixture proving the compiler does not recognize CLI or schema actors by spelling.
+- [ ] 2.4 Format each fixture twice and assert idempotent source.
+
+## 3. Differential Engine Matrix
+
+- [ ] 3.1 Add evaluator traces for success, help, selection failure, decode failure, uncalled cleanup, called cleanup, and suspension.
+- [ ] 3.2 Add native LLVM execution and structural artifact comparisons for the same cases.
+- [ ] 3.3 Add direct-Wasm execution and assert zero tables and `call_indirect` introduced by static composition.
+- [ ] 3.4 Compare result/failure fingerprints, handler counts, selected targets, and cleanup traces across all engines.
+
+## 4. Static-Tree Characterization
+
+- [ ] 4.1 Generate left-associated and balanced trees at `1`, `8`, `32`, `64`, and `128` distinct leaves.
+- [ ] 4.2 Record canonical bytes, semantic/representation/instance/layout/MIR counts, phase times, peak heap, native size, and Wasm size in two fresh processes.
+- [ ] 4.3 Fail and diagnose any nondeterministic artifact or unexplained superlinear semantic growth.
+- [ ] 4.4 Check in the environment metadata, plots, findings, and recommended measured regression thresholds.
+
+## 5. Tooling and Release Gate
+
+- [ ] 5.1 Assert first-divergent-field diagnostics, complete-type hovers, and witness navigation on the pressure program.
+- [ ] 5.2 Inspect compiler artifacts for forbidden actor-name logic, runtime dictionaries, erasure, allocation, or indirect dispatch.
+- [ ] 5.3 Classify every finding as repaired, returned to an owning proposal, or accepted empirical cost.
+
+## 6. Verification
+
+- [ ] 6.1 Run `pnpm typecheck` and `pnpm exec biome check .`.
+- [ ] 6.2 Run `pnpm test`, `pnpm check`, and `pnpm release:candidate`; report exact failures.
+- [ ] 6.3 Run `openspec validate validate-static-composition-pressure-program --strict` after all prerequisite change specs are synchronized.


### PR DESCRIPTION
## Summary

- add seven dependency-ordered OpenSpec changes for static representation-dependent composition
- define representation parameters, opaque results, callable and Effect storage, conditional conformances, complete interface contracts, and the final integration pressure program
- preserve the consensus RFC boundaries: static specialization, no implicit erasure, no runtime interface dictionaries, and no compiler-known library actor names

## Validation

- all seven changes report 4/4 artifacts complete
- all seven pass strict OpenSpec validation
- git diff whitespace check passes

## Impact

Documentation and implementation planning only; no compiler or runtime behavior changes in this PR.