### PR TITLE
Retain complete interface contract facts

### DIFF
--- a/openspec/changes/support-complete-interface-contracts/tasks.md
+++ b/openspec/changes/support-complete-interface-contracts/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Contract Facts
 
-- [ ] 1.1 Confirm conditional generic conformances are complete and representation parameters are available for witness binders.
-- [ ] 1.2 Extend interface declarations, applications, and mapped operations with literal operand shapes, flow kind, success, failure rows, requirement rows, and access.
-- [ ] 1.3 Add syntax, kind, provider-equality, damaged, and visibility fixtures for complete contracts.
+- [x] 1.1 Confirm conditional generic conformances are complete and representation parameters are available for witness binders.
+- [x] 1.2 Extend interface declarations, applications, and mapped operations with literal operand shapes, flow kind, success, failure rows, requirement rows, and access.
+- [x] 1.3 Add syntax, kind, provider-equality, damaged, and visibility fixtures for complete contracts.
 
 ## 2. Literal Ownership and Subsumption
 

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -583,8 +583,10 @@ export interface InterfaceFact {
 }
 
 const interfaceOperandAccess = (type: DeclaredTypeFact): InterfaceOperandAccess => {
+  if (type._tag === 'Reference' || type._tag === 'Slice') return type.access
   if (type._tag !== 'Resolved') return 'Unavailable'
-  return Type.isReference(type.type) ? type.type.access : 'Take'
+  if (Type.isReference(type.type) || Type.isSlice(type.type)) return type.type.access
+  return 'Take'
 }
 
 const interfaceReceiverAccess = (
@@ -703,8 +705,22 @@ const applyInterfaceOperation = (
   source: InterfaceOperationContractFact,
   capability: Type.Nominal,
   provider: Type.Type,
-  substitution: Type.Substitution,
+  substitution: Type.Substitution | undefined,
 ): InterfaceOperationApplicationFact => {
+  if (substitution === undefined)
+    return Object.freeze({
+      _tag: 'InterfaceOperationApplication',
+      declaration: source.declaration,
+      capability,
+      provider,
+      source,
+      functionKind: source.functionKind,
+      operands: source.operands,
+      success: source.success,
+      failureRow: source.failureRow,
+      requirementRow: source.requirementRow,
+      receiverAccess: source.receiverAccess,
+    })
   const operands = Object.freeze(
     source.operands.map((operand): InterfaceOperandFact => {
       const type = substituteDeclaredTypeFact(operand.type, substitution)
@@ -745,6 +761,13 @@ const applyInterfaceOperation = (
   })
 }
 
+const interfaceOperationAvailable = (operation: InterfaceOperationApplicationFact): boolean =>
+  operation.operands.every((operand) => operand.type._tag === 'Resolved') &&
+  operation.success._tag === 'Resolved' &&
+  operation.failureRow.available &&
+  operation.requirementRow.available &&
+  operation.receiverAccess !== 'Unavailable'
+
 const interfaceApplication = (
   declaration: InterfaceFact,
   capability: Type.Nominal,
@@ -760,11 +783,17 @@ const interfaceApplication = (
     declaration.typeParameters.map((parameter) => parameter.type),
     capability.arguments,
   )
-  const available = providerMatches && substitution !== undefined
   const sourceContracts =
     declaration.operationContracts.length === declaration.operations.length
       ? declaration.operationContracts
       : interfaceOperationContracts(declaration.typeParameters, declaration.operations)
+  const operations = Object.freeze(
+    sourceContracts.map((operation) =>
+      applyInterfaceOperation(operation, capability, provider, substitution),
+    ),
+  )
+  const available =
+    providerMatches && substitution !== undefined && operations.every(interfaceOperationAvailable)
   return Object.freeze({
     _tag: 'InterfaceApplication',
     declaration: declaration.canonical.id,
@@ -772,14 +801,7 @@ const interfaceApplication = (
     provider,
     providerMatches,
     visibility: declaration.visibility,
-    operations:
-      available && substitution !== undefined
-        ? Object.freeze(
-            sourceContracts.map((operation) =>
-              applyInterfaceOperation(operation, capability, provider, substitution),
-            ),
-          )
-        : Object.freeze([]),
+    operations,
     available,
   })
 }

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -62,13 +62,13 @@ export type BoundFact =
       readonly _tag: 'ResolvedBound'
       readonly spelling: string
       readonly path: TypePathFact
-      readonly capability: CanonicalId
-      readonly operations: ReadonlyArray<string>
+      readonly application: InterfaceApplicationFact
     }
   | {
       readonly _tag: 'UnresolvedBound'
       readonly spelling: string
       readonly path: TypePathFact
+      readonly application: DeclaredTypeFact
     }
 
 /** One ordered, declaration-owned generic type parameter with exact source provenance. */
@@ -205,6 +205,21 @@ export type DeclaredTypeFact =
       readonly _tag: 'Applied'
       readonly target: DeclaredTypeFact
       readonly arguments: ReadonlyArray<DeclaredTypeFact>
+      readonly failureRow?: {
+        readonly failures: ReadonlyArray<DeclaredTypeFact>
+        readonly parameters: ReadonlyArray<Type.Parameter>
+        readonly syntax: SyntaxTree.Node
+      }
+      readonly requirementRow?: {
+        readonly requirements: ReadonlyArray<{
+          readonly capability: DeclaredTypeFact
+          readonly role: string
+          readonly access: Type.Requirement['access']
+          readonly syntax: SyntaxTree.Node
+        }>
+        readonly parameters: ReadonlyArray<Type.Parameter>
+        readonly syntax: SyntaxTree.Node
+      }
       readonly spelling: string
       readonly token: Token.Token
       readonly syntax: SyntaxTree.Node
@@ -485,6 +500,63 @@ export interface ServiceOperationFact {
   readonly syntax: SyntaxTree.Node
 }
 
+/** The literal ownership promised by one source interface operand. */
+export type InterfaceOperandAccess = 'Shared' | 'Exclusive' | 'Take' | 'Unavailable'
+
+/** One source interface operand with its authored type shape and ownership retained together. */
+export interface InterfaceOperandFact {
+  readonly _tag: 'InterfaceOperand'
+  readonly parameter: ParameterFact
+  readonly type: DeclaredTypeFact
+  readonly access: InterfaceOperandAccess
+}
+
+/**
+ * One complete operation contract owned by a source interface declaration.
+ *
+ * Interface operations reuse service-operation syntax, but this fact gives the static interface
+ * path its own vocabulary: literal operands, flow kind, success, exact rows, and the access of the
+ * operand that denotes the provider. It remains compile-time data and creates no service slot.
+ */
+export interface InterfaceOperationContractFact {
+  readonly _tag: 'InterfaceOperationContract'
+  readonly declaration: ServiceOperationFact
+  readonly provider?: Type.Type
+  readonly functionKind: ServiceOperationFact['functionKind']
+  readonly operands: ReadonlyArray<InterfaceOperandFact>
+  readonly success: ReturnTypeFact
+  readonly failureRow: FailureRowFact
+  readonly requirementRow: RequirementRowFact
+  readonly receiverAccess: InterfaceOperandAccess
+}
+
+/** One complete interface operation after substituting a particular interface application. */
+export interface InterfaceOperationApplicationFact
+  extends Omit<InterfaceOperationContractFact, '_tag'> {
+  readonly _tag: 'InterfaceOperationApplication'
+  readonly capability: Type.Nominal
+  readonly provider: Type.Type
+  readonly source: InterfaceOperationContractFact
+}
+
+/**
+ * One interface application retained on a bound.
+ *
+ * `providerMatches` is an explicit fact rather than an assumption: complete contracts may only be
+ * consumed when the interface's first argument is the bounded provider. Damaged applications stay
+ * visible with `available: false` and never collapse into an operation-free interface.
+ */
+export interface InterfaceApplicationFact {
+  readonly _tag: 'InterfaceApplication'
+  readonly declaration: CanonicalId
+  readonly capability: Type.Nominal
+  readonly provider: Type.Type
+  readonly providerMatches: boolean
+  readonly visibility: InterfaceFact['visibility']
+  readonly operations: ReadonlyArray<InterfaceOperationApplicationFact>
+  readonly available: boolean
+}
+
 /** One nominal runtime-service contract declared in ordinary Silk source. */
 export interface ServiceFact {
   readonly _tag: 'ServiceDeclaration'
@@ -506,7 +578,210 @@ export interface InterfaceFact {
   readonly typeParameters: ReadonlyArray<TypeParameterFact>
   readonly name: DeclaredName
   readonly operations: ReadonlyArray<ServiceOperationFact>
+  readonly operationContracts: ReadonlyArray<InterfaceOperationContractFact>
   readonly syntax: SyntaxTree.Node
+}
+
+const interfaceOperandAccess = (type: DeclaredTypeFact): InterfaceOperandAccess => {
+  if (type._tag !== 'Resolved') return 'Unavailable'
+  return Type.isReference(type.type) ? type.type.access : 'Take'
+}
+
+const interfaceReceiverAccess = (
+  operands: ReadonlyArray<InterfaceOperandFact>,
+  provider: Type.Type | undefined,
+): InterfaceOperandAccess => {
+  if (provider === undefined) return 'Unavailable'
+  return (
+    operands.find((operand) => {
+      if (operand.type._tag !== 'Resolved') return false
+      const type = operand.type.type
+      return Type.equals(Type.isReference(type) ? type.target : type, provider)
+    })?.access ?? 'Unavailable'
+  )
+}
+
+const interfaceOperationContract = (
+  operation: ServiceOperationFact,
+  provider: Type.Type | undefined,
+): InterfaceOperationContractFact => {
+  const operands = Object.freeze(
+    operation.parameters.map(
+      (parameter): InterfaceOperandFact =>
+        Object.freeze({
+          _tag: 'InterfaceOperand',
+          parameter,
+          type: parameter.declaredType,
+          access: interfaceOperandAccess(parameter.declaredType),
+        }),
+    ),
+  )
+  return Object.freeze({
+    _tag: 'InterfaceOperationContract',
+    declaration: operation,
+    ...(provider === undefined ? {} : { provider }),
+    functionKind: operation.functionKind,
+    operands,
+    success: operation.returnType,
+    failureRow: operation.failureRow,
+    requirementRow: operation.requirementRow,
+    receiverAccess: interfaceReceiverAccess(operands, provider),
+  })
+}
+
+const interfaceOperationContracts = (
+  parameters: ReadonlyArray<TypeParameterFact>,
+  operations: ReadonlyArray<ServiceOperationFact>,
+): ReadonlyArray<InterfaceOperationContractFact> => {
+  const provider = parameters.at(0)?.type
+  return Object.freeze(
+    operations.map((operation) => interfaceOperationContract(operation, provider)),
+  )
+}
+
+const substituteDeclaredTypeFact = (
+  fact: DeclaredTypeFact,
+  substitution: Type.Substitution,
+): DeclaredTypeFact => {
+  if (fact._tag !== 'Resolved') return fact
+  const type = Type.substitute(fact.type, substitution)
+  return Object.freeze({ ...fact, type, spelling: Type.encode(type) })
+}
+
+const substituteFailureRowFact = (
+  fact: FailureRowFact,
+  substitution: Type.Substitution,
+  rows: Type.Effect,
+): FailureRowFact => {
+  const members = Object.freeze(
+    fact.members.map((member) => substituteDeclaredTypeFact(member, substitution)),
+  )
+  return Object.freeze({
+    ...fact,
+    members,
+    parameters: rows.failureParameters,
+    failures: rows.failures,
+    available:
+      rows.failureParameters.length === 0 &&
+      members.every(
+        (member) =>
+          member._tag === 'Resolved' && Type.isNominal(member.type) && Type.isConcrete(member.type),
+      ),
+  })
+}
+
+const substituteRequirementRowFact = (
+  fact: RequirementRowFact,
+  substitution: Type.Substitution,
+  rows: Type.Effect,
+): RequirementRowFact => {
+  const entries = Object.freeze(
+    fact.entries.map((entry) =>
+      Object.freeze({
+        ...entry,
+        capability: substituteDeclaredTypeFact(entry.capability, substitution),
+      }),
+    ),
+  )
+  return Object.freeze({
+    ...fact,
+    entries,
+    parameters: rows.requirementParameters,
+    requirements: rows.requirements,
+    available:
+      rows.requirementParameters.length === 0 &&
+      entries.every(
+        (entry) =>
+          entry.capability._tag === 'Resolved' &&
+          (Type.isNominal(entry.capability.type) ||
+            (Type.isParameter(entry.capability.type) && entry.capability.type.kind === 'Value')),
+      ),
+  })
+}
+
+const applyInterfaceOperation = (
+  source: InterfaceOperationContractFact,
+  capability: Type.Nominal,
+  provider: Type.Type,
+  substitution: Type.Substitution,
+): InterfaceOperationApplicationFact => {
+  const operands = Object.freeze(
+    source.operands.map((operand): InterfaceOperandFact => {
+      const type = substituteDeclaredTypeFact(operand.type, substitution)
+      return Object.freeze({
+        ...operand,
+        parameter: Object.freeze({ ...operand.parameter, declaredType: type }),
+        type,
+        access: interfaceOperandAccess(type),
+      })
+    }),
+  )
+  const substitutedRows = Type.substitute(
+    Type.effect(
+      Type.unit,
+      source.failureRow.failures,
+      'Shared',
+      source.requirementRow.requirements,
+      source.failureRow.parameters,
+      source.requirementRow.parameters,
+    ),
+    substitution,
+  )
+  const rows = Type.isEffect(substitutedRows)
+    ? substitutedRows
+    : Type.effect(Type.unit, [], 'Shared')
+  return Object.freeze({
+    _tag: 'InterfaceOperationApplication',
+    declaration: source.declaration,
+    capability,
+    provider,
+    source,
+    functionKind: source.functionKind,
+    operands,
+    success: substituteDeclaredTypeFact(source.success, substitution),
+    failureRow: substituteFailureRowFact(source.failureRow, substitution, rows),
+    requirementRow: substituteRequirementRowFact(source.requirementRow, substitution, rows),
+    receiverAccess: interfaceReceiverAccess(operands, provider),
+  })
+}
+
+const interfaceApplication = (
+  declaration: InterfaceFact,
+  capability: Type.Nominal,
+  provider: Type.Type,
+): InterfaceApplicationFact | undefined => {
+  if (declaration.canonical._tag !== 'Canonical') return undefined
+  const declaredProvider = capability.arguments.at(0)
+  const providerMatches =
+    declaredProvider !== undefined &&
+    Type.isTypeArgument(declaredProvider) &&
+    Type.equals(declaredProvider, provider)
+  const substitution = Type.substitution(
+    declaration.typeParameters.map((parameter) => parameter.type),
+    capability.arguments,
+  )
+  const available = providerMatches && substitution !== undefined
+  const sourceContracts =
+    declaration.operationContracts.length === declaration.operations.length
+      ? declaration.operationContracts
+      : interfaceOperationContracts(declaration.typeParameters, declaration.operations)
+  return Object.freeze({
+    _tag: 'InterfaceApplication',
+    declaration: declaration.canonical.id,
+    capability,
+    provider,
+    providerMatches,
+    visibility: declaration.visibility,
+    operations:
+      available && substitution !== undefined
+        ? Object.freeze(
+            sourceContracts.map((operation) =>
+              applyInterfaceOperation(operation, capability, provider, substitution),
+            ),
+          )
+        : Object.freeze([]),
+    available,
+  })
 }
 
 /**
@@ -568,6 +843,7 @@ export interface ConformanceFact {
     readonly target:
       | TypePathFact
       | { readonly _tag: 'Unavailable'; readonly syntax: SyntaxTree.Element }
+    readonly contract?: InterfaceOperationApplicationFact
     readonly syntax: SyntaxTree.Node
   }>
   readonly hook?: DropHookFact
@@ -1498,11 +1774,119 @@ export const analyzeDeclaredType = (
         diagnostics: Object.freeze(diagnostics),
       })
     }
+    const failureRowSyntax = SyntaxTree.directNode(list, 'FailureRow')
+    const failureType = failureRowSyntax?.children.find(isDeclaredTypeNode)
+    const failureNodes =
+      failureType?.kind === 'UnionType'
+        ? failureType.children.filter(isDeclaredTypeNode)
+        : failureType === undefined
+          ? []
+          : [failureType]
+    const failureParameters: Array<Type.Parameter> = []
+    const rowDiagnostics: Array<Diagnostic.Diagnostic> = []
+    const failures = failureNodes.flatMap((member): ReadonlyArray<TypeResolution> => {
+      const parameter = parameterAtTypePath(source, member, typeParameters)
+      if (parameter?.kind === 'FailureRow') {
+        failureParameters.push(parameter)
+        return []
+      }
+      if (parameter?.kind === 'RequirementRow') {
+        const token = SyntaxTree.directToken(member, 'Identifier')
+        if (token !== undefined)
+          rowDiagnostics.push(
+            Diagnostic.genericParameterKindMismatch(
+              spelling(source, token),
+              'FailureRow',
+              parameter.kind,
+              token.span,
+            ),
+          )
+        return []
+      }
+      return [analyzeDeclaredType(source, member, typeParameters)]
+    })
+    const requirementRowSyntax = SyntaxTree.directNode(list, 'RequirementRow')
+    const requirements =
+      requirementRowSyntax?.children
+        .filter(
+          (element): element is SyntaxTree.Node =>
+            SyntaxTree.isNode(element) && element.kind === 'Requirement',
+        )
+        .map((requirement) => {
+          const capability = requirement.children.find(isDeclaredTypeNode)
+          const analyzed =
+            capability === undefined
+              ? Object.freeze({
+                  fact: Object.freeze({ _tag: 'Unavailable' as const, syntax: requirement }),
+                  diagnostics: Object.freeze<ReadonlyArray<Diagnostic.Diagnostic>>([]),
+                })
+              : analyzeDeclaredType(source, capability, typeParameters)
+          const role = SyntaxTree.directToken(requirement, 'Identifier')
+          return Object.freeze({
+            capability: analyzed,
+            role: role === undefined ? 'DefaultRole' : spelling(source, role),
+            access:
+              SyntaxTree.directToken(requirement, 'MutKeyword') === undefined
+                ? ('Shared' as const)
+                : ('Exclusive' as const),
+            syntax: requirement,
+          })
+        }) ?? []
+    const requirementParameters =
+      requirementRowSyntax?.children
+        .filter(
+          (element): element is SyntaxTree.Node =>
+            SyntaxTree.isNode(element) && element.kind === 'TypePath',
+        )
+        .flatMap((path): ReadonlyArray<Type.Parameter> => {
+          const token = SyntaxTree.directToken(path, 'Identifier')
+          const parameter = parameterAtTypePath(source, path, typeParameters)
+          if (parameter?.kind === 'RequirementRow') return [parameter]
+          if (token !== undefined) {
+            if (parameter === undefined)
+              rowDiagnostics.push(Diagnostic.unknownType(spelling(source, token), token.span))
+            else
+              rowDiagnostics.push(
+                Diagnostic.genericParameterKindMismatch(
+                  spelling(source, token),
+                  'RequirementRow',
+                  parameter.kind,
+                  token.span,
+                ),
+              )
+          }
+          return []
+        }) ?? []
     return Object.freeze({
       fact: Object.freeze({
         _tag: 'Applied',
         target: target.fact,
         arguments: Object.freeze(arguments_.map((argument) => argument.fact)),
+        ...(failureRowSyntax === undefined
+          ? {}
+          : {
+              failureRow: Object.freeze({
+                failures: Object.freeze(failures.map((failure) => failure.fact)),
+                parameters: Object.freeze(failureParameters),
+                syntax: failureRowSyntax,
+              }),
+            }),
+        ...(requirementRowSyntax === undefined
+          ? {}
+          : {
+              requirementRow: Object.freeze({
+                requirements: Object.freeze(
+                  requirements.map((requirement) =>
+                    Object.freeze({
+                      ...requirement,
+                      capability: requirement.capability.fact,
+                    }),
+                  ),
+                ),
+                parameters: Object.freeze(requirementParameters),
+                syntax: requirementRowSyntax,
+              }),
+            }),
         spelling: SyntaxTree.tokens(syntax)
           .filter(
             (token) =>
@@ -1516,6 +1900,9 @@ export const analyzeDeclaredType = (
       diagnostics: Diagnostic.merge(
         target.diagnostics,
         ...arguments_.map((argument) => argument.diagnostics),
+        ...failures.map((failure) => failure.diagnostics),
+        ...requirements.map((requirement) => requirement.capability.diagnostics),
+        rowDiagnostics,
       ),
     })
   }
@@ -1859,6 +2246,9 @@ const collectTypeParameters = (
               ]),
               syntax: boundNode,
             }),
+            application:
+              boundResolution?.fact ??
+              Object.freeze({ _tag: 'Unavailable' as const, syntax: boundNode }),
           })
     const duplicateOf = name._tag === 'Present' ? environment.get(name.spelling) : undefined
     const type =
@@ -2329,7 +2719,7 @@ const collectModule = (syntax: SyntaxFile.SyntaxFile): ModuleHeaders => {
         })
       }
     }
-    const visibility =
+    const visibility: 'Private' | 'Public' =
       SyntaxTree.directToken(node, 'PubKeyword') === undefined ? 'Private' : 'Public'
     const typeParameters = collectTypeParameters(
       source,
@@ -2511,11 +2901,7 @@ const collectModule = (syntax: SyntaxFile.SyntaxFile): ModuleHeaders => {
           })
         },
       )
-      return Object.freeze({
-        _tag:
-          node.kind === 'ServiceDeclaration'
-            ? ('ServiceDeclaration' as const)
-            : ('InterfaceDeclaration' as const),
+      const shared = {
         id,
         canonical,
         visibility,
@@ -2523,7 +2909,14 @@ const collectModule = (syntax: SyntaxFile.SyntaxFile): ModuleHeaders => {
         name,
         operations: Object.freeze(operations),
         syntax: node,
-      })
+      }
+      return node.kind === 'InterfaceDeclaration'
+        ? Object.freeze({
+            _tag: 'InterfaceDeclaration',
+            ...shared,
+            operationContracts: interfaceOperationContracts(typeParameters.facts, operations),
+          })
+        : Object.freeze({ _tag: 'ServiceDeclaration', ...shared })
     }
     const parameterList = childNode(node, 'ParameterList')
     const parameters = SyntaxTree.directNodes(parameterList, 'ParameterDeclaration').map(
@@ -3015,20 +3408,80 @@ const resolveDeclaredType = (
     const arguments_ = fact.arguments.map((argument) =>
       resolveDeclaredType(module, argument, resolvers, modules),
     )
+    const failures =
+      fact.failureRow?.failures.map((failure) =>
+        resolveDeclaredType(module, failure, resolvers, modules),
+      ) ?? []
+    const requirements =
+      fact.requirementRow?.requirements.map((requirement) =>
+        Object.freeze({
+          ...requirement,
+          capability: resolveDeclaredType(module, requirement.capability, resolvers, modules),
+        }),
+      ) ?? []
     const diagnostics = [
       ...target.diagnostics,
       ...arguments_.flatMap((argument) => argument.diagnostics),
+      ...failures.flatMap((failure) => failure.diagnostics),
+      ...requirements.flatMap((requirement) => requirement.capability.diagnostics),
     ]
     if (target.fact._tag === 'Resolved' && Type.isNominal(target.fact.type)) {
       const declaration = memberByNominal(modules, target.fact.type)
       const expected =
         declaration?.typeParameters.length ?? Type.intrinsicNominalArity(target.fact.type)
       const declaredParameters = declaration?.typeParameters.map((parameter) => parameter.type)
-      const available = arguments_.map((argument, ordinal): Type.GenericArgument | undefined => {
-        if (argument.fact._tag !== 'Resolved') return undefined
-        return genericArgumentForParameter(declaredParameters?.at(ordinal), argument.fact.type)
-      })
-      if (expected === arguments_.length && available.every((argument) => argument !== undefined)) {
+      const valueArguments = arguments_.map(
+        (argument, ordinal): Type.GenericArgument | undefined => {
+          if (argument.fact._tag !== 'Resolved') return undefined
+          return genericArgumentForParameter(declaredParameters?.at(ordinal), argument.fact.type)
+        },
+      )
+      const failureTypes = failures.flatMap(
+        (failure): ReadonlyArray<Type.Nominal> =>
+          failure.fact._tag === 'Resolved' && Type.isNominal(failure.fact.type)
+            ? [failure.fact.type]
+            : [],
+      )
+      const failuresAvailable = failures.every(
+        (failure) =>
+          failure.fact._tag === 'Resolved' &&
+          (Type.isNominal(failure.fact.type) || Type.isNever(failure.fact.type)),
+      )
+      const requirementTypes = requirements.flatMap(
+        (requirement): ReadonlyArray<Type.Requirement> =>
+          requirement.capability.fact._tag === 'Resolved' &&
+          (Type.isNominal(requirement.capability.fact.type) ||
+            (Type.isParameter(requirement.capability.fact.type) &&
+              requirement.capability.fact.type.kind === 'Value'))
+            ? [
+                Object.freeze({
+                  capability: requirement.capability.fact.type,
+                  role: requirement.role,
+                  access: requirement.access,
+                }),
+              ]
+            : [],
+      )
+      const requirementsAvailable = requirementTypes.length === requirements.length
+      const rowArguments: ReadonlyArray<Type.GenericArgument | undefined> = Object.freeze([
+        ...(fact.failureRow === undefined
+          ? []
+          : [
+              failuresAvailable
+                ? Type.failureRowArgument(failureTypes, fact.failureRow.parameters)
+                : undefined,
+            ]),
+        ...(fact.requirementRow === undefined
+          ? []
+          : [
+              requirementsAvailable
+                ? Type.requirementRowArgument(requirementTypes, fact.requirementRow.parameters)
+                : undefined,
+            ]),
+      ])
+      const available = Object.freeze([...valueArguments, ...rowArguments])
+      const suppliedCount = available.length
+      if (expected === suppliedCount && available.every((argument) => argument !== undefined)) {
         const concrete = available.filter(
           (argument): argument is Type.GenericArgument => argument !== undefined,
         )
@@ -3183,13 +3636,19 @@ const resolveDeclaredType = (
             components: Object.freeze([
               target.fact,
               ...arguments_.map((argument) => argument.fact),
+              ...failures.map((failure) => failure.fact),
+              ...requirements.map((requirement) => requirement.capability.fact),
             ]),
           }),
           diagnostics: Object.freeze(diagnostics),
         })
       }
-      if (expected === arguments_.length) {
-        const unavailable = arguments_.find((argument) => argument.fact._tag !== 'Resolved')
+      if (expected === suppliedCount) {
+        const unavailable = [
+          ...arguments_,
+          ...failures,
+          ...requirements.map((requirement) => requirement.capability),
+        ].find((argument) => argument.fact._tag !== 'Resolved')
         const cause =
           unavailable !== undefined && 'cause' in unavailable.fact
             ? unavailable.fact.cause
@@ -3202,7 +3661,7 @@ const resolveDeclaredType = (
       const diagnostic = Diagnostic.typeArgumentArity(
         fact.spelling,
         expected,
-        arguments_.length,
+        suppliedCount,
         fact.token.span,
       )
       diagnostics.push(diagnostic)
@@ -3469,34 +3928,98 @@ const resolveBounds = (
       }
       const bound = parameter.bound
       if (bound === undefined) return parameter
-      const resolved = resolvers.type(module, bound.path).fact
-      const capability =
-        resolved._tag === 'Resolved' && Type.isNominal(resolved.type) ? resolved.type : undefined
+      const parameterName = parameter.name._tag === 'Present' ? parameter.name : undefined
+      const boundResolvers: ResolutionSeams.ResolutionSeams =
+        parameterName === undefined
+          ? resolvers
+          : Object.freeze({
+              ...resolvers,
+              type: (candidateModule: string, path: TypePathFact): TypeResolution =>
+                path.segments.length === 1 && path.spelling === parameterName.spelling
+                  ? Object.freeze({
+                      fact: Object.freeze({
+                        _tag: 'Resolved' as const,
+                        type: parameter.type,
+                        spelling: parameterName.spelling,
+                        token: parameterName.token,
+                        syntax: path.syntax,
+                        components: Object.freeze([]),
+                      }),
+                      diagnostics: Object.freeze([]),
+                    })
+                  : resolvers.type(candidateModule, path),
+            })
+      const unresolvedCapability =
+        bound._tag === 'ResolvedBound'
+          ? bound.application.capability
+          : (() => {
+              const resolved = resolveDeclaredType(
+                module,
+                bound.application,
+                boundResolvers,
+                modules,
+              ).fact
+              if (resolved._tag === 'Resolved' && Type.isNominal(resolved.type))
+                return resolved.type
+              return resolved._tag === 'Unresolved' &&
+                resolved.candidate !== undefined &&
+                Type.isNominal(resolved.candidate)
+                ? resolved.candidate
+                : undefined
+            })()
       const declaration =
-        capability === undefined ? undefined : memberByNominal(modules, capability)
+        unresolvedCapability === undefined
+          ? undefined
+          : memberByNominal(modules, unresolvedCapability)
       if (
-        capability === undefined ||
+        unresolvedCapability === undefined ||
         declaration?._tag !== 'InterfaceDeclaration' ||
         declaration.canonical._tag !== 'Canonical'
       )
         return Object.freeze({ ...parameter, bound })
+      const capability =
+        unresolvedCapability.arguments.length === 0 && declaration.typeParameters.length === 1
+          ? Type.nominal(unresolvedCapability.module, unresolvedCapability.name, [parameter.type])
+          : unresolvedCapability
+      const application = interfaceApplication(declaration, capability, parameter.type)
+      if (application === undefined) return Object.freeze({ ...parameter, bound })
       return Object.freeze({
         ...parameter,
         bound: Object.freeze({
           _tag: 'ResolvedBound' as const,
           spelling: bound.spelling,
           path: bound.path,
-          capability: declaration.canonical.id,
-          operations: Object.freeze(
-            declaration.operations.flatMap((operation) =>
-              operation.name._tag === 'Present' ? [operation.name.spelling] : [],
-            ),
-          ),
+          application,
         }),
       })
     }),
   )
 }
+
+/** Refreshes resolved bound applications once every interface header has its completed contracts. */
+const refreshInterfaceApplications = (
+  typeParameters: ReadonlyArray<TypeParameterFact>,
+  modules: ReadonlyArray<ModuleHeaders>,
+): ReadonlyArray<TypeParameterFact> =>
+  Object.freeze(
+    typeParameters.map((parameter): TypeParameterFact => {
+      const bound = parameter.bound
+      if (bound?._tag !== 'ResolvedBound') return parameter
+      const declaration = memberByNominal(modules, bound.application.capability)
+      if (declaration?._tag !== 'InterfaceDeclaration') return parameter
+      const application = interfaceApplication(
+        declaration,
+        bound.application.capability,
+        parameter.type,
+      )
+      return application === undefined
+        ? parameter
+        : Object.freeze({
+            ...parameter,
+            bound: Object.freeze({ ...bound, application }),
+          })
+    }),
+  )
 
 /**
  * Reads one conformance's requirements as the interface applications proof search will follow.
@@ -3560,8 +4083,8 @@ const unpromisedWitnessBound = (
         (requirement) =>
           requirement.capability._tag === 'Resolved' &&
           Type.isNominal(requirement.capability.type) &&
-          requirement.capability.type.module === bound.capability.module &&
-          requirement.capability.type.name === bound.capability.name &&
+          requirement.capability.type.module === bound.application.capability.module &&
+          requirement.capability.type.name === bound.application.capability.name &&
           Type.equals(requirement.parameter, header),
       )
     )
@@ -4126,11 +4649,20 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
             requirementRow: requirementRow.fact,
           })
         })
-        return Object.freeze({
+        const completed = Object.freeze({
           ...member,
           typeParameters: resolvedMemberTypeParameters,
           operations: Object.freeze(operations),
         })
+        return completed._tag === 'InterfaceDeclaration'
+          ? Object.freeze({
+              ...completed,
+              operationContracts: interfaceOperationContracts(
+                resolvedMemberTypeParameters,
+                operations,
+              ),
+            })
+          : completed
       }
       const fields = member.fields.map((field) => {
         const resolved = resolveDeclaredType(
@@ -4249,6 +4781,91 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
         members.filter((member): member is ConstantFact => member._tag === 'ConstantDeclaration'),
       ),
       conformances: Object.freeze(conformances),
+    })
+  })
+
+  // Bounds may precede the interface they name, and the first completion pass intentionally reads
+  // the old immutable module graph. Refresh only their applications now that every interface owns
+  // resolved operation contracts; no witness selection or executable behavior is decided here.
+  modules = modules.map((module): ModuleHeaders => {
+    const members = module.members.map((member): MemberFact => {
+      const typeParameters = refreshInterfaceApplications(member.typeParameters, modules)
+      if (member._tag !== 'ServiceDeclaration' && member._tag !== 'InterfaceDeclaration')
+        return Object.freeze({ ...member, typeParameters })
+      const operations = Object.freeze(
+        member.operations.map((operation) =>
+          Object.freeze({
+            ...operation,
+            typeParameters: refreshInterfaceApplications(operation.typeParameters, modules),
+          }),
+        ),
+      )
+      return member._tag === 'InterfaceDeclaration'
+        ? Object.freeze({
+            ...member,
+            typeParameters,
+            operations,
+            operationContracts: interfaceOperationContracts(typeParameters, operations),
+          })
+        : Object.freeze({ ...member, typeParameters, operations })
+    })
+    const conformances = Object.freeze(
+      module.conformances.map((conformance) => {
+        const capability =
+          conformance.capability._tag === 'Resolved' && Type.isNominal(conformance.capability.type)
+            ? conformance.capability.type
+            : undefined
+        const provider =
+          conformance.provider._tag === 'Resolved' ? conformance.provider.type : undefined
+        const declaration =
+          capability === undefined ? undefined : memberByNominal(modules, capability)
+        const application =
+          capability !== undefined &&
+          provider !== undefined &&
+          declaration?._tag === 'InterfaceDeclaration'
+            ? interfaceApplication(declaration, capability, provider)
+            : undefined
+        return Object.freeze({
+          ...conformance,
+          typeParameters: refreshInterfaceApplications(conformance.typeParameters, modules),
+          operations: Object.freeze(
+            conformance.operations.map((operation) => {
+              const contract = application?.operations.find(
+                (candidate) =>
+                  operation.name._tag === 'Present' &&
+                  candidate.declaration.name._tag === 'Present' &&
+                  candidate.declaration.name.spelling === operation.name.spelling,
+              )
+              return Object.freeze({
+                ...operation,
+                ...(contract === undefined ? {} : { contract }),
+              })
+            }),
+          ),
+        })
+      }),
+    )
+    return Object.freeze({
+      ...module,
+      members: Object.freeze(members),
+      declarations: Object.freeze(
+        members.filter(
+          (member): member is DeclarationFact => member._tag === 'FunctionDeclaration',
+        ),
+      ),
+      structs: Object.freeze(
+        members.filter((member): member is StructFact => member._tag === 'StructDeclaration'),
+      ),
+      services: Object.freeze(
+        members.filter((member): member is ServiceFact => member._tag === 'ServiceDeclaration'),
+      ),
+      interfaces: Object.freeze(
+        members.filter((member): member is InterfaceFact => member._tag === 'InterfaceDeclaration'),
+      ),
+      constants: Object.freeze(
+        members.filter((member): member is ConstantFact => member._tag === 'ConstantDeclaration'),
+      ),
+      conformances,
     })
   })
 
@@ -5181,7 +5798,13 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
             }),
           }),
         )
-        return Object.freeze({ ...member, operations: Object.freeze(operations) })
+        const exposed = Object.freeze({ ...member, operations: Object.freeze(operations) })
+        return exposed._tag === 'InterfaceDeclaration'
+          ? Object.freeze({
+              ...exposed,
+              operationContracts: interfaceOperationContracts(exposed.typeParameters, operations),
+            })
+          : exposed
       }
       const fields = member.fields.map((field) =>
         field.visibility === 'Public'

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -764,8 +764,15 @@ const applyInterfaceOperation = (
 const interfaceOperationAvailable = (operation: InterfaceOperationApplicationFact): boolean =>
   operation.operands.every((operand) => operand.type._tag === 'Resolved') &&
   operation.success._tag === 'Resolved' &&
-  operation.failureRow.available &&
-  operation.requirementRow.available &&
+  operation.failureRow.members.every(
+    (member) => member._tag === 'Resolved' && Type.isNominal(member.type),
+  ) &&
+  operation.requirementRow.entries.every(
+    (entry) =>
+      entry.capability._tag === 'Resolved' &&
+      (Type.isNominal(entry.capability.type) ||
+        (Type.isParameter(entry.capability.type) && entry.capability.type.kind === 'Value')),
+  ) &&
   operation.receiverAccess !== 'Unavailable'
 
 const interfaceApplication = (

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -183,6 +183,7 @@ export type CallReferenceFact =
       readonly provider: Type.Parameter
       readonly operation: string
       readonly declaration: DeclarationIndex.ServiceOperationFact
+      readonly interfaceContract: DeclarationIndex.InterfaceOperationApplicationFact
       readonly parameters: ReadonlyArray<SemanticType>
       readonly result: SemanticType
     }
@@ -593,6 +594,7 @@ export interface InterfaceOperationFact {
   readonly capability: Type.Nominal
   readonly provider: Type.Parameter
   readonly operation: string
+  readonly contract: DeclarationIndex.InterfaceOperationApplicationFact
 }
 
 /** One declaration or builtin named as a callable value without invocation. */
@@ -4359,7 +4361,28 @@ const interfaceConstraintDiagnostics = (
             parameter.syntax.span,
           ),
         ]
-      const capability = Type.nominal(bound.capability.module, bound.capability.name, [provider])
+      const substitutedCapability = Type.substitute(bound.application.capability, substitution)
+      if (!Type.isNominal(substitutedCapability))
+        return [
+          Diagnostic.invalidConformance(
+            `unknown interface constraint ${bound.spelling}`,
+            parameter.syntax.span,
+          ),
+        ]
+      const capability = substitutedCapability
+      const declaredProvider = capability.arguments.at(0)
+      if (
+        !bound.application.providerMatches ||
+        declaredProvider === undefined ||
+        !Type.isTypeArgument(declaredProvider) ||
+        !Type.equals(declaredProvider, provider)
+      )
+        return [
+          Diagnostic.invalidConformance(
+            `${bound.spelling} must be applied to its own provider ${Type.encode(provider)}`,
+            parameter.syntax.span,
+          ),
+        ]
       // Selection excludes rejected declarations, but a partial declaration still carries the most
       // useful source error: name the exact operation it failed to map before reporting the broader
       // missing-witness result.
@@ -4475,41 +4498,37 @@ const serviceOperation = (
  * canonical parameter, before any concrete argument exists.
  */
 const interfaceOperationContract = (
-  interface_: DeclarationIndex.InterfaceFact,
-  member: string,
-  parameter: Type.Parameter,
+  operation: DeclarationIndex.InterfaceOperationApplicationFact,
 ):
   | {
       readonly declaration: DeclarationIndex.ServiceOperationFact
+      readonly contract: DeclarationIndex.InterfaceOperationApplicationFact
       readonly parameters: ReadonlyArray<SemanticType>
       readonly result: SemanticType
     }
   | undefined => {
-  const operation = interface_.operations.find(
-    (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === member,
-  )
-  if (
-    operation === undefined ||
-    operation.functionKind !== 'Ordinary' ||
-    operation.typeParameters.length > 0 ||
-    operation.returnType._tag !== 'Resolved'
-  )
+  if (operation.declaration.typeParameters.length > 0 || operation.success._tag !== 'Resolved')
     return undefined
-  const substitution = Type.substitution(
-    interface_.typeParameters.map((declared) => declared.type),
-    Object.freeze([parameter]),
+  const parameters = operation.operands.flatMap((operand) =>
+    operand.type._tag === 'Resolved' ? [operand.type.type] : [],
   )
-  if (substitution === undefined) return undefined
-  const parameters = operation.parameters.flatMap((declared) =>
-    declared.declaredType._tag === 'Resolved'
-      ? [Type.substitute(declared.declaredType.type, substitution)]
-      : [],
-  )
-  if (parameters.length !== operation.parameters.length) return undefined
+  if (parameters.length !== operation.operands.length) return undefined
+  const result =
+    operation.functionKind === 'Ordinary'
+      ? operation.success.type
+      : Type.effect(
+          operation.success.type,
+          operation.failureRow.failures,
+          'Shared',
+          operation.requirementRow.requirements,
+          operation.failureRow.parameters,
+          operation.requirementRow.parameters,
+        )
   return Object.freeze({
-    declaration: operation,
+    declaration: operation.declaration,
+    contract: operation,
     parameters: Object.freeze(parameters),
-    result: Type.substitute(operation.returnType.type, substitution),
+    result,
   })
 }
 
@@ -4545,9 +4564,13 @@ const boundOperationReference = (
     const bound = parameter.bound
     return (
       bound?._tag === 'ResolvedBound' &&
-      bound.capability.module === capability.module &&
-      bound.capability.name === capability.name &&
-      bound.operations.includes(member)
+      bound.application.declaration.module === capability.module &&
+      bound.application.declaration.name === capability.name &&
+      bound.application.operations.some(
+        (operation) =>
+          operation.declaration.name._tag === 'Present' &&
+          operation.declaration.name.spelling === member,
+      )
     )
   })
   if (bounded.length === 0) return undefined
@@ -4562,7 +4585,15 @@ const boundOperationReference = (
     })
   const parameter = bounded.at(0)
   if (parameter === undefined) return undefined
-  const contract = interfaceOperationContract(interface_, member, parameter.type)
+  const bound = parameter.bound
+  if (bound?._tag !== 'ResolvedBound') return undefined
+  const operation = bound.application.operations.find(
+    (candidate) =>
+      candidate.declaration.name._tag === 'Present' &&
+      candidate.declaration.name.spelling === member,
+  )
+  if (operation === undefined) return undefined
+  const contract = interfaceOperationContract(operation)
   if (contract === undefined) return undefined
   return Object.freeze({
     _tag: 'BoundOperation',
@@ -4570,10 +4601,11 @@ const boundOperationReference = (
       _tag: 'ResolvedBoundOperation' as const,
       spelling: `${qualifier}.${member}`,
       token: memberToken,
-      capability: Type.nominal(capability.module, capability.name, [parameter.type]),
+      capability: bound.application.capability,
       provider: parameter.type,
       operation: member,
       declaration: contract.declaration,
+      interfaceContract: contract.contract,
       parameters: contract.parameters,
       result: contract.result,
     }),
@@ -5747,17 +5779,21 @@ const analyzeOperatorExpression = (
           if (!Type.equals(parameter.type, boundOperand) || bound?._tag !== 'ResolvedBound')
             return []
           const operationName = `${operator.slice(0, 1).toLowerCase()}${operator.slice(1)}`
-          return bound.operations.includes(operationName)
-            ? [
+          const contract = bound.application.operations.find(
+            (operation) =>
+              operation.declaration.name._tag === 'Present' &&
+              operation.declaration.name.spelling === operationName,
+          )
+          return contract === undefined
+            ? []
+            : [
                 Object.freeze({
-                  capability: Type.nominal(bound.capability.module, bound.capability.name, [
-                    boundOperand,
-                  ]),
+                  capability: bound.application.capability,
                   provider: boundOperand,
                   operation: operationName,
+                  contract,
                 }),
               ]
-            : []
         })[0]
   const genericInterface = interfaceOperation !== undefined
   const selectedActor: Operator.Actor =
@@ -9174,6 +9210,7 @@ const hirExpression = (fact: ExpressionFact, borrow?: Hir.BorrowId): Hir.Express
       capability: fact.reference.capability,
       provider: fact.reference.provider,
       operation: fact.reference.operation,
+      contract: fact.reference.interfaceContract,
       arguments: Object.freeze(
         fact.arguments.map((argument, ordinal) =>
           hirExpression(

--- a/packages/compiler/src/Hir.ts
+++ b/packages/compiler/src/Hir.ts
@@ -641,6 +641,7 @@ export type Expression =
         readonly capability: Type.Nominal
         readonly provider: Type.Parameter
         readonly operation: string
+        readonly contract: DeclarationIndex.InterfaceOperationApplicationFact
       }
       readonly typeArguments: ReadonlyArray<Type.Type>
       readonly arguments: ReadonlyArray<Expression>
@@ -662,6 +663,7 @@ export type Expression =
       readonly capability: Type.Nominal
       readonly provider: Type.Type
       readonly operation: string
+      readonly contract: DeclarationIndex.InterfaceOperationApplicationFact
       readonly arguments: ReadonlyArray<Expression>
       readonly loanEnds: ReadonlyArray<BorrowId>
       readonly type: DeclarationIndex.SemanticType

--- a/packages/compiler/src/ModuleSurface.ts
+++ b/packages/compiler/src/ModuleSurface.ts
@@ -107,6 +107,30 @@ const declaredType = (value: DeclarationIndex.DeclaredTypeFact): string => {
       return record('AppliedType', [
         declaredType(value.target),
         array(value.arguments.map(declaredType)),
+        optional(
+          value.failureRow === undefined
+            ? undefined
+            : record('FailureRowArgument', [
+                array(value.failureRow.failures.map(declaredType)),
+                array(value.failureRow.parameters.map(type)),
+              ]),
+        ),
+        optional(
+          value.requirementRow === undefined
+            ? undefined
+            : record('RequirementRowArgument', [
+                array(
+                  value.requirementRow.requirements.map((requirement) =>
+                    record('Requirement', [
+                      declaredType(requirement.capability),
+                      requirement.role,
+                      requirement.access,
+                    ]),
+                  ),
+                ),
+                array(value.requirementRow.parameters.map(type)),
+              ]),
+        ),
         boolean(value.cause !== undefined),
       ])
     case 'Effect':

--- a/packages/compiler/src/ModuleSurface.ts
+++ b/packages/compiler/src/ModuleSurface.ts
@@ -146,13 +146,6 @@ const declaredType = (value: DeclarationIndex.DeclaredTypeFact): string => {
   }
 }
 
-const typeParameter = (value: DeclarationIndex.TypeParameterFact): string =>
-  record('TypeParameter', [
-    type(value.type),
-    name(value.name),
-    optional(value.duplicateOf === undefined ? undefined : type(value.duplicateOf)),
-  ])
-
 const opaqueResult = (value: DeclarationIndex.OpaqueResultFact | undefined): string | undefined =>
   value === undefined
     ? undefined
@@ -196,6 +189,69 @@ const requirementRow = (value: DeclarationIndex.RequirementRowFact): string =>
         ]),
       ),
     ),
+  ])
+
+const interfaceOperand = (value: DeclarationIndex.InterfaceOperandFact): string =>
+  record('InterfaceOperand', [
+    number(value.parameter.id.ordinal),
+    declaredType(value.type),
+    value.access,
+  ])
+
+const interfaceOperationContract = (
+  value: DeclarationIndex.InterfaceOperationContractFact,
+): string =>
+  record(value._tag, [
+    name(value.declaration.name),
+    optional(value.provider === undefined ? undefined : type(value.provider)),
+    value.functionKind,
+    array(value.operands.map(interfaceOperand)),
+    declaredType(value.success),
+    failureRow(value.failureRow),
+    requirementRow(value.requirementRow),
+    value.receiverAccess,
+  ])
+
+const interfaceOperationApplication = (
+  value: DeclarationIndex.InterfaceOperationApplicationFact,
+): string =>
+  record(value._tag, [
+    name(value.declaration.name),
+    type(value.capability),
+    type(value.provider),
+    value.functionKind,
+    array(value.operands.map(interfaceOperand)),
+    declaredType(value.success),
+    failureRow(value.failureRow),
+    requirementRow(value.requirementRow),
+    value.receiverAccess,
+  ])
+
+const interfaceApplication = (value: DeclarationIndex.InterfaceApplicationFact): string =>
+  record('InterfaceApplication', [
+    value.declaration.module,
+    value.declaration.name,
+    type(value.capability),
+    type(value.provider),
+    boolean(value.providerMatches),
+    value.visibility,
+    boolean(value.available),
+    array(value.operations.map(interfaceOperationApplication)),
+  ])
+
+const bound = (value: DeclarationIndex.BoundFact | undefined): string | undefined => {
+  if (value === undefined) return undefined
+  return value._tag === 'ResolvedBound'
+    ? record('ResolvedBound', [value.spelling, interfaceApplication(value.application)])
+    : record('UnresolvedBound', [value.spelling, declaredType(value.application)])
+}
+
+const typeParameter = (value: DeclarationIndex.TypeParameterFact): string =>
+  record('TypeParameter', [
+    type(value.type),
+    name(value.name),
+    optional(value.duplicateOf === undefined ? undefined : type(value.duplicateOf)),
+    optional(bound(value.bound)),
   ])
 
 const declaration = (value: DeclarationIndex.DeclarationFact): string =>
@@ -288,6 +344,9 @@ const service = (value: DeclarationIndex.ServiceFact | DeclarationIndex.Interfac
     array(value.typeParameters.map(typeParameter)),
     name(value.name),
     array(value.operations.map(serviceOperation)),
+    ...(value._tag === 'InterfaceDeclaration'
+      ? [array(value.operationContracts.map(interfaceOperationContract))]
+      : []),
   ])
 
 const constantLiteral = (value: DeclarationIndex.ConstantLiteralFact): string => {
@@ -379,6 +438,11 @@ const conformance = (value: DeclarationIndex.ConformanceFact): string =>
           operation.target._tag === 'TypePath'
             ? typePath(operation.target)
             : record('UnavailableTarget'),
+          optional(
+            operation.contract === undefined
+              ? undefined
+              : interfaceOperationApplication(operation.contract),
+          ),
         ]),
       ),
     ),

--- a/packages/compiler/src/Parser.ts
+++ b/packages/compiler/src/Parser.ts
@@ -2620,6 +2620,7 @@ const parseInterfaceDeclaration = (initial: State): NodeResult => {
       : undefined
   const left = expect(typeParameters?.state ?? name.state, 'LeftBrace', [
     'FnKeyword',
+    'EffectKeyword',
     'RightBrace',
     ...topLevelFollowing,
   ])
@@ -2643,7 +2644,7 @@ const parseInterfaceDeclaration = (initial: State): NodeResult => {
     nextSignificantKind(state) !== 'ImplKeyword'
   ) {
     const operation =
-      nextSignificantKind(state) === 'FnKeyword'
+      nextSignificantKind(state) === 'FnKeyword' || nextSignificantKind(state) === 'EffectKeyword'
         ? parseServiceOperation(state)
         : parseServiceInvalidMember(state)
     children = Object.freeze([...children, operation.node])

--- a/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
+++ b/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
@@ -1,0 +1,232 @@
+import { NodeServices } from '@effect/platform-node'
+import { assert, layer } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as FileSystem from 'effect/FileSystem'
+import * as Path from 'effect/Path'
+import * as Analysis from '../src/Analysis.js'
+import type * as DeclarationIndex from '../src/DeclarationIndex.js'
+import * as FormattedDocument from '../src/FormattedDocument.js'
+import * as Formatter from '../src/Formatter.js'
+import * as Lexer from '../src/Lexer.js'
+import * as Parser from '../src/Parser.js'
+import * as SourceFile from '../src/SourceFile.js'
+import * as Type from '../src/Type.js'
+
+const decoder = new TextDecoder()
+const fixture = Effect.fnUntraced(function* (name: string) {
+  const fileSystem = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const fixturePath = yield* path.fromFileUrl(
+    new URL(`./fixtures/complete-interface-contracts/${name}.silk`, import.meta.url),
+  )
+  return yield* fileSystem.readFile(fixturePath)
+})
+const parse = Effect.fnUntraced(function* (name: string) {
+  const source = yield* fixture(name)
+  return Parser.parse(Lexer.lex(SourceFile.make(`complete-interface-contracts/${name}`, source)))
+})
+const analyze = Effect.fnUntraced(function* (name: string) {
+  const source = yield* fixture(name)
+  return yield* Analysis.ofSourceRealized(
+    `complete-interface-contracts/${name}`,
+    source,
+    'wasm32-unknown-unknown',
+  )
+})
+const namedInterface = (
+  index: DeclarationIndex.Index,
+  name: string,
+): DeclarationIndex.InterfaceFact | undefined =>
+  index.modules
+    .flatMap((module) => module.interfaces)
+    .find((candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === name)
+const namedDeclaration = (
+  index: DeclarationIndex.Index,
+  name: string,
+): DeclarationIndex.DeclarationFact | undefined =>
+  index.modules
+    .flatMap((module) => module.declarations)
+    .find((candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === name)
+const encodedOperand = (operand: DeclarationIndex.InterfaceOperandFact): string =>
+  operand.type._tag === 'Resolved' ? Type.encode(operand.type.type) : operand.type._tag
+
+layer(NodeServices.layer)('complete interface contract fixtures', (it) => {
+  it.effect('parses and formats complete kinded interface syntax idempotently', () =>
+    Effect.gen(function* () {
+      const syntax = yield* parse('syntax')
+      assert.deepEqual(syntax.parserDiagnostics, [])
+      const first = yield* Formatter.format(syntax)
+      const text = decoder.decode(FormattedDocument.toUint8Array(first))
+      assert.include(text, 'pub interface Decoder<S, Arguments, A, !E, ?R>')
+      assert.include(text, 'effect fn decode(self: &S, encoded: Arguments) -> A ! E ? R')
+      const second = yield* Formatter.format(
+        Parser.parse(
+          Lexer.lex(
+            SourceFile.make('complete-interface-contracts/formatted', Uint8Array.from(first.bytes)),
+          ),
+        ),
+      )
+      assert.deepEqual(second.bytes, first.bytes)
+      assert.strictEqual(second.changed, false)
+    }),
+  )
+
+  it.effect('retains declaration flow, literal operands, success, rows, access, and kinds', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('syntax')
+      assert.deepEqual(Analysis.diagnostics(snapshot), [])
+      const declaration = namedInterface(Analysis.declarationIndex(snapshot), 'Decoder')
+      assert.strictEqual(declaration?.visibility, 'Public')
+      assert.deepEqual(
+        declaration?.typeParameters.map((parameter) => parameter.type.kind),
+        ['Value', 'Value', 'Value', 'FailureRow', 'RequirementRow'],
+      )
+      const contract = declaration?.operationContracts.at(0)
+      assert.strictEqual(contract?.functionKind, 'Effect')
+      assert.deepEqual(contract?.operands.map(encodedOperand), ['&S', 'Arguments'])
+      assert.deepEqual(
+        contract?.operands.map((operand) => operand.access),
+        ['Shared', 'Take'],
+      )
+      assert.strictEqual(contract?.receiverAccess, 'Shared')
+      assert.strictEqual(
+        contract?.success._tag === 'Resolved' ? Type.encode(contract.success.type) : undefined,
+        'A',
+      )
+      assert.deepEqual(
+        contract?.failureRow.parameters.map((parameter) => parameter.name),
+        ['E'],
+      )
+      assert.deepEqual(
+        contract?.requirementRow.parameters.map((parameter) => parameter.name),
+        ['R'],
+      )
+    }),
+  )
+
+  it.effect('records complete applications and makes provider equality explicit', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('provider-equality')
+      const index = Analysis.declarationIndex(snapshot)
+      const matching = namedDeclaration(index, 'matching')?.typeParameters.at(0)?.bound
+      const mismatched = namedDeclaration(index, 'mismatched')?.typeParameters.at(0)?.bound
+      assert.strictEqual(matching?._tag, 'ResolvedBound')
+      assert.strictEqual(mismatched?._tag, 'ResolvedBound')
+      if (matching?._tag !== 'ResolvedBound' || mismatched?._tag !== 'ResolvedBound') return
+      assert.strictEqual(matching.application.providerMatches, true)
+      assert.strictEqual(matching.application.available, true)
+      assert.strictEqual(mismatched.application.providerMatches, false)
+      assert.strictEqual(mismatched.application.available, false)
+      assert.isTrue(
+        Analysis.diagnostics(snapshot).some((diagnostic) =>
+          diagnostic.message.includes('Decoder must be applied to its own provider'),
+        ),
+      )
+      const contract = matching.application.operations.at(0)
+      assert.deepEqual(contract?.operands.map(encodedOperand), ['&T', 'i32'])
+      assert.strictEqual(
+        contract?.success._tag === 'Resolved' ? Type.encode(contract.success.type) : undefined,
+        'bool',
+      )
+      assert.deepEqual(contract?.failureRow.failures.map(Type.encode), [
+        'complete-interface-contracts/provider-equality.DecodeError',
+      ])
+      assert.strictEqual(contract?.failureRow.available, true)
+      assert.deepEqual(
+        contract?.requirementRow.requirements.map((requirement) => ({
+          capability: Type.encode(requirement.capability),
+          access: requirement.access,
+        })),
+        [
+          {
+            capability: 'complete-interface-contracts/provider-equality.Clock',
+            access: 'Shared',
+          },
+        ],
+      )
+      assert.strictEqual(contract?.requirementRow.available, true)
+    }),
+  )
+
+  it.effect('retains damaged contracts without presenting unavailable shapes as complete', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('damaged')
+      assert.isAbove(Analysis.diagnostics(snapshot).length, 0)
+      const declaration = namedInterface(Analysis.declarationIndex(snapshot), 'Broken')
+      const contract = declaration?.operationContracts.at(0)
+      assert.strictEqual(declaration?.operationContracts.length, 1)
+      assert.deepEqual(contract?.operands.map(encodedOperand), ['&S', 'Unresolved'])
+      assert.deepEqual(
+        contract?.operands.map((operand) => operand.access),
+        ['Shared', 'Unavailable'],
+      )
+      assert.strictEqual(contract?.success._tag, 'Unresolved')
+      assert.strictEqual(contract?.requirementRow.available, false)
+    }),
+  )
+
+  it.effect('carries declaration visibility into each bound application', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('visibility')
+      const index = Analysis.declarationIndex(snapshot)
+      const privateBound = namedDeclaration(index, 'privateBound')?.typeParameters.at(0)?.bound
+      const publicBound = namedDeclaration(index, 'publicBound')?.typeParameters.at(0)?.bound
+      assert.strictEqual(
+        privateBound?._tag === 'ResolvedBound' ? privateBound.application.visibility : undefined,
+        'Private',
+      )
+      assert.strictEqual(
+        publicBound?._tag === 'ResolvedBound' ? publicBound.application.visibility : undefined,
+        'Public',
+      )
+    }),
+  )
+
+  it.effect('keeps representation parameters available to conditional witness binders', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('representation-witness')
+      assert.deepEqual(
+        Analysis.diagnostics(snapshot).filter(
+          (diagnostic) =>
+            diagnostic.span.sourceId === 'complete-interface-contracts/representation-witness',
+        ),
+        [],
+      )
+      const index = Analysis.declarationIndex(snapshot)
+      const conformance = index.modules.flatMap((module) => module.conformances).at(0)
+      const witness = namedDeclaration(index, 'render')
+      assert.strictEqual(conformance?.typeParameters.at(0)?.type.kind, 'CallableRepresentation')
+      assert.strictEqual(witness?.typeParameters.at(0)?.type.kind, 'CallableRepresentation')
+      assert.strictEqual(conformance?.operations.at(0)?.contract?.receiverAccess, 'Take')
+      assert.strictEqual(conformance?.validity._tag, 'ValidConformance')
+    }),
+  )
+
+  it.effect('attaches the complete applied contract before legacy witness compatibility', () =>
+    Effect.gen(function* () {
+      const snapshot = yield* analyze('mapped-effect')
+      const conformance = Analysis.declarationIndex(snapshot)
+        .modules.flatMap((module) => module.conformances)
+        .at(0)
+      const contract = conformance?.operations.at(0)?.contract
+      assert.strictEqual(contract?.functionKind, 'Effect')
+      assert.deepEqual(contract?.operands.map(encodedOperand), [
+        '&complete-interface-contracts/mapped-effect.Schema',
+        'i32',
+      ])
+      assert.strictEqual(contract?.receiverAccess, 'Shared')
+      assert.deepEqual(contract?.failureRow.failures.map(Type.encode), [
+        'complete-interface-contracts/mapped-effect.DecodeError',
+      ])
+      assert.deepEqual(
+        contract?.requirementRow.requirements.map((requirement) =>
+          Type.encode(requirement.capability),
+        ),
+        ['complete-interface-contracts/mapped-effect.Clock'],
+      )
+      // Task 1 only publishes the fact. The existing pure/shared-borrow witness checker remains the
+      // compatibility seam until ownership and row subsumption land in the next slice.
+      assert.strictEqual(conformance?.validity._tag, 'InvalidConformance')
+    }),
+  )
+})

--- a/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
+++ b/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
@@ -101,6 +101,25 @@ layer(NodeServices.layer)('complete interface contract fixtures', (it) => {
         contract?.requirementRow.parameters.map((parameter) => parameter.name),
         ['R'],
       )
+      const bound = namedDeclaration(
+        Analysis.declarationIndex(snapshot),
+        'generic',
+      )?.typeParameters.at(5)?.bound
+      assert.strictEqual(bound?._tag, 'ResolvedBound')
+      if (bound?._tag !== 'ResolvedBound') return
+      assert.strictEqual(bound.application.available, true)
+      assert.deepEqual(
+        bound.application.operations
+          .at(0)
+          ?.failureRow.parameters.map((parameter) => parameter.name),
+        ['E'],
+      )
+      assert.deepEqual(
+        bound.application.operations
+          .at(0)
+          ?.requirementRow.parameters.map((parameter) => parameter.name),
+        ['R'],
+      )
     }),
   )
 

--- a/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
+++ b/packages/compiler/test/CompleteInterfaceContractsFixtures.test.ts
@@ -117,6 +117,14 @@ layer(NodeServices.layer)('complete interface contract fixtures', (it) => {
       assert.strictEqual(matching.application.available, true)
       assert.strictEqual(mismatched.application.providerMatches, false)
       assert.strictEqual(mismatched.application.available, false)
+      assert.strictEqual(mismatched.application.operations.length, 1)
+      const mismatchedOperation = mismatched.application.operations.at(0)
+      assert.strictEqual(
+        mismatchedOperation?.declaration.name._tag === 'Present'
+          ? mismatchedOperation.declaration.name.spelling
+          : undefined,
+        'decode',
+      )
       assert.isTrue(
         Analysis.diagnostics(snapshot).some((diagnostic) =>
           diagnostic.message.includes('Decoder must be applied to its own provider'),
@@ -155,13 +163,28 @@ layer(NodeServices.layer)('complete interface contract fixtures', (it) => {
       const declaration = namedInterface(Analysis.declarationIndex(snapshot), 'Broken')
       const contract = declaration?.operationContracts.at(0)
       assert.strictEqual(declaration?.operationContracts.length, 1)
-      assert.deepEqual(contract?.operands.map(encodedOperand), ['&S', 'Unresolved'])
+      assert.deepEqual(contract?.operands.map(encodedOperand), [
+        '&S',
+        'Unresolved',
+        '&[u8]',
+        '&mut [u8]',
+        'Reference',
+      ])
       assert.deepEqual(
         contract?.operands.map((operand) => operand.access),
-        ['Shared', 'Unavailable'],
+        ['Shared', 'Unavailable', 'Shared', 'Exclusive', 'Exclusive'],
       )
       assert.strictEqual(contract?.success._tag, 'Unresolved')
       assert.strictEqual(contract?.requirementRow.available, false)
+      const bound = namedDeclaration(
+        Analysis.declarationIndex(snapshot),
+        'broken',
+      )?.typeParameters.at(0)?.bound
+      assert.strictEqual(bound?._tag, 'ResolvedBound')
+      if (bound?._tag !== 'ResolvedBound') return
+      assert.strictEqual(bound.application.available, false)
+      assert.strictEqual(bound.application.operations.length, 1)
+      assert.strictEqual(bound.application.operations.at(0)?.success._tag, 'Unresolved')
     }),
   )
 
@@ -195,8 +218,19 @@ layer(NodeServices.layer)('complete interface contract fixtures', (it) => {
       const index = Analysis.declarationIndex(snapshot)
       const conformance = index.modules.flatMap((module) => module.conformances).at(0)
       const witness = namedDeclaration(index, 'render')
-      assert.strictEqual(conformance?.typeParameters.at(0)?.type.kind, 'CallableRepresentation')
-      assert.strictEqual(witness?.typeParameters.at(0)?.type.kind, 'CallableRepresentation')
+      assert.strictEqual(conformance?.requirements.length, 1)
+      assert.strictEqual(
+        conformance?.typeParameters.find(
+          (parameter) => parameter.type.kind === 'CallableRepresentation',
+        )?.type.kind,
+        'CallableRepresentation',
+      )
+      assert.strictEqual(
+        witness?.typeParameters.find(
+          (parameter) => parameter.type.kind === 'CallableRepresentation',
+        )?.type.kind,
+        'CallableRepresentation',
+      )
       assert.strictEqual(conformance?.operations.at(0)?.contract?.receiverAccess, 'Take')
       assert.strictEqual(conformance?.validity._tag, 'ValidConformance')
     }),

--- a/packages/compiler/test/InterfaceBounds.test.ts
+++ b/packages/compiler/test/InterfaceBounds.test.ts
@@ -299,11 +299,18 @@ it.effect('records the resolved bound contract on the declaration it belongs to'
     assert.strictEqual(bound?._tag, 'ResolvedBound')
     if (bound?._tag !== 'ResolvedBound') return
     assert.strictEqual(bound.spelling, 'Arith')
-    assert.deepEqual(bound.capability, {
+    assert.deepEqual(bound.application.declaration, {
       _tag: 'CanonicalDeclarationId',
       module: 'interface-bounds/main',
       name: 'Arith',
     })
-    assert.deepEqual(bound.operations, ['add', 'subtract'])
+    assert.deepEqual(
+      bound.application.operations.map((operation) =>
+        operation.declaration.name._tag === 'Present'
+          ? operation.declaration.name.spelling
+          : 'Unavailable',
+      ),
+      ['add', 'subtract'],
+    )
   }),
 )

--- a/packages/compiler/test/ModuleSurface.test.ts
+++ b/packages/compiler/test/ModuleSurface.test.ts
@@ -87,6 +87,17 @@ it.effect('keeps malformed and unavailable header states deterministic without s
   }),
 )
 
+it.effect('distinguishes damaged applied row arguments in module surfaces', () =>
+  Effect.gen(function* () {
+    const withFailure = (failure: string) => `pub struct Envelope<T, !E> {}
+pub fn inspect(value: Envelope<i32 ! ${failure}>) -> i32 { return 0 }`
+    const left = yield* surface(withFailure('MissingA'))
+    const right = yield* surface(withFailure('MissingB'))
+
+    assert.strictEqual(ModuleSurface.equals(left, right), false)
+  }),
+)
+
 it.effect('excludes conformance hook bodies from the exported semantic surface', () =>
   Effect.gen(function* () {
     const first = yield* surface(`struct Guard {}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/damaged.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/damaged.silk
@@ -1,5 +1,15 @@
 struct Problem {}
 
 interface Broken<S, !E> {
-  effect fn decode(self: &S, encoded: Missing) -> Missing ! E ? &MissingRow
+  effect fn decode(
+    self: &S,
+    encoded: Missing,
+    shared: &[u8],
+    exclusive: &mut [u8],
+    damaged: &mut Missing,
+  ) -> Missing ! E ? &MissingRow
+}
+
+fn broken<T: Broken<T ! Problem>>(value: T) -> T {
+  return move value
 }

--- a/packages/compiler/test/fixtures/complete-interface-contracts/damaged.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/damaged.silk
@@ -1,0 +1,5 @@
+struct Problem {}
+
+interface Broken<S, !E> {
+  effect fn decode(self: &S, encoded: Missing) -> Missing ! E ? &MissingRow
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/mapped-effect.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/mapped-effect.silk
@@ -1,0 +1,15 @@
+struct DecodeError {}
+service Clock {}
+struct Schema {}
+
+interface Decoder<S, Arguments, A, !E, ?R> {
+  effect fn decode(self: &S, encoded: Arguments) -> A ! E ? R
+}
+
+effect fn decode(self: &Schema, encoded: i32) -> bool ! DecodeError ? &Clock {
+  return true
+}
+
+impl Decoder<Schema, i32, bool ! DecodeError ? &Clock> for Schema {
+  decode: Schema.decode
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/provider-equality.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/provider-equality.silk
@@ -1,0 +1,20 @@
+struct DecodeError {}
+service Clock {}
+struct Schema {}
+struct Other {}
+
+interface Decoder<S, Arguments, A, !E, ?R> {
+  effect fn decode(self: &S, encoded: Arguments) -> A ! E ? R
+}
+
+fn matching<T: Decoder<T, i32, bool ! DecodeError ? &Clock>>(value: T) -> T {
+  return move value
+}
+
+fn mismatched<T: Decoder<Other, i32, bool ! DecodeError ? &Clock>>(value: T) -> T {
+  return move value
+}
+
+fn main() -> Other {
+  return mismatched<Other>(Other {})
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/representation-witness.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/representation-witness.silk
@@ -1,15 +1,20 @@
+interface Ready<T> {
+  fn ready(value: T) -> i32
+}
+
 interface Renderer<T, F: fn(i32) -> i32> {
   fn render(value: T) -> i32
 }
 
-struct Box<F: fn(i32) -> i32> {
+struct Box<S, F: fn(i32) -> i32> {
+  source: S
   operation: F
 }
 
-fn render<F: fn(i32) -> i32>(value: &Box<F>) -> i32 {
+fn render<S: Ready<S>, F: fn(i32) -> i32>(value: &Box<S, F>) -> i32 {
   return 1
 }
 
-impl<F: fn(i32) -> i32> Renderer<Box<F>, F> for Box<F> {
+impl<S: Ready<S>, F: fn(i32) -> i32> Renderer<Box<S, F>, F> for Box<S, F> {
   render: Box.render
 }

--- a/packages/compiler/test/fixtures/complete-interface-contracts/representation-witness.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/representation-witness.silk
@@ -1,0 +1,15 @@
+interface Renderer<T, F: fn(i32) -> i32> {
+  fn render(value: T) -> i32
+}
+
+struct Box<F: fn(i32) -> i32> {
+  operation: F
+}
+
+fn render<F: fn(i32) -> i32>(value: &Box<F>) -> i32 {
+  return 1
+}
+
+impl<F: fn(i32) -> i32> Renderer<Box<F>, F> for Box<F> {
+  render: Box.render
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/syntax.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/syntax.silk
@@ -1,0 +1,6 @@
+pub struct DecodeError {}
+pub service Clock {}
+
+pub interface Decoder<S, Arguments, A, !E, ?R> {
+  effect fn decode(self: &S, encoded: Arguments) -> A ! E ? R
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/syntax.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/syntax.silk
@@ -4,3 +4,7 @@ pub service Clock {}
 pub interface Decoder<S, Arguments, A, !E, ?R> {
   effect fn decode(self: &S, encoded: Arguments) -> A ! E ? R
 }
+
+fn generic<S, Arguments, A, !E, ?R, T: Decoder<T, Arguments, A ! E ? R>>(value: T) -> T {
+  return move value
+}

--- a/packages/compiler/test/fixtures/complete-interface-contracts/visibility.silk
+++ b/packages/compiler/test/fixtures/complete-interface-contracts/visibility.silk
@@ -1,0 +1,18 @@
+struct Problem {}
+service Clock {}
+
+interface PrivateDecoder<S, A, !E, ?R> {
+  effect fn decode(self: &S) -> A ! E ? R
+}
+
+pub interface PublicDecoder<S, A, !E, ?R> {
+  effect fn decode(self: &S) -> A ! E ? R
+}
+
+fn privateBound<T: PrivateDecoder<T, i32 ! Problem ? &Clock>>(value: T) -> T {
+  return move value
+}
+
+fn publicBound<T: PublicDecoder<T, i32 ! Problem ? &Clock>>(value: T) -> T {
+  return move value
+}


### PR DESCRIPTION
## Summary

- retain literal operand ownership, flow kind, success, failure/requirement rows, receiver access, visibility, and provider equality on interface declarations and applications
- carry the applied contract into bound calls, operators, mapped operations, HIR, and module surfaces without changing witness lowering
- add complete-contract syntax, kind, provider-equality, damaged, visibility, representation-binder, and compatibility-seam fixtures

## Scope

This is the first slice of `support-complete-interface-contracts`: OpenSpec tasks 1.1–1.3 only. Literal ownership/subsumption, generic mapped-target inference, standard-library migration, and witness lowering remain for later slices.

Refs #192

## Verification

- `pnpm --filter @silk-effect/compiler typecheck`
- `pnpm exec biome check <touched compiler paths>`
- `pnpm --filter @silk-effect/compiler exec vitest run test/CompleteInterfaceContractsFixtures.test.ts test/InterfaceBounds.test.ts test/ConditionalConformance.test.ts test/DeclarationIndex.test.ts --reporter=dot` (72 tests)