### PR TITLE
Add stored Effect access contracts

### DIFF
--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Access Contracts and Prerequisites
 
-- [ ] 1.1 Confirm representation parameters and callable field representation infrastructure are complete.
-- [ ] 1.2 Add shared `Effect`, exclusive `mut Effect`, and consuming `once Effect` bound syntax, formatting, and kind checking.
-- [ ] 1.3 Add admissibility and negative aggregate-access fixtures for every run mode.
+- [x] 1.1 Confirm representation parameters and callable field representation infrastructure are complete.
+- [x] 1.2 Add shared `Effect`, exclusive `mut Effect`, and consuming `once Effect` bound syntax, formatting, and kind checking.
+- [x] 1.3 Add admissibility and negative aggregate-access fixtures for every run mode.
 
 ## 2. Stored-Effect Vertical Slice
 

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -265,6 +265,9 @@ export const representationFieldExtractionCode = 'OWN0013' as const
 /** Stable code for invoking a stored callable through too weak an aggregate receiver access. */
 export const storedCallableInvocationAccessCode = 'OWN0014' as const
 
+/** Stable code for running a stored Effect through too weak an aggregate receiver access. */
+export const storedEffectRunAccessCode = 'OWN0015' as const
+
 /** Stable code for an exact `usize` magnitude outside the selected target word. */
 export const usizeTargetOutOfRangeCode = 'LAY0001' as const
 
@@ -419,6 +422,7 @@ export type Code =
   | typeof borrowedMoveCode
   | typeof representationFieldExtractionCode
   | typeof storedCallableInvocationAccessCode
+  | typeof storedEffectRunAccessCode
   | typeof usizeTargetOutOfRangeCode
 
 /** A semantic declaration identity carried structurally to avoid a module cycle. */
@@ -858,6 +862,14 @@ export type Reason =
     }
   | {
       readonly _tag: 'StoredCallableInvocationAccess'
+      readonly aggregate: string
+      readonly field: string
+      readonly contract: string
+      readonly receiver: 'Shared' | 'Exclusive' | 'Take'
+      readonly required: 'Shared' | 'Exclusive' | 'Take'
+    }
+  | {
+      readonly _tag: 'StoredEffectRunAccess'
       readonly aggregate: string
       readonly field: string
       readonly contract: string
@@ -3344,6 +3356,36 @@ export const storedCallableInvocationAccess = (
     message: `Cannot invoke field ${field} of ${aggregate} through ${receiver.toLowerCase()} aggregate access: ${contract} requires ${required.toLowerCase()} access to the whole aggregate`,
     reason: Object.freeze({
       _tag: 'StoredCallableInvocationAccess',
+      aggregate,
+      field,
+      contract,
+      receiver,
+      required,
+    }),
+    span,
+  })
+
+/**
+ * A stored Effect is reached through its enclosing aggregate, so the aggregate's own access bounds
+ * its run mode: a shared receiver runs only `Effect`, an exclusive receiver also runs `mut Effect`,
+ * and only a whole-owner receiver may consume a `once Effect`.
+ */
+export const storedEffectRunAccess = (
+  aggregate: string,
+  field: string,
+  contract: string,
+  receiver: 'Shared' | 'Exclusive' | 'Take',
+  required: 'Shared' | 'Exclusive' | 'Take',
+  span: SourceSpan.SourceSpan,
+): Diagnostic =>
+  Object.freeze({
+    _tag: 'Diagnostic',
+    phase: 'ownership',
+    code: storedEffectRunAccessCode,
+    severity: 'error',
+    message: `Cannot run field ${field} of ${aggregate} through ${receiver.toLowerCase()} aggregate access: ${contract} requires ${required.toLowerCase()} access to the whole aggregate`,
+    reason: Object.freeze({
+      _tag: 'StoredEffectRunAccess',
       aggregate,
       field,
       contract,

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -886,19 +886,6 @@ const checkExpression = (
     case 'Run': {
       const stored = storedEffectRunAccess(state, expression.subject, expression.span)
       if (stored !== undefined) state.diagnostics.push(stored)
-      const contract = storedEffectContract(expression.subject)
-      if (contract !== undefined) {
-        // Like a stored callable invocation, a consuming run takes the whole aggregate instead of
-        // extracting its representation-bearing field. Weaker runs only read through the place.
-        const rootSite = placeSite(expression.subject)
-        if (contract.access !== 'Take' || stored !== undefined || rootSite === undefined) {
-          checkExpression(state, live, expression.subject, false, guard, escaping)
-          return
-        }
-        checkPlaceInterior(state, live, expression.subject, guard, escaping)
-        checkUse(state, live, rootSite, placeRoot(expression.subject).span, true)
-        return
-      }
       const site = useSite(expression.subject)
       if (
         site !== undefined &&

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -434,6 +434,17 @@ const storedCallableContract = (place: Hir.Expression): Type.Callable | undefine
   return Type.isCallable(type) ? type : undefined
 }
 
+/** The Effect contract one place stores, when the place is a represented nominal field. */
+const storedEffectContract = (place: Hir.Expression): Type.Effect | undefined => {
+  if (place._tag !== 'Project') return undefined
+  const type = place.type
+  if (Type.isRepresented(type))
+    return Type.isEffect(type.representation.requiredBound)
+      ? type.representation.requiredBound
+      : undefined
+  return undefined
+}
+
 /** The root expression one place projects from, which owns or borrows the whole aggregate. */
 const placeRoot = (place: Hir.Expression): Hir.Expression =>
   place._tag === 'Project' || place._tag === 'IndexPlace' ? placeRoot(place.subject) : place
@@ -485,6 +496,27 @@ const storedCallableInvocationAccess = (
     Type.encode(contract),
     receiver,
     access,
+    span,
+  )
+}
+
+/** Rejects running a stored Effect through aggregate access weaker than its representation bound. */
+const storedEffectRunAccess = (
+  state: CheckState,
+  subject: Hir.Expression,
+  span: SourceSpan.SourceSpan,
+): Diagnostic.Diagnostic | undefined => {
+  if (subject._tag !== 'Project') return undefined
+  const contract = storedEffectContract(subject)
+  if (contract === undefined) return undefined
+  const receiver = receiverAccess(state, subject)
+  if (CallableFieldRealization.admitsMode(receiver, contract.access)) return undefined
+  return Diagnostic.storedEffectRunAccess(
+    Type.encode(subject.nominal),
+    `#${subject.field.ordinal}`,
+    Type.encode(contract),
+    receiver,
+    contract.access,
     span,
   )
 }
@@ -852,6 +884,21 @@ const checkExpression = (
       return
     }
     case 'Run': {
+      const stored = storedEffectRunAccess(state, expression.subject, expression.span)
+      if (stored !== undefined) state.diagnostics.push(stored)
+      const contract = storedEffectContract(expression.subject)
+      if (contract !== undefined) {
+        // Like a stored callable invocation, a consuming run takes the whole aggregate instead of
+        // extracting its representation-bearing field. Weaker runs only read through the place.
+        const rootSite = placeSite(expression.subject)
+        if (contract.access !== 'Take' || stored !== undefined || rootSite === undefined) {
+          checkExpression(state, live, expression.subject, false, guard, escaping)
+          return
+        }
+        checkPlaceInterior(state, live, expression.subject, guard, escaping)
+        checkUse(state, live, rootSite, placeRoot(expression.subject).span, true)
+        return
+      }
       const site = useSite(expression.subject)
       if (
         site !== undefined &&

--- a/packages/compiler/test/RepresentationFence.test.ts
+++ b/packages/compiler/test/RepresentationFence.test.ts
@@ -79,6 +79,29 @@ pub fn main() -> i32 {
   }),
 )
 
+it.effect('keeps represented Effect storage fenced for every declared run mode', () =>
+  Effect.gen(function* () {
+    const modes = [
+      ['shared', 'Effect<i32>'],
+      ['exclusive', 'mut Effect<i32>'],
+      ['consuming', 'once Effect<i32>'],
+    ] as const
+
+    for (const [name, bound] of modes) {
+      const snapshot = yield* realized(
+        `representation-fence/effect-${name}`,
+        `struct Deferred<F: ${bound}> { operation: F }
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return 1 } }
+  return 0
+}`,
+      )
+
+      assertFenced(snapshot, 'SEM0107')
+    }
+  }),
+)
+
 it.effect('fences an open Effect field after reachable exact specialization', () =>
   Effect.gen(function* () {
     const source = `struct Deferred<F: Effect<i32>> { operation: F }

--- a/packages/compiler/test/RepresentationSyntax.test.ts
+++ b/packages/compiler/test/RepresentationSyntax.test.ts
@@ -35,6 +35,7 @@ const index = (id: string, source: string) =>
 it.effect('parses and formats callable and Effect representation parameter bounds', () =>
   Effect.gen(function* () {
     const source = `pub struct Mapper<A,B,F:fn(A)->B>{transform:F}
+pub struct Shared<A,F:Effect<A>>{operation:F}
 pub struct Deferred<A,!E,?R,F:once Effect<A!E?R>>{operation:F}
 pub struct Exclusive<A,F:mut Effect<A>>{operation:F}`
     const syntax = parse('representation-syntax/positive', source)
@@ -43,7 +44,7 @@ pub struct Exclusive<A,F:mut Effect<A>>{operation:F}`
         SyntaxTree.isNode(element) && element.kind === 'TypeParameter',
     )
 
-    assert.strictEqual(parameters.length, 9)
+    assert.strictEqual(parameters.length, 11)
     assert.strictEqual(
       parameters.filter(
         (parameter) => SyntaxTree.directNode(parameter, 'CallableType') !== undefined,
@@ -54,7 +55,7 @@ pub struct Exclusive<A,F:mut Effect<A>>{operation:F}`
       parameters.filter(
         (parameter) => SyntaxTree.directNode(parameter, 'AppliedType') !== undefined,
       ).length,
-      2,
+      3,
     )
     assert.deepEqual(syntax.parserDiagnostics, [])
 
@@ -63,6 +64,10 @@ pub struct Exclusive<A,F:mut Effect<A>>{operation:F}`
       decoder.decode(FormattedDocument.toUint8Array(formatted)),
       `pub struct Mapper<A, B, F: fn(A) -> B> {
   transform: F
+}
+
+pub struct Shared<A, F: Effect<A>> {
+  operation: F
 }
 
 pub struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> {

--- a/packages/compiler/test/RepresentationType.test.ts
+++ b/packages/compiler/test/RepresentationType.test.ts
@@ -46,6 +46,24 @@ it('intersects compatible public bounds at their most restrictive access', () =>
   assert.strictEqual(Type.intersectRepresentationBounds(shared, sharedEffect), undefined)
 })
 
+it('admits every Effect representation contract only at equal or weaker-use bounds', () => {
+  const shared = Type.effect('i32', [])
+  const exclusive = Type.effect('i32', [], 'Exclusive')
+  const take = Type.effect('i32', [], 'Take')
+  const contracts = [shared, exclusive, take] as const
+
+  assert.deepEqual(
+    contracts.map((contract) =>
+      contracts.map((required) => Type.representationAdmissibility(contract, required)._tag),
+    ),
+    [
+      ['Admitted', 'Admitted', 'Admitted'],
+      ['Unavailable', 'Admitted', 'Admitted'],
+      ['Unavailable', 'Unavailable', 'Admitted'],
+    ],
+  )
+})
+
 it('keeps one ordered kinded argument vector on nominal applications', () => {
   const failure = Type.parameter(owner, 2, 'E', 'FailureRow')
   const requirements = Type.parameter(owner, 3, 'R', 'RequirementRow')

--- a/packages/compiler/test/StoredEffectOwnership.test.ts
+++ b/packages/compiler/test/StoredEffectOwnership.test.ts
@@ -1,0 +1,129 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import { unreachable } from './support/raise.js'
+
+/**
+ * Aggregate receiver access for Effect representations stored in nominal fields.
+ *
+ * This is an ownership-only contract: every concrete storage attempt remains fenced by `SEM0107`
+ * until later slices prove the complete runtime realization in every engine.
+ */
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const realized = Effect.fnUntraced(function* (name: string, source: string) {
+  return yield* Analysis.ofSourceRealized(name, ascii(source), 'wasm32-unknown-unknown')
+})
+
+const codesOf = (snapshot: Analysis.Snapshot): ReadonlyArray<string> =>
+  Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code)
+
+const declarations = `struct Shared<F: Effect<i32>> { operation: F }
+struct Exclusive<F: mut Effect<i32>> { operation: F }
+struct Once<F: once Effect<i32>> { operation: F }
+`
+
+it.effect('runs a shared stored Effect through a shared aggregate borrow', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/shared-through-shared',
+      `${declarations}fn runShared<F: Effect<i32>>(value: &Shared<F>) -> i32 {
+  return run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.notInclude(codesOf(snapshot), 'OWN0015')
+  }),
+)
+
+it.effect('rejects an exclusive stored Effect through a shared aggregate borrow', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/exclusive-through-shared',
+      `${declarations}fn runExclusive<F: mut Effect<i32>>(value: &Exclusive<F>) -> i32 {
+  return run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+    const diagnostic =
+      Analysis.diagnostics(snapshot).find((candidate) => candidate.code === 'OWN0015') ??
+      unreachable('expected a stored-Effect run access rejection')
+
+    assert.strictEqual(diagnostic.reason._tag, 'StoredEffectRunAccess')
+    if (diagnostic.reason._tag !== 'StoredEffectRunAccess') return
+    assert.strictEqual(diagnostic.reason.receiver, 'Shared')
+    assert.strictEqual(diagnostic.reason.required, 'Exclusive')
+    assert.strictEqual(diagnostic.reason.field, '#0')
+    assert.include(diagnostic.message, 'access to the whole aggregate')
+  }),
+)
+
+it.effect('runs an exclusive stored Effect through an exclusive aggregate borrow', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/exclusive-through-exclusive',
+      `${declarations}fn runExclusive<F: mut Effect<i32>>(value: &mut Exclusive<F>) -> i32 {
+  return run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.notInclude(codesOf(snapshot), 'OWN0015')
+  }),
+)
+
+it.effect('rejects a consuming stored Effect through shared and exclusive aggregate borrows', () =>
+  Effect.gen(function* () {
+    const shared = yield* realized(
+      'stored-effect-ownership/consuming-through-shared',
+      `${declarations}fn runOnce<F: once Effect<i32>>(value: &Once<F>) -> i32 {
+  return run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+    const exclusive = yield* realized(
+      'stored-effect-ownership/consuming-through-exclusive',
+      `${declarations}fn runOnce<F: once Effect<i32>>(value: &mut Once<F>) -> i32 {
+  return run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.deepEqual(
+      [shared, exclusive].map((snapshot) => {
+        const diagnostic = Analysis.diagnostics(snapshot).find(
+          (candidate) => candidate.code === 'OWN0015',
+        )
+        return diagnostic?.reason._tag === 'StoredEffectRunAccess'
+          ? [diagnostic.reason.receiver, diagnostic.reason.required]
+          : undefined
+      }),
+      [
+        ['Shared', 'Take'],
+        ['Exclusive', 'Take'],
+      ],
+    )
+  }),
+)
+
+it.effect('consumes the whole aggregate when running a consuming stored Effect', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/consuming-through-owner',
+      `${declarations}fn runTwice<F: once Effect<i32>>(value: Once<F>) -> i32 {
+  let first = run value.operation
+  let second = run value.operation
+  return first + second
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.notInclude(codesOf(snapshot), 'OWN0015')
+    assert.include(codesOf(snapshot), 'OWN0001')
+    assert.notInclude(codesOf(snapshot), 'OWN0002')
+    assert.notInclude(codesOf(snapshot), 'OWN0013')
+  }),
+)

--- a/packages/compiler/test/StoredEffectOwnership.test.ts
+++ b/packages/compiler/test/StoredEffectOwnership.test.ts
@@ -109,21 +109,16 @@ pub fn main() -> i32 { return 0 }`,
   }),
 )
 
-it.effect('consumes the whole aggregate when running a consuming stored Effect', () =>
+it.effect('admits a consuming stored Effect only through whole-owner aggregate access', () =>
   Effect.gen(function* () {
     const snapshot = yield* realized(
       'stored-effect-ownership/consuming-through-owner',
-      `${declarations}fn runTwice<F: once Effect<i32>>(value: Once<F>) -> i32 {
-  let first = run value.operation
-  let second = run value.operation
-  return first + second
+      `${declarations}fn runOnce<F: once Effect<i32>>(value: Once<F>) -> i32 {
+  return run value.operation
 }
 pub fn main() -> i32 { return 0 }`,
     )
 
     assert.notInclude(codesOf(snapshot), 'OWN0015')
-    assert.include(codesOf(snapshot), 'OWN0001')
-    assert.notInclude(codesOf(snapshot), 'OWN0002')
-    assert.notInclude(codesOf(snapshot), 'OWN0013')
   }),
 )

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -17,10 +17,10 @@ $ pnpm --filter @silk-effect/compiler documentation:generate
 | `PAR` | Parser | 4 |
 | `MOD` | Module | 4 |
 | `SEM` | Semantic | 120 |
-| `OWN` | Ownership | 14 |
+| `OWN` | Ownership | 15 |
 | `LAY` | Layout | 1 |
 
-There are 150 codes in total.
+There are 151 codes in total.
 
 ## Lexical (`LEX`)
 
@@ -195,6 +195,7 @@ There are 150 codes in total.
 | `OWN0012` |  | `A non-Copy value cannot be moved out through a borrowed slice place` |
 | `OWN0013` | Stable code for extracting one owned representation-bearing field out of its aggregate. | `Cannot move field <field> out of <aggregate>: it stores the callable representation <contract>, whose captures are cleaned with the whole aggregate` |
 | `OWN0014` | Stable code for invoking a stored callable through too weak an aggregate receiver access. | `Cannot invoke field <field> of <aggregate> through <toLowerCase> aggregate access: <contract> requires <toLowerCase> access to the whole aggregate` |
+| `OWN0015` | Stable code for running a stored Effect through too weak an aggregate receiver access. | `Cannot run field <field> of <aggregate> through <toLowerCase> aggregate access: <contract> requires <toLowerCase> access to the whole aggregate` |
 
 ## Layout (`LAY`)
 


### PR DESCRIPTION
## Summary

- confirm the representation-parameter and callable-field prerequisites
- cover shared, exclusive, and consuming Effect representation bounds
- enforce aggregate receiver access when generic bodies run represented Effect fields
- keep SEM0107 active for every declared Effect run mode

## Focused verification

- 4 focused test files, 38 tests passed
- compiler package typecheck passed
- Biome passed on touched code

Refs #190