### PR TITLE
Realize stored Effect fields

### DIFF
--- a/openspec/changes/store-effects-in-nominals/design.md
+++ b/openspec/changes/store-effects-in-nominals/design.md
@@ -40,7 +40,10 @@ Instance discovery publishes one `EffectInstance` for each concrete source Effec
 contains the canonical runner identity and target, the enclosing concrete arguments, ordered typed
 captures, and suspendability. HIR owns the single projection from an Effect site to the semantic
 origin retained by exact representations; realization and lowering delegate to that projection
-rather than rebuilding its encoding.
+rather than rebuilding its encoding. The retained origin also carries the enclosing executable's
+specialization, so two concrete instantiations of the same generic source site select different
+runner facts. Captured local Effect and callable bindings publish their already-resolved nested
+identities with the ordered environment; later phases never recover them from binding initializers.
 
 `CallableFieldRealization` remains the one resolved-field index and now carries a tagged union. Its
 Effect tag enriches the existing `RepresentationField` identity with the discovered runner, exact

--- a/openspec/changes/store-effects-in-nominals/design.md
+++ b/openspec/changes/store-effects-in-nominals/design.md
@@ -42,8 +42,10 @@ captures, and suspendability. HIR owns the single projection from an Effect site
 origin retained by exact representations; realization and lowering delegate to that projection
 rather than rebuilding its encoding. The retained origin also carries the enclosing executable's
 specialization, so two concrete instantiations of the same generic source site select different
-runner facts. Captured local Effect and callable bindings publish their already-resolved nested
-identities with the ordered environment; later phases never recover them from binding initializers.
+runner facts. Discovery completes that owner with the entire `InstanceKey`, including hidden Effect
+and callable parameter identities rather than only declared source arguments. Captured local Effect
+and callable bindings publish their already-resolved nested identities with the ordered environment;
+later phases never recover them from binding initializers.
 
 `CallableFieldRealization` remains the one resolved-field index and now carries a tagged union. Its
 Effect tag enriches the existing `RepresentationField` identity with the discovered runner, exact

--- a/openspec/changes/store-effects-in-nominals/design.md
+++ b/openspec/changes/store-effects-in-nominals/design.md
@@ -34,6 +34,26 @@ arguments, ordered environment slots, run access, rows, cleanup, and suspendabil
 layout, MIR, and engines consume the same fact. Work stops if a backend requires a separate Effect
 field model or reconstructs runner behavior.
 
+#### Publish one construction fact and extend the shared field index
+
+Instance discovery publishes one `EffectInstance` for each concrete source Effect construction. It
+contains the canonical runner identity and target, the enclosing concrete arguments, ordered typed
+captures, and suspendability. HIR owns the single projection from an Effect site to the semantic
+origin retained by exact representations; realization and lowering delegate to that projection
+rather than rebuilding its encoding.
+
+`CallableFieldRealization` remains the one resolved-field index and now carries a tagged union. Its
+Effect tag enriches the existing `RepresentationField` identity with the discovered runner, exact
+contract rows, actual run access, ordered environment, unrun cleanup lanes, and suspendability. It
+contains no sizes, offsets, row dictionaries, or dispatch ABI. Callable consumers explicitly narrow
+to the callable tag, and no Effect consumer is enabled in this slice, so `SEM0107` still stops every
+stored Effect before layout and MIR.
+
+The task-2 cleanup and suspension cases are realization proofs, not runtime claims. The unrun case
+records the owned lanes that later ownership and cleanup phases must release; the suspension case
+records the exact runner's transitive suspendability. Executing either case remains work for the
+ownership/layout/MIR and engine slices below.
+
 ### Keep Effects lazy and inline
 
 Construction transfers or borrows captures into the nominal but never enters the runner. The

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -6,9 +6,9 @@
 
 ## 2. Stored-Effect Vertical Slice
 
-- [ ] 2.1 Extend resolved field representations with runner, concrete arguments, rows, access, environment, cleanup, and suspendability.
-- [ ] 2.2 Implement one unrun cleanup case and one suspending run case without a standalone structural Effect ABI.
-- [ ] 2.3 Stop and revise the design if any backend reconstructs runner semantics or requires a parallel field model.
+- [x] 2.1 Extend resolved field representations with runner, concrete arguments, rows, access, environment, cleanup, and suspendability.
+- [x] 2.2 Implement one unrun cleanup case and one suspending run case without a standalone structural Effect ABI.
+- [x] 2.3 Stop and revise the design if any backend reconstructs runner semantics or requires a parallel field model.
 
 ## 3. Ownership, Layout, and MIR
 

--- a/packages/compiler/src/CallableFieldRealization.ts
+++ b/packages/compiler/src/CallableFieldRealization.ts
@@ -4,17 +4,18 @@ import * as RepresentationField from './RepresentationField.js'
 import * as Type from './Type.js'
 
 /**
- * The runtime half of nominal callable storage.
+ * The runtime half of nominal executable storage.
  *
  * `RepresentationField` owns the semantic half: stable field identities, the concrete or explicitly
  * unavailable representation argument, the substituted required bound, and admissibility. This
- * actor consumes one of those resolutions and enriches it with everything a runtime phase needs —
- * the static target, its concrete arguments, the ordered capture environment, the receiver access
- * each invocation demands, capture loans, liveness, and cleanup.
+ * actor consumes one of those resolutions and enriches it with one tagged callable or Effect
+ * realization. Effect realizations carry the canonical runner selected by instance discovery, its
+ * concrete arguments, exact compile-time rows, run access, ordered environment, cleanup, and
+ * suspendability without assigning the structural `Effect` contract a standalone target ABI.
  *
- * Ownership, layout, MIR, and every engine read this one record. None of them recovers callable
- * identity from initializer syntax: the target and captures come from the representation argument
- * the frontend already retained and from the specialized callable instance it names.
+ * Existing callable consumers keep reading this record. Effect consumers are deliberately not
+ * enabled by this slice; when later phases arrive, they must consume the Effect tag rather than
+ * recover runners from initializer syntax.
  */
 
 /** How a capture reaches the callable environment stored inside the enclosing aggregate. */
@@ -66,7 +67,7 @@ export interface Cleanup {
 }
 
 /** One resolved callable field enriched with everything construction through cleanup needs. */
-export interface Realization {
+export interface CallableRealization {
   readonly _tag: 'CallableFieldRealization'
   readonly field: RepresentationField.Id
   readonly instance: Type.Nominal
@@ -84,11 +85,76 @@ export interface Realization {
   readonly cleanup: Cleanup
 }
 
+/** One ordered Effect environment slot, still independent of target size and alignment. */
+export interface EffectEnvironmentSlot {
+  readonly _tag: 'EffectEnvironmentSlot'
+  readonly ordinal: number
+  readonly source: 'Parameter' | 'Binding'
+  readonly sourceOrdinal: number
+  readonly access: CaptureAccess
+  readonly type: Type.Type
+  readonly effectIdentity?: string
+  readonly callableIdentity?: Type.CallableIdentityArgument
+  readonly owned: boolean
+  readonly borrowed: boolean
+}
+
+/** Exact compile-time rows carried by one concrete stored Effect. */
+export interface EffectRows {
+  readonly _tag: 'EffectFieldRows'
+  readonly failures: ReadonlyArray<Type.Nominal>
+  readonly requirements: ReadonlyArray<Type.Requirement>
+}
+
+/** The exactly-once obligation retained while a stored Effect has not run. */
+export interface EffectCleanup {
+  readonly _tag: 'EffectFieldCleanup'
+  /** Owned environment ordinals released if the enclosing nominal is dropped before execution. */
+  readonly unrunLanes: ReadonlyArray<number>
+  /** A consuming run transfers those lanes to the runner instead of cleaning them at scope exit. */
+  readonly consumedByRun: boolean
+}
+
+/**
+ * One resolved Effect field. This is a specialization fact for an enclosing nominal, not a
+ * structural Effect layout: no sizes, offsets, runtime row dictionaries, or indirect dispatch live
+ * here.
+ */
+export interface EffectRealization {
+  readonly _tag: 'EffectFieldRealization'
+  readonly field: RepresentationField.Id
+  readonly instance: Type.Nominal
+  readonly contract: Type.Effect
+  readonly requiredBound: Type.Effect
+  readonly runnerIdentity: string
+  readonly runner: Instances.EffectInstance['runner']
+  readonly runnerInstance: Instances.InstanceKey
+  readonly runnerArguments: ReadonlyArray<Type.GenericArgument>
+  readonly site: Hir.EffectSiteId
+  readonly rows: EffectRows
+  readonly access: Type.Effect['access']
+  readonly environment: ReadonlyArray<EffectEnvironmentSlot>
+  readonly cleanup: EffectCleanup
+  readonly suspendable: boolean
+}
+
+/** The one shared tagged realization consumed by represented-field lookups. */
+export type Realization = CallableRealization | EffectRealization
+
 /** Why one resolved representation field has no runtime realization. */
 export type UnsupportedReason =
   | { readonly _tag: 'UnresolvedRepresentation' }
-  | { readonly _tag: 'EffectRepresentation' }
   | { readonly _tag: 'NonCallableBound' }
+  | { readonly _tag: 'NonEffectBound' }
+  | { readonly _tag: 'MissingEffectRunner'; readonly identity: string }
+  | { readonly _tag: 'AmbiguousEffectRunner'; readonly identity: string }
+  | { readonly _tag: 'OpenEffectContract'; readonly identity: string }
+  | {
+      readonly _tag: 'EffectContractMismatch'
+      readonly identity: string
+      readonly expected: Type.Effect
+      readonly actual: Type.Effect
+    }
   | { readonly _tag: 'MissingCallableEnvironment'; readonly environment: string }
   | { readonly _tag: 'AmbiguousCallableEnvironment'; readonly environment: string }
   | {
@@ -180,6 +246,46 @@ const cleanupOf = (captures: ReadonlyArray<CaptureSlot>, invocation: ReceiverAcc
     consumedByInvocation: invocation === 'Take',
   })
 
+const effectEnvironmentSlot = (
+  capture: Instances.EffectInstance['captures'][number],
+): EffectEnvironmentSlot =>
+  Object.freeze({
+    _tag: 'EffectEnvironmentSlot' as const,
+    ordinal: capture.ordinal,
+    source: capture.source,
+    sourceOrdinal: capture.sourceOrdinal,
+    access: capture.access,
+    type: capture.type,
+    ...(capture.effectIdentity === undefined ? {} : { effectIdentity: capture.effectIdentity }),
+    ...(capture.callableIdentity === undefined
+      ? {}
+      : { callableIdentity: capture.callableIdentity }),
+    owned: ownedAccess(capture.access),
+    borrowed: borrowedAccess(capture.access),
+  })
+
+const compareEffectEnvironmentSlots = (
+  left: EffectEnvironmentSlot,
+  right: EffectEnvironmentSlot,
+): number => left.ordinal - right.ordinal || left.sourceOrdinal - right.sourceOrdinal
+
+const effectRows = (contract: Type.Effect): EffectRows =>
+  Object.freeze({
+    _tag: 'EffectFieldRows',
+    failures: Object.freeze([...contract.failures]),
+    requirements: Object.freeze([...contract.requirements]),
+  })
+
+const effectCleanup = (
+  environment: ReadonlyArray<EffectEnvironmentSlot>,
+  access: Type.Effect['access'],
+): EffectCleanup =>
+  Object.freeze({
+    _tag: 'EffectFieldCleanup',
+    unrunLanes: Object.freeze(environment.flatMap((slot) => (slot.owned ? [slot.ordinal] : []))),
+    consumedByRun: access === 'Take',
+  })
+
 /** Structural executable values need their own hidden identity and cannot be an inline lane yet. */
 const hasUnsupportedCaptureLayout = (type: Type.Type): boolean =>
   Type.isCallable(type) ||
@@ -269,27 +375,16 @@ const environmentCaptures = (
   })
 }
 
-/**
- * Enriches one resolved representation field into a runtime realization. The callable instances are
- * the discovery's already-specialized sections; this function never inspects initializer syntax.
- */
-export const realizeField = (
-  resolution: RepresentationField.Resolution,
+type ResolvedField = Extract<
+  RepresentationField.Resolution,
+  { readonly _tag: 'ResolvedRepresentationField' }
+>
+
+const realizeCallableField = (
+  resolution: ResolvedField,
+  identity: Type.CallableIdentityArgument,
   callables: ReadonlyArray<Instances.CallableInstance>,
 ): Support => {
-  if (resolution._tag !== 'ResolvedRepresentationField')
-    return unsupported(
-      resolution.id,
-      resolution.instance,
-      Object.freeze({ _tag: 'UnresolvedRepresentation' }),
-    )
-  const identity = resolution.argument.identity
-  if (!Type.isCallableIdentityArgument(identity))
-    return unsupported(
-      resolution.id,
-      resolution.instance,
-      Object.freeze({ _tag: 'EffectRepresentation' }),
-    )
   const contract = Type.isCallable(resolution.requiredBound)
     ? resolution.requiredBound
     : Type.isCallable(resolution.argument.contract)
@@ -340,10 +435,122 @@ export const realizeField = (
   })
 }
 
+/** One construction shape signature, used only to reject inconsistent duplicate runner facts. */
+const effectShape = (effect: Instances.EffectInstance): string =>
+  [
+    effect.identity,
+    `${effect.runner.module}.${effect.runner.name}`,
+    effect.typeArguments.map(Type.genericArgumentKey).join(','),
+    Type.key(effect.type),
+    effect.suspendable ? 'suspendable' : 'synchronous',
+    ...effect.captures.map(
+      (capture) =>
+        `${capture.ordinal}:${capture.source}:${capture.sourceOrdinal}:${capture.access}:${Type.key(capture.type)}`,
+    ),
+  ].join(' ')
+
+const realizeEffectField = (
+  resolution: ResolvedField,
+  identity: Type.EffectIdentityArgument,
+  effects: ReadonlyArray<Instances.EffectInstance>,
+): Support => {
+  const contract = Type.isEffect(resolution.argument.contract)
+    ? resolution.argument.contract
+    : undefined
+  const requiredBound = Type.isEffect(resolution.requiredBound)
+    ? resolution.requiredBound
+    : undefined
+  if (contract === undefined || requiredBound === undefined)
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({ _tag: 'NonEffectBound' }),
+    )
+  if (!Type.isConcrete(contract))
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({ _tag: 'OpenEffectContract', identity: identity.identity }),
+    )
+  const candidates = effects.filter(
+    (effect) =>
+      effect.identity === identity.identity || effect.representationIdentity === identity.identity,
+  )
+  const selected = candidates.at(0)
+  if (selected === undefined)
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({ _tag: 'MissingEffectRunner', identity: identity.identity }),
+    )
+  if (new Set(candidates.map(effectShape)).size > 1)
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({ _tag: 'AmbiguousEffectRunner', identity: identity.identity }),
+    )
+  if (!Type.equals(selected.type, contract))
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({
+        _tag: 'EffectContractMismatch',
+        identity: identity.identity,
+        expected: contract,
+        actual: selected.type,
+      }),
+    )
+  const environment = Object.freeze(
+    [...selected.captures.map(effectEnvironmentSlot)].sort(compareEffectEnvironmentSlots),
+  )
+  return Object.freeze({
+    _tag: 'Supported',
+    realization: Object.freeze({
+      _tag: 'EffectFieldRealization' as const,
+      field: resolution.id,
+      instance: resolution.instance,
+      contract,
+      requiredBound,
+      runnerIdentity: selected.identity,
+      runner: selected.runner,
+      runnerInstance: selected.owner,
+      runnerArguments: Object.freeze([...selected.typeArguments]),
+      site: selected.site,
+      rows: effectRows(contract),
+      access: contract.access,
+      environment,
+      cleanup: effectCleanup(environment, contract.access),
+      suspendable: selected.suspendable,
+    }),
+  })
+}
+
+/**
+ * Enriches one resolved representation field from the discovery's specialized executable facts.
+ * This function never inspects initializer syntax and never invents a second field identity.
+ */
+export const realizeField = (
+  resolution: RepresentationField.Resolution,
+  callables: ReadonlyArray<Instances.CallableInstance>,
+  effects: ReadonlyArray<Instances.EffectInstance>,
+): Support => {
+  if (resolution._tag !== 'ResolvedRepresentationField')
+    return unsupported(
+      resolution.id,
+      resolution.instance,
+      Object.freeze({ _tag: 'UnresolvedRepresentation' }),
+    )
+  const identity = resolution.argument.identity
+  return Type.isCallableIdentityArgument(identity)
+    ? realizeCallableField(resolution, identity, callables)
+    : realizeEffectField(resolution, identity, effects)
+}
+
 /** Realizes every callable field of one resolved field index in deterministic key order. */
 export const realize = (
   fields: RepresentationField.Index,
   callables: ReadonlyArray<Instances.CallableInstance>,
+  effects: ReadonlyArray<Instances.EffectInstance>,
 ): Index => {
   const entries = new Map<string, Entry>()
   for (const resolution of fields.resolutions) {
@@ -354,7 +561,7 @@ export const realize = (
       Object.freeze({
         _tag: 'CallableFieldRealizationEntry' as const,
         key: entryKey,
-        support: realizeField(resolution, callables),
+        support: realizeField(resolution, callables, effects),
       }),
     )
   }
@@ -388,6 +595,34 @@ export const realizationOf = (
   return support?._tag === 'Supported' ? support.realization : undefined
 }
 
+/** Narrows the shared realization union to the callable variant. */
+export const isCallableRealization = (self: Realization): self is CallableRealization =>
+  self._tag === 'CallableFieldRealization'
+
+/** Narrows the shared realization union to the Effect variant. */
+export const isEffectRealization = (self: Realization): self is EffectRealization =>
+  self._tag === 'EffectFieldRealization'
+
+/** Returns only callable realizations, preserving the Effect storage fence in callable consumers. */
+export const callableRealizationOf = (
+  self: Index,
+  instance: Type.Nominal,
+  id: RepresentationField.Id,
+): CallableRealization | undefined => {
+  const realization = realizationOf(self, instance, id)
+  return realization !== undefined && isCallableRealization(realization) ? realization : undefined
+}
+
+/** Returns only Effect realizations to consumers that are explicitly prepared for that variant. */
+export const effectRealizationOf = (
+  self: Index,
+  instance: Type.Nominal,
+  id: RepresentationField.Id,
+): EffectRealization | undefined => {
+  const realization = realizationOf(self, instance, id)
+  return realization !== undefined && isEffectRealization(realization) ? realization : undefined
+}
+
 /** True when every realized field of one complete instance has a runtime realization. */
 export const supportsInstance = (self: Index, instance: Type.Nominal): boolean => {
   const entries = self.entries.filter((entry) =>
@@ -403,7 +638,7 @@ export const supportsInstance = (self: Index, instance: Type.Nominal): boolean =
 
 /** True when a discovered callable is the complete specialization this realization names. */
 export const matchesCallable = (
-  self: Realization,
+  self: CallableRealization,
   candidate: Instances.CallableInstance,
 ): boolean =>
   self.site !== undefined &&
@@ -416,8 +651,8 @@ export const matchesCallable = (
     Hir.callableEnvironmentIdentity(candidate.site, candidate.owner),
   )
 
-/** Structural equality for the runtime fact owned by this actor. */
-export const equals = (left: Realization, right: Realization): boolean =>
+/** Structural equality for callable runtime facts owned by this actor. */
+const equalsCallable = (left: CallableRealization, right: CallableRealization): boolean =>
   key(left.instance, left.field) === key(right.instance, right.field) &&
   Type.equals(left.contract, right.contract) &&
   Hir.sameCallableTarget(
@@ -451,6 +686,53 @@ export const equals = (left: Realization, right: Realization): boolean =>
   left.cleanup.lanes.length === right.cleanup.lanes.length &&
   left.cleanup.lanes.every((lane, ordinal) => lane === right.cleanup.lanes.at(ordinal))
 
+const equalsEffectEnvironment = (
+  left: ReadonlyArray<EffectEnvironmentSlot>,
+  right: ReadonlyArray<EffectEnvironmentSlot>,
+): boolean =>
+  left.length === right.length &&
+  left.every((slot, ordinal) => {
+    const candidate = right.at(ordinal)
+    return (
+      candidate !== undefined &&
+      slot.ordinal === candidate.ordinal &&
+      slot.source === candidate.source &&
+      slot.sourceOrdinal === candidate.sourceOrdinal &&
+      slot.access === candidate.access &&
+      Type.equals(slot.type, candidate.type) &&
+      slot.effectIdentity === candidate.effectIdentity &&
+      ((slot.callableIdentity === undefined && candidate.callableIdentity === undefined) ||
+        (slot.callableIdentity !== undefined &&
+          candidate.callableIdentity !== undefined &&
+          Type.equalsGenericArgument(slot.callableIdentity, candidate.callableIdentity))) &&
+      slot.owned === candidate.owned &&
+      slot.borrowed === candidate.borrowed
+    )
+  })
+
+const equalsEffect = (left: EffectRealization, right: EffectRealization): boolean =>
+  key(left.instance, left.field) === key(right.instance, right.field) &&
+  Type.equals(left.contract, right.contract) &&
+  Type.equals(left.requiredBound, right.requiredBound) &&
+  left.runnerIdentity === right.runnerIdentity &&
+  left.runner.module === right.runner.module &&
+  left.runner.name === right.runner.name &&
+  sameArguments(left.runnerArguments, right.runnerArguments) &&
+  Hir.sameExecutableSite(left.site, right.site) &&
+  equalsEffectEnvironment(left.environment, right.environment) &&
+  left.cleanup.consumedByRun === right.cleanup.consumedByRun &&
+  left.cleanup.unrunLanes.length === right.cleanup.unrunLanes.length &&
+  left.cleanup.unrunLanes.every((lane, ordinal) => lane === right.cleanup.unrunLanes.at(ordinal)) &&
+  left.suspendable === right.suspendable
+
+/** Structural equality for the shared tagged realization fact owned by this actor. */
+export const equals = (left: Realization, right: Realization): boolean =>
+  left._tag === 'CallableFieldRealization' && right._tag === 'CallableFieldRealization'
+    ? equalsCallable(left, right)
+    : left._tag === 'EffectFieldRealization' && right._tag === 'EffectFieldRealization'
+      ? equalsEffect(left, right)
+      : false
+
 /** Every invocation mode one receiver access admits, weakest receiver first. */
 export const admittedModes = (receiver: ReceiverAccess): ReadonlyArray<Type.CallableMode> =>
   receiver === 'Shared'
@@ -474,5 +756,5 @@ export const weakerAccess = (left: ReceiverAccess, right: ReceiverAccess): Recei
   admittedModes(left).length <= admittedModes(right).length ? left : right
 
 /** True when one aggregate receiver access may invoke a realization's callable mode. */
-export const admitsInvocation = (self: Realization, receiver: ReceiverAccess): boolean =>
+export const admitsInvocation = (self: CallableRealization, receiver: ReceiverAccess): boolean =>
   admitsMode(receiver, self.invocation)

--- a/packages/compiler/src/CallableFieldRealization.ts
+++ b/packages/compiler/src/CallableFieldRealization.ts
@@ -163,7 +163,7 @@ export type UnsupportedReason =
       readonly type: Type.Type
     }
 
-/** The complete support proof one storage fence consults before admitting a stored callable. */
+/** The complete support proof one storage fence consults before admitting a stored executable. */
 export type Support =
   | { readonly _tag: 'Supported'; readonly realization: Realization }
   | {
@@ -180,7 +180,7 @@ export interface Entry {
   readonly support: Support
 }
 
-/** Complete-instance lookup table for realized and explicitly unsupported callable fields. */
+/** Complete-instance lookup table for realized and explicitly unsupported executable fields. */
 export interface Index {
   readonly _tag: 'CallableFieldRealizationIndex'
   readonly entries: ReadonlyArray<Entry>
@@ -445,9 +445,28 @@ const effectShape = (effect: Instances.EffectInstance): string =>
     effect.suspendable ? 'suspendable' : 'synchronous',
     ...effect.captures.map(
       (capture) =>
-        `${capture.ordinal}:${capture.source}:${capture.sourceOrdinal}:${capture.access}:${Type.key(capture.type)}`,
+        `${capture.ordinal}:${capture.source}:${capture.sourceOrdinal}:${capture.access}:${Type.key(capture.type)}:${capture.effectIdentity ?? ''}:${capture.callableIdentity === undefined ? '' : Type.genericArgumentKey(capture.callableIdentity)}`,
     ),
   ].join(' ')
+
+/** Matches one retained source origin to exactly one enclosing concrete specialization. */
+const matchesEffectIdentity = (
+  identity: Type.EffectIdentityArgument,
+  candidate: Instances.EffectInstance,
+): boolean => {
+  if (candidate.identity === identity.identity) return true
+  if (candidate.representationIdentity !== identity.identity) return false
+  const owner = identity.owner
+  if (owner === undefined) return true
+  return (
+    candidate.owner.declaration.module === owner.declaration.module &&
+    candidate.owner.declaration.name === owner.declaration.name &&
+    sameArguments(
+      owner.typeArguments,
+      candidate.owner.typeArguments.filter((argument) => !Type.isHiddenIdentityArgument(argument)),
+    )
+  )
+}
 
 const realizeEffectField = (
   resolution: ResolvedField,
@@ -472,10 +491,7 @@ const realizeEffectField = (
       resolution.instance,
       Object.freeze({ _tag: 'OpenEffectContract', identity: identity.identity }),
     )
-  const candidates = effects.filter(
-    (effect) =>
-      effect.identity === identity.identity || effect.representationIdentity === identity.identity,
-  )
+  const candidates = effects.filter((effect) => matchesEffectIdentity(identity, effect))
   const selected = candidates.at(0)
   if (selected === undefined)
     return unsupported(
@@ -546,7 +562,7 @@ export const realizeField = (
     : realizeEffectField(resolution, identity, effects)
 }
 
-/** Realizes every callable field of one resolved field index in deterministic key order. */
+/** Realizes every executable field of one resolved field index in deterministic key order. */
 export const realize = (
   fields: RepresentationField.Index,
   callables: ReadonlyArray<Instances.CallableInstance>,

--- a/packages/compiler/src/CallableFieldRealization.ts
+++ b/packages/compiler/src/CallableFieldRealization.ts
@@ -461,10 +461,7 @@ const matchesEffectIdentity = (
   return (
     candidate.owner.declaration.module === owner.declaration.module &&
     candidate.owner.declaration.name === owner.declaration.name &&
-    sameArguments(
-      owner.typeArguments,
-      candidate.owner.typeArguments.filter((argument) => !Type.isHiddenIdentityArgument(argument)),
-    )
+    sameArguments(owner.typeArguments, candidate.owner.typeArguments)
   )
 }
 

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -675,6 +675,7 @@ export interface EffectRequirementBindingFact {
 export interface EffectExpressionFact {
   readonly _tag: 'EffectBlock'
   readonly site: Hir.EffectSiteId
+  readonly representationOwner?: Type.ExecutableSpecializationOwner
   readonly statements: ReadonlyArray<StatementFact>
   readonly captures: ReadonlyArray<EffectCaptureFact>
   readonly bindings: ReadonlyArray<BindingDeclarationFact>
@@ -2738,7 +2739,10 @@ export const representationOfExpression = (
     if (!Type.isEffect(contract)) return undefined
     const site = expression.site
     return Type.exactRepresentationArgument(
-      Type.effectIdentityArgument(Hir.effectRepresentationIdentity(site)),
+      Type.effectIdentityArgument(
+        Hir.effectRepresentationIdentity(site),
+        expression.representationOwner,
+      ),
       contract,
     )
   }
@@ -4972,6 +4976,20 @@ const executableSites = (root: SyntaxTree.Node): ReadonlyMap<SyntaxTree.Node, nu
   return sites
 }
 
+const executableSpecializationOwner = (
+  resolution: ResolutionContext,
+): Type.ExecutableSpecializationOwner | undefined => {
+  const owner = resolution.executableOwner
+  if (owner === undefined) return undefined
+  const declaration = DeclarationIndex.byCanonical(resolution.index, owner)
+  return declaration === undefined
+    ? undefined
+    : Object.freeze({
+        declaration: Object.freeze({ module: owner.module, name: owner.name }),
+        typeArguments: Object.freeze(declaration.typeParameters.map((parameter) => parameter.type)),
+      })
+}
+
 const finishCallableSection = (
   node: SyntaxTree.Node,
   reference: Extract<CallReferenceFact, { readonly _tag: 'Resolved' | 'ResolvedBuiltin' }>,
@@ -4997,19 +5015,7 @@ const finishCallableSection = (
     contract.valid && callable !== undefined
       ? availableExpressionType(callable)
       : unavailableExpressionType
-  const environmentOwner = (() => {
-    const owner = resolution.executableOwner
-    if (owner === undefined) return undefined
-    const declaration = DeclarationIndex.byCanonical(resolution.index, owner)
-    return declaration === undefined
-      ? undefined
-      : Object.freeze({
-          declaration: Object.freeze({ module: owner.module, name: owner.name }),
-          typeArguments: Object.freeze(
-            declaration.typeParameters.map((parameter) => parameter.type),
-          ),
-        })
-  })()
+  const environmentOwner = executableSpecializationOwner(resolution)
   return Object.freeze({
     fact: Object.freeze({
       _tag: 'CallableSection',
@@ -6640,12 +6646,14 @@ function analyzeExpression(
   borrowAllowed = false,
 ): ExpressionResult | undefined {
   if (node.kind === 'EffectExpression') {
+    const representationOwner = executableSpecializationOwner(resolution)
     const block = SyntaxTree.directNode(node, 'Block')
     if (block === undefined)
       return Object.freeze({
         fact: Object.freeze({
           _tag: 'EffectBlock',
           site: executableSite('EffectSiteId', resolution, node),
+          ...(representationOwner === undefined ? {} : { representationOwner }),
           statements: Object.freeze([]),
           captures: Object.freeze([]),
           bindings: Object.freeze([]),
@@ -6704,6 +6712,7 @@ function analyzeExpression(
       fact: Object.freeze({
         _tag: 'EffectBlock',
         site: executableSite('EffectSiteId', resolution, node),
+        ...(representationOwner === undefined ? {} : { representationOwner }),
         statements,
         captures,
         bindings: Object.freeze(nested.bindings),

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -2738,7 +2738,7 @@ export const representationOfExpression = (
     if (!Type.isEffect(contract)) return undefined
     const site = expression.site
     return Type.exactRepresentationArgument(
-      Type.effectIdentityArgument(`effect:${Hir.executableSiteKey(site)}`),
+      Type.effectIdentityArgument(Hir.effectRepresentationIdentity(site)),
       contract,
     )
   }

--- a/packages/compiler/src/Hir.ts
+++ b/packages/compiler/src/Hir.ts
@@ -97,6 +97,10 @@ export const compareExecutableSites = (
 export const executableSiteLabel = (self: EffectSiteId | CallableSiteId): string =>
   executableSiteKey(self).replaceAll('\u0000', ':')
 
+/** Projects one Effect site into the semantic origin retained by exact representations. */
+export const effectRepresentationIdentity = (self: EffectSiteId): string =>
+  `effect:${executableSiteKey(self)}`
+
 /** Projects a HIR callable site into the semantic identity retained across specialization. */
 export const callableEnvironmentSite = (self: CallableSiteId): Type.CallableEnvironmentSite =>
   Type.callableEnvironmentSite(

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -1840,10 +1840,20 @@ const concreteCallables = (
 const concreteEffects = (
   instances: ReadonlyArray<Instance>,
   suspendableEffects: ReadonlySet<string>,
+  results: ReadonlyMap<string, Elaboration.Result>,
+  index: DeclarationIndex.Index,
 ): ReadonlyArray<EffectInstance> => {
   const effects = new Map<string, EffectInstance>()
   for (const instance of instances) {
     const bindings = callableBindings(instance.function)
+    const context: EffectOriginContext = Object.freeze({
+      fn: instance.function,
+      owner: instance.key,
+      substitution: instance.substitution,
+      results,
+      index,
+      resolving: new Set<string>(),
+    })
     const blocks = callableExpressions(instance.function).flatMap((expression) =>
       expression._tag === 'EffectBlock' ? [expression] : [],
     )
@@ -1870,14 +1880,20 @@ const concreteEffects = (
         if (sourceOrdinal === undefined || sourceType === undefined) return []
         const specialized = Type.substitute(sourceType, instance.substitution)
         if (!Type.isConcrete(specialized)) return []
-        const capturedEffectIdentity =
-          source === 'Parameter' && Type.isEffect(specialized)
+        const capturedEffectIdentity = Type.isEffect(specialized)
+          ? source === 'Parameter'
             ? parameterEffectIdentity(instance.function, instance.key, sourceOrdinal)
-            : undefined
-        const capturedCallableIdentity =
-          source === 'Parameter' && Type.isCallable(specialized)
+            : initializer === undefined
+              ? undefined
+              : effectOriginOf(initializer, context)
+          : undefined
+        const capturedCallableIdentity = Type.isCallable(specialized)
+          ? source === 'Parameter'
             ? parameterCallableIdentity(instance.function, instance.key, sourceOrdinal)
-            : undefined
+            : initializer === undefined
+              ? undefined
+              : callableOriginOf(initializer, context)
+          : undefined
         return [
           Object.freeze({
             ordinal,
@@ -2479,7 +2495,7 @@ export const discover = (
     entry,
     instances,
     callables: Object.freeze([...recordedCallables.values()]),
-    effects: concreteEffects(instances, new Set(suspendableEffectIdentities)),
+    effects: concreteEffects(instances, new Set(suspendableEffectIdentities), results, index),
     calls: Object.freeze([...recordedCalls.values()]),
     intrinsics: reachableIntrinsics(instances, index),
     suspendableExecutions: Object.freeze(

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -57,6 +57,28 @@ export interface CallableInstance {
   readonly mode: Type.CallableMode
 }
 
+/** One specialized source Effect construction before any target layout is selected. */
+export interface EffectInstance {
+  readonly _tag: 'EffectInstance'
+  readonly representationIdentity: string
+  readonly identity: string
+  readonly owner: InstanceKey
+  readonly site: Hir.EffectSiteId
+  readonly runner: DeclarationIndex.CanonicalId
+  readonly typeArguments: ReadonlyArray<Type.GenericArgument>
+  readonly captures: ReadonlyArray<{
+    readonly ordinal: number
+    readonly source: 'Parameter' | 'Binding'
+    readonly sourceOrdinal: number
+    readonly access: 'Copy' | 'Shared' | 'Exclusive' | 'Take'
+    readonly type: Type.Type
+    readonly effectIdentity?: string
+    readonly callableIdentity?: Type.CallableIdentityArgument
+  }>
+  readonly type: Type.Effect
+  readonly suspendable: boolean
+}
+
 /** One monomorphic ordinary/effect constructor call with hidden Effect identities resolved. */
 export interface CallInstance {
   readonly _tag: 'CallInstance'
@@ -111,6 +133,7 @@ export interface Discovery {
   readonly entry: Entry
   readonly instances: ReadonlyArray<Instance>
   readonly callables: ReadonlyArray<CallableInstance>
+  readonly effects: ReadonlyArray<EffectInstance>
   readonly calls: ReadonlyArray<CallInstance>
   readonly intrinsics: ReadonlyArray<IntrinsicCall>
   /** Exact concrete function executions that can suspend, excluding lazy result runners. */
@@ -599,8 +622,9 @@ export const representedNominals = (
 }
 
 /**
- * The runtime realization index for every reachable represented callable field. Ownership, layout,
- * MIR, and every engine read realizations from here rather than re-deriving callable identity.
+ * The shared realization index for every reachable represented executable field. Effect entries
+ * remain semantic specialization facts until later phases explicitly consume them; the SEM0107
+ * construction fence therefore stays active.
  */
 export const callableFieldRealizations = (
   self: Discovery,
@@ -609,6 +633,7 @@ export const callableFieldRealizations = (
   CallableFieldRealization.realize(
     RepresentationField.resolveFields(index, representedNominals(self, index)),
     self.callables,
+    self.effects,
   )
 
 /** Rejects reachable constructions that retain bare or represented callable values. */
@@ -655,6 +680,7 @@ export const invalid = (rootModule: string): Discovery =>
     entry: Object.freeze({ _tag: 'Unavailable', reason: 'InvalidSource' }),
     instances: Object.freeze([]),
     callables: Object.freeze([]),
+    effects: Object.freeze([]),
     calls: Object.freeze([]),
     intrinsics: Object.freeze([]),
     suspendableExecutions: Object.freeze([]),
@@ -1807,6 +1833,91 @@ const concreteCallables = (
   return Object.freeze(instances)
 }
 
+/**
+ * Collects specialized semantic facts for every source Effect construction. Represented fields
+ * consume these published facts instead of recovering a runner from construction syntax.
+ */
+const concreteEffects = (
+  instances: ReadonlyArray<Instance>,
+  suspendableEffects: ReadonlySet<string>,
+): ReadonlyArray<EffectInstance> => {
+  const effects = new Map<string, EffectInstance>()
+  for (const instance of instances) {
+    const bindings = callableBindings(instance.function)
+    const blocks = callableExpressions(instance.function).flatMap((expression) =>
+      expression._tag === 'EffectBlock' ? [expression] : [],
+    )
+    for (const block of blocks) {
+      const type = Type.substitute(block.type, instance.substitution)
+      if (!Type.isEffect(type) || !Type.isConcrete(type)) continue
+      const captures = block.captures.flatMap((capture, ordinal) => {
+        const source = capture.binding === undefined ? 'Parameter' : 'Binding'
+        const sourceOrdinal = capture.binding?.ordinal ?? capture.parameter?.ordinal
+        const initializer =
+          sourceOrdinal === undefined || source === 'Parameter'
+            ? undefined
+            : bindings.get(sourceOrdinal)
+        const sourceType =
+          sourceOrdinal === undefined
+            ? undefined
+            : source === 'Parameter'
+              ? instance.function.contract._tag === 'Contract'
+                ? instance.function.contract.parameters.at(sourceOrdinal)
+                : undefined
+              : initializer === undefined || initializer._tag === 'Unavailable'
+                ? undefined
+                : initializer.type
+        if (sourceOrdinal === undefined || sourceType === undefined) return []
+        const specialized = Type.substitute(sourceType, instance.substitution)
+        if (!Type.isConcrete(specialized)) return []
+        const capturedEffectIdentity =
+          source === 'Parameter' && Type.isEffect(specialized)
+            ? parameterEffectIdentity(instance.function, instance.key, sourceOrdinal)
+            : undefined
+        const capturedCallableIdentity =
+          source === 'Parameter' && Type.isCallable(specialized)
+            ? parameterCallableIdentity(instance.function, instance.key, sourceOrdinal)
+            : undefined
+        return [
+          Object.freeze({
+            ordinal,
+            source,
+            sourceOrdinal,
+            access: capture.access,
+            type: specialized,
+            ...(capturedEffectIdentity === undefined
+              ? {}
+              : { effectIdentity: capturedEffectIdentity }),
+            ...(capturedCallableIdentity === undefined
+              ? {}
+              : { callableIdentity: capturedCallableIdentity }),
+          }),
+        ]
+      })
+      if (captures.length !== block.captures.length) continue
+      const identity = effectIdentity(instance.key, block.site)
+      effects.set(
+        identity,
+        Object.freeze({
+          _tag: 'EffectInstance',
+          representationIdentity: Hir.effectRepresentationIdentity(block.site),
+          identity,
+          owner: instance.key,
+          site: block.site,
+          runner: Hir.effectRunnerId(instance.key.declaration, block.site),
+          typeArguments: Object.freeze([...instance.key.typeArguments]),
+          captures: Object.freeze(captures),
+          type,
+          suspendable: suspendableEffects.has(identity),
+        }),
+      )
+    }
+  }
+  return Object.freeze(
+    [...effects.values()].sort((left, right) => left.identity.localeCompare(right.identity)),
+  )
+}
+
 const functionByKey = (
   results: ReadonlyMap<string, Elaboration.Result>,
   key: InstanceKey,
@@ -2134,6 +2245,7 @@ export const discover = (
       entry,
       instances: Object.freeze([]),
       callables: Object.freeze([]),
+      effects: Object.freeze([]),
       calls: Object.freeze([]),
       intrinsics: Object.freeze([]),
       suspendableExecutions: Object.freeze([]),
@@ -2358,12 +2470,16 @@ export const discover = (
   const instances = Object.freeze([...recorded.values()])
   const graph = suspensionGraph(instances, results, index)
   const suspendable = suspendableNodes(graph)
+  const suspendableEffectIdentities = Object.freeze(
+    [...graph.effectIdentities].filter((identity) => suspendable.has(effectNode(identity))).sort(),
+  )
   return Object.freeze({
     _tag: 'InstanceDiscovery',
     rootModule,
     entry,
     instances,
     callables: Object.freeze([...recordedCallables.values()]),
+    effects: concreteEffects(instances, new Set(suspendableEffectIdentities)),
     calls: Object.freeze([...recordedCalls.values()]),
     intrinsics: reachableIntrinsics(instances, index),
     suspendableExecutions: Object.freeze(
@@ -2384,11 +2500,7 @@ export const discover = (
         })
         .sort(compareInstanceKeys),
     ),
-    suspendableEffects: Object.freeze(
-      [...graph.effectIdentities]
-        .filter((identity) => suspendable.has(effectNode(identity)))
-        .sort(),
-    ),
+    suspendableEffects: suspendableEffectIdentities,
     violations: Object.freeze(violations),
   })
 }

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -38,6 +38,23 @@ export interface Instance {
   }>
 }
 
+/** Completes every source executable identity with the full discovered owner specialization. */
+const specializeInstanceType = (
+  type: Type.Type,
+  owner: InstanceKey,
+  substitutions: ReadonlyArray<Type.Substitution>,
+): Type.Type =>
+  Type.specializeExecutableOwner(
+    substitutions.reduce(
+      (specialized, substitution) => Type.substitute(specialized, substitution),
+      type,
+    ),
+    Object.freeze({
+      declaration: owner.declaration,
+      typeArguments: owner.typeArguments,
+    }),
+  )
+
 /** One concrete hidden callable-section construction reachable from an instance. */
 export interface CallableInstance {
   readonly _tag: 'CallableInstance'
@@ -496,7 +513,9 @@ const storedExecutableViolations = (
         .flatMap(Hir.expressionTree)
         .flatMap((expression) => {
           if (expression._tag !== 'Construct' && expression._tag !== 'ArrayConstruct') return []
-          const aggregate = Type.substitute(expression.type, instance.substitution)
+          const aggregate = specializeInstanceType(expression.type, instance.key, [
+            instance.substitution,
+          ])
           const found = storedExecutable(index, aggregate, kind)
           if (found === undefined) return []
           if (
@@ -608,7 +627,7 @@ export const representedNominals = (
       if (expression._tag !== 'Construct' && expression._tag !== 'ArrayConstruct') continue
       collectNominals(
         index,
-        Type.substitute(expression.type, instance.substitution),
+        specializeInstanceType(expression.type, instance.key, [instance.substitution]),
         found,
         new Set(),
       )
@@ -1783,12 +1802,12 @@ const concreteCallables = (
           Type.substituteGenericArgument(argument, ownerSubstitution),
         ]),
       )
-      const type = Type.substitute(Type.substitute(section.type, ownerSubstitution), substitution)
+      const type = specializeInstanceType(section.type, owner, [ownerSubstitution, substitution])
       const arguments_ = targetArguments(section.target, substitution, results)
       const captureTypes = section.captures.flatMap((capture) =>
         capture.value._tag === 'Unavailable'
           ? []
-          : [Type.substitute(Type.substitute(capture.value.type, ownerSubstitution), substitution)],
+          : [specializeInstanceType(capture.value.type, owner, [ownerSubstitution, substitution])],
       )
       if (
         !Type.isCallable(type) ||
@@ -1858,7 +1877,7 @@ const concreteEffects = (
       expression._tag === 'EffectBlock' ? [expression] : [],
     )
     for (const block of blocks) {
-      const type = Type.substitute(block.type, instance.substitution)
+      const type = specializeInstanceType(block.type, instance.key, [instance.substitution])
       if (!Type.isEffect(type) || !Type.isConcrete(type)) continue
       const captures = block.captures.flatMap((capture, ordinal) => {
         const source = capture.binding === undefined ? 'Parameter' : 'Binding'
@@ -1878,7 +1897,9 @@ const concreteEffects = (
                 ? undefined
                 : initializer.type
         if (sourceOrdinal === undefined || sourceType === undefined) return []
-        const specialized = Type.substitute(sourceType, instance.substitution)
+        const specialized = specializeInstanceType(sourceType, instance.key, [
+          instance.substitution,
+        ])
         if (!Type.isConcrete(specialized)) return []
         const capturedEffectIdentity = Type.isEffect(specialized)
           ? source === 'Parameter'

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -36,7 +36,7 @@ export type Representation =
     }
   | {
       readonly _tag: 'CallableEnvironment'
-      readonly realization: CallableFieldRealization.Realization
+      readonly realization: CallableFieldRealization.CallableRealization
       readonly fields: ReadonlyArray<CallableEnvironmentField>
       readonly tailPadding: number
     }
@@ -635,7 +635,7 @@ export const catalog = (
 
   const layoutRepresentedCallable = (
     type: Type.Represented,
-    realization: CallableFieldRealization.Realization,
+    realization: CallableFieldRealization.CallableRealization,
   ): CatalogEntry => {
     const key = Type.key(type)
     const existing = completed.get(key)
@@ -871,7 +871,7 @@ export const catalog = (
           const realization =
             plan === undefined || callableRealizations === undefined
               ? undefined
-              : CallableFieldRealization.realizationOf(callableRealizations, type, plan.id)
+              : CallableFieldRealization.callableRealizationOf(callableRealizations, type, plan.id)
           if (realization === undefined) {
             return unavailable(candidate, Object.freeze(Type.nominals(candidate)), {
               _tag: 'InvalidDeclaration',

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -556,7 +556,7 @@ const representedValueType = (
           ),
           definition.construction.arguments,
         ) &&
-        definition.construction.site === `effect:${Hir.executableSiteKey(candidate.site)}`,
+        definition.construction.site === Hir.effectRepresentationIdentity(candidate.site),
     )
     return environment === undefined
       ? undefined

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -2206,7 +2206,7 @@ export const specializeCleanup = (
  */
 export const realizedCallableCleanup = (
   index: DeclarationIndex.Index,
-  realization: CallableFieldRealization.Realization,
+  realization: CallableFieldRealization.CallableRealization,
 ): CleanupPlan => {
   const type = realization.contract
   const site = realization.site

--- a/packages/compiler/src/Type.ts
+++ b/packages/compiler/src/Type.ts
@@ -97,10 +97,18 @@ export interface RequirementRowArgument {
   readonly parameters: ReadonlyArray<Parameter>
 }
 
+/** The complete enclosing executable specialization retained by a source construction identity. */
+export interface ExecutableSpecializationOwner {
+  readonly declaration: { readonly module: string; readonly name: string }
+  readonly typeArguments: ReadonlyArray<GenericArgument>
+}
+
 /** One compiler-only hidden Effect construction identity used for monomorphic specialization. */
 export interface EffectIdentityArgument {
   readonly _tag: 'EffectIdentityArgument'
   readonly identity: string
+  /** Present for a source site whose runner depends on its enclosing generic specialization. */
+  readonly owner?: ExecutableSpecializationOwner
 }
 
 /** The path- and span-independent construction site of one callable capture environment. */
@@ -120,10 +128,7 @@ export type CallableEnvironmentSite =
 export interface CallableEnvironmentIdentity {
   readonly _tag: 'CallableEnvironmentIdentity'
   readonly site: CallableEnvironmentSite
-  readonly owner: {
-    readonly declaration: { readonly module: string; readonly name: string }
-    readonly typeArguments: ReadonlyArray<GenericArgument>
-  }
+  readonly owner: ExecutableSpecializationOwner
 }
 
 /** One compiler-only hidden callable identity used for monomorphic higher-order lowering. */
@@ -577,8 +582,22 @@ export const requirementRowArgument = (
     parameters: effect('never', [], 'Shared', requirements, [], parameters).requirementParameters,
   })
 
-export const effectIdentityArgument = (identity: string): EffectIdentityArgument =>
-  Object.freeze({ _tag: 'EffectIdentityArgument', identity })
+export const effectIdentityArgument = (
+  identity: string,
+  owner?: ExecutableSpecializationOwner,
+): EffectIdentityArgument =>
+  Object.freeze({
+    _tag: 'EffectIdentityArgument',
+    identity,
+    ...(owner === undefined
+      ? {}
+      : {
+          owner: Object.freeze({
+            declaration: Object.freeze({ ...owner.declaration }),
+            typeArguments: Object.freeze(Array.from(owner.typeArguments)),
+          }),
+        }),
+  })
 
 /** Constructs the stable structural site of one callable capture environment. */
 export const callableEnvironmentSite = (
@@ -923,7 +942,9 @@ export const genericArgumentKey = (self: GenericArgument): string =>
         : isExactRepresentationArgument(self)
           ? `exact-representation:${genericArgumentKey(self.identity)}:${key(self.contract)}`
           : isEffectIdentityArgument(self)
-            ? `effect-identity:${self.identity}`
+            ? self.owner === undefined
+              ? `effect-identity:${self.identity}`
+              : `effect-identity:${self.identity}:owner=${self.owner.declaration.module}.${self.owner.declaration.name}<${self.owner.typeArguments.map(genericArgumentKey).join(',')}>`
             : isCallableIdentityArgument(self)
               ? callableIdentityKey(self)
               : isFailureRowArgument(self)
@@ -1748,7 +1769,7 @@ export const isConcreteGenericArgument = (self: GenericArgument): boolean =>
         : isExactRepresentationArgument(self)
           ? isConcrete(self.contract) && isConcreteGenericArgument(self.identity)
           : isEffectIdentityArgument(self)
-            ? true
+            ? (self.owner?.typeArguments.every(isConcreteGenericArgument) ?? true)
             : isCallableIdentityArgument(self)
               ? self.typeArguments.every(isConcreteGenericArgument) &&
                 (self.environment?.owner.typeArguments.every(isConcreteGenericArgument) ?? true)
@@ -1955,15 +1976,23 @@ export const substituteGenericArgument = (
           ? (() => {
               const contract = substitute(self.contract, substitution)
               if (!isCallable(contract) && !isEffect(contract)) return self
-              const identity = isCallableIdentityArgument(self.identity)
-                ? substituteGenericArgument(self.identity, substitution)
-                : self.identity
+              const identity = substituteGenericArgument(self.identity, substitution)
               return isCallableIdentityArgument(identity) || isEffectIdentityArgument(identity)
                 ? exactRepresentationArgument(identity, contract)
                 : self
             })()
           : isEffectIdentityArgument(self)
-            ? self
+            ? effectIdentityArgument(
+                self.identity,
+                self.owner === undefined
+                  ? undefined
+                  : {
+                      declaration: self.owner.declaration,
+                      typeArguments: self.owner.typeArguments.map((argument) =>
+                        substituteGenericArgument(argument, substitution),
+                      ),
+                    },
+              )
             : isCallableIdentityArgument(self)
               ? callableIdentityArgument(
                   self.identity,

--- a/packages/compiler/src/Type.ts
+++ b/packages/compiler/src/Type.ts
@@ -1585,6 +1585,8 @@ const fold = <A>(self: Type, visitor: FoldVisitor<A>): ReadonlyArray<A> => {
     } else if (isExactRepresentationArgument(argument)) {
       visitArgument(argument.identity)
       visitType(argument.contract)
+    } else if (isEffectIdentityArgument(argument)) {
+      for (const typeArgument of argument.owner?.typeArguments ?? []) visitArgument(typeArgument)
     } else if (isCallableIdentityArgument(argument)) {
       for (const typeArgument of argument.typeArguments) visitArgument(typeArgument)
       for (const typeArgument of argument.environment?.owner.typeArguments ?? [])
@@ -2054,6 +2056,141 @@ export const substituteGenericArgument = (
                       }),
                     )
                   : substitute(self, substitution)
+
+const sameExecutableOwnerDeclaration = (
+  left: ExecutableSpecializationOwner,
+  right: ExecutableSpecializationOwner,
+): boolean =>
+  left.declaration.module === right.declaration.module &&
+  left.declaration.name === right.declaration.name
+
+/**
+ * Replaces a source executable owner's open specialization with one complete discovered instance.
+ * This stays a semantic type transformation: it neither inspects construction syntax nor creates a
+ * second representation identity.
+ */
+export const specializeExecutableOwner = (
+  self: Type,
+  owner: ExecutableSpecializationOwner,
+): Type => {
+  const specializeOwner = (
+    current: ExecutableSpecializationOwner,
+  ): ExecutableSpecializationOwner =>
+    sameExecutableOwnerDeclaration(current, owner)
+      ? owner
+      : Object.freeze({
+          declaration: current.declaration,
+          typeArguments: Object.freeze(current.typeArguments.map(specializeArgument)),
+        })
+  const specializeArgument = (argument: GenericArgument): GenericArgument => {
+    if (isUnavailableGenericArgument(argument) || isRepresentationParameterArgument(argument))
+      return argument
+    if (isOpaqueRepresentationArgument(argument)) {
+      const contract = specializeType(argument.contract)
+      return isCallable(contract) || isEffect(contract)
+        ? opaqueRepresentationArgument(
+            argument.family,
+            contract,
+            argument.arguments.map(specializeArgument),
+          )
+        : argument
+    }
+    if (isExactRepresentationArgument(argument)) {
+      const contract = specializeType(argument.contract)
+      const identity = specializeArgument(argument.identity)
+      return (isCallableIdentityArgument(identity) || isEffectIdentityArgument(identity)) &&
+        (isCallable(contract) || isEffect(contract))
+        ? exactRepresentationArgument(identity, contract)
+        : argument
+    }
+    if (isEffectIdentityArgument(argument))
+      return effectIdentityArgument(
+        argument.identity,
+        argument.owner === undefined ? undefined : specializeOwner(argument.owner),
+      )
+    if (isCallableIdentityArgument(argument))
+      return callableIdentityArgument(
+        argument.identity,
+        argument.target,
+        argument.typeArguments.map(specializeArgument),
+        argument.environment === undefined
+          ? undefined
+          : callableEnvironmentIdentity(
+              argument.environment.site,
+              specializeOwner(argument.environment.owner),
+            ),
+      )
+    if (isFailureRowArgument(argument))
+      return failureRowArgument(
+        argument.failures.map((failure) => {
+          const specialized = specializeType(failure)
+          return isNominal(specialized) ? specialized : failure
+        }),
+        argument.parameters,
+      )
+    if (isRequirementRowArgument(argument))
+      return requirementRowArgument(
+        argument.requirements.map((requirement) => {
+          const capability = specializeType(requirement.capability)
+          return Object.freeze({
+            ...requirement,
+            capability:
+              isNominal(capability) || isParameter(capability)
+                ? capability
+                : requirement.capability,
+          })
+        }),
+        argument.parameters,
+      )
+    return specializeType(argument)
+  }
+  const specializeType = (type: Type): Type => {
+    if (isNominal(type))
+      return nominal(type.module, type.name, type.arguments.map(specializeArgument))
+    if (isFixedArray(type)) return fixedArray(specializeType(type.element), type.length)
+    if (isSlice(type)) return slice(type.access, specializeType(type.element))
+    if (isReference(type)) return reference(type.access, specializeType(type.target))
+    if (isCallable(type))
+      return callable(type.parameters.map(specializeType), specializeType(type.result), type.mode)
+    if (isEffect(type))
+      return effect(
+        specializeType(type.success),
+        type.failures.map((failure) => {
+          const specialized = specializeType(failure)
+          return isNominal(specialized) ? specialized : failure
+        }),
+        type.access,
+        type.requirements.map((requirement) => {
+          const capability = specializeType(requirement.capability)
+          return Object.freeze({
+            ...requirement,
+            capability:
+              isNominal(capability) || isParameter(capability)
+                ? capability
+                : requirement.capability,
+          })
+        }),
+        type.failureParameters,
+        type.requirementParameters,
+      )
+    if (isRepresented(type)) {
+      const contract = specializeType(type.contract)
+      const requiredBound = specializeType(type.representation.requiredBound)
+      const argument = specializeArgument(type.representation.argument)
+      return (isCallable(contract) || isEffect(contract)) &&
+        (isCallable(requiredBound) || isEffect(requiredBound)) &&
+        isRepresentationArgument(argument)
+        ? represented(contract, requiredBound, argument)
+        : type
+    }
+    if (isUnion(type)) {
+      const normalized = union(type.members.map(specializeType))
+      return normalized._tag === 'Normalized' ? normalized.type : type
+    }
+    return type
+  }
+  return specializeType(self)
+}
 
 /** Adds structural constraints from one declared type pattern to one supplied concrete type. */
 const bindGenericArgument = (

--- a/packages/compiler/test/CallableFieldRealization.test.ts
+++ b/packages/compiler/test/CallableFieldRealization.test.ts
@@ -11,13 +11,13 @@ import * as Type from '../src/Type.js'
 import { unreachable } from './support/raise.js'
 
 /**
- * The runtime realization seam of nominal callable storage.
+ * The runtime realization seam of nominal executable storage.
  *
  * `RepresentationField` (issue #187) owns stable field identity, the retained representation
  * argument, and admissibility. These tests pin the enrichment this change adds on top: one static
- * target, its concrete arguments, the ordered capture environment, the receiver access an
- * invocation demands, capture loans, liveness, and the exactly-once cleanup plan — all reached
- * through one deterministic lookup rather than re-read from initializer syntax.
+ * target or Effect runner, its concrete arguments, the ordered capture environment, the receiver
+ * access an invocation demands, capture loans, rows, liveness, cleanup, and suspendability — all
+ * reached through one deterministic lookup rather than re-read from initializer syntax.
  */
 
 const ascii = (value: string): Uint8Array =>
@@ -40,6 +40,7 @@ const soleRealization = (
       ? [entry.support.realization]
       : [],
   )
+  assert.strictEqual(supported.length, 1)
   return supported.at(0) ?? unreachable('expected one supported callable field realization')
 }
 
@@ -52,6 +53,7 @@ const soleEffectRealization = (
       ? [entry.support.realization]
       : [],
   )
+  assert.strictEqual(supported.length, 1)
   return supported.at(0) ?? unreachable('expected one supported Effect field realization')
 }
 
@@ -192,6 +194,165 @@ pub fn main() -> i32 {
     assert.deepEqual(realization.rows.requirements, [])
     assert.deepEqual(realization.environment, [])
   }),
+)
+
+it.effect(
+  'selects same-site Effect runners by owner specialization with ordered concrete captures',
+  () =>
+    Effect.gen(function* () {
+      const module = 'effect-field/specializations'
+      const snapshot = yield* realized(
+        module,
+        `struct Token<T> { value: T }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn retain<T>(token: Token<T>, marker: T, condition: bool) -> i32 {
+  let deferred = Deferred { operation: effect {
+    if condition { return 0 }
+    let retainedToken = move token
+    let retainedMarker = move marker
+    return 1
+  } }
+  return 0
+}
+pub fn main() -> i32 {
+  return retain<i32>(Token<i32> { value: 1 }, 2, false) +
+    retain<bool>(Token<bool> { value: true }, false, false)
+}`,
+      )
+      const realizations = realizationsOf(snapshot).entries.flatMap((entry) =>
+        entry.support._tag === 'Supported' &&
+        CallableFieldRealization.isEffectRealization(entry.support.realization)
+          ? [entry.support.realization]
+          : [],
+      )
+
+      assert.deepEqual(
+        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+        ['SEM0107', 'SEM0107'],
+      )
+      assert.strictEqual(realizations.length, 2)
+      assert.deepEqual(
+        realizations
+          .map((realization) =>
+            realization.runnerArguments.map(Type.encodeGenericArgument).join(','),
+          )
+          .sort(),
+        ['bool', 'i32'],
+      )
+      for (const realization of realizations) {
+        assert.deepEqual(
+          realization.environment.map((slot) => [slot.source, slot.sourceOrdinal]),
+          [
+            ['Parameter', 0],
+            ['Parameter', 1],
+            ['Parameter', 2],
+          ],
+        )
+      }
+    }),
+)
+
+it.effect('publishes nested Effect and callable identities for local binding captures', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'effect-field/nested-bindings',
+      `struct Deferred<F: once Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let nested = effect { return 1 }
+  let transform = i32.add(1)
+  let deferred = Deferred { operation: effect {
+    let base = run move nested
+    return transform(base)
+  } }
+  return 0
+}`,
+    )
+    const realization = soleEffectRealization(realizationsOf(snapshot))
+
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'SEM0107',
+    )
+    assert.deepEqual(
+      realization.environment.map((slot) => [slot.source, slot.sourceOrdinal]),
+      [
+        ['Binding', 0],
+        ['Binding', 1],
+      ],
+    )
+    const nestedEffect = realization.environment.at(0)
+    const nestedCallable = realization.environment.at(1)
+    assert.strictEqual(
+      snapshot.instances.effects.some(
+        (effect) => effect.identity === nestedEffect?.effectIdentity && effect.site.ordinal === 0,
+      ),
+      true,
+    )
+    const callableIdentity = nestedCallable?.callableIdentity
+    assert.strictEqual(
+      callableIdentity !== undefined &&
+        snapshot.instances.callables.some((callable) =>
+          CallableFieldRealization.matchesIdentity(callableIdentity, callable),
+        ),
+      true,
+    )
+  }),
+)
+
+it.effect(
+  'copies concrete runner arguments and both exact rows from the selected Effect fact',
+  () =>
+    Effect.gen(function* () {
+      const snapshot = yield* realized(
+        'effect-field/row-evidence',
+        `struct Deferred<F: Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return 1 } }
+  return 0
+}`,
+      )
+      const fields = RepresentationField.resolveFields(
+        snapshot.index,
+        Instances.representedNominals(snapshot.instances, snapshot.index),
+      )
+      const resolution = fields.resolutions.find(
+        (candidate) => candidate._tag === 'ResolvedRepresentationField',
+      )
+      const discovered = snapshot.instances.effects.at(0)
+      if (resolution?._tag !== 'ResolvedRepresentationField' || discovered === undefined)
+        return yield* Effect.die('expected one resolved Effect field and construction fact')
+      const failure = Type.nominal('effect-field/row-evidence', 'Problem')
+      const requirement = Object.freeze({
+        capability: Type.nominal('effect-field/row-evidence', 'Console'),
+        role: 'Audit',
+        access: 'Exclusive' as const,
+      })
+      const contract = Type.effect('i32', [failure], 'Take', [requirement])
+      const arguments_ = Object.freeze([
+        Type.nominal('effect-field/row-evidence', 'Marker'),
+        Type.failureRowArgument([failure]),
+        Type.requirementRowArgument([requirement]),
+      ])
+      const support = CallableFieldRealization.realizeField(
+        Object.freeze({
+          ...resolution,
+          argument: Type.exactRepresentationArgument(resolution.argument.identity, contract),
+          requiredBound: contract,
+        }),
+        [],
+        [Object.freeze({ ...discovered, typeArguments: arguments_, type: contract })],
+      )
+      if (support._tag !== 'Supported')
+        return yield* Effect.die(`expected supported Effect evidence, got ${support.reason._tag}`)
+      const realization = support.realization
+      if (!CallableFieldRealization.isEffectRealization(realization))
+        return yield* Effect.die('expected one Effect realization')
+
+      assert.deepEqual(realization.runnerArguments, arguments_)
+      assert.deepEqual(realization.rows.failures, [failure])
+      assert.deepEqual(realization.rows.requirements, [requirement])
+      assert.strictEqual(realization.access, 'Take')
+    }),
 )
 
 it.effect('keeps the realization keyed by the shared representation field identity', () =>

--- a/packages/compiler/test/CallableFieldRealization.test.ts
+++ b/packages/compiler/test/CallableFieldRealization.test.ts
@@ -252,6 +252,82 @@ pub fn main() -> i32 {
     }),
 )
 
+it.effect('distinguishes same-site runners by hidden Effect parameter identities', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'effect-field/hidden-specializations',
+      `struct Deferred<F: once Effect<i32>> { operation: F }
+fn retain(input: Effect<i32>) -> i32 {
+  let deferred = Deferred { operation: effect { return run move input } }
+  return 0
+}
+pub fn main() -> i32 {
+  return retain(effect { return 20 }) + retain(effect { return 22 })
+}`,
+    )
+    const realizations = realizationsOf(snapshot).entries.flatMap((entry) =>
+      entry.support._tag === 'Supported' &&
+      CallableFieldRealization.isEffectRealization(entry.support.realization)
+        ? [entry.support.realization]
+        : [],
+    )
+
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      ['SEM0107', 'SEM0107'],
+    )
+    assert.strictEqual(realizations.length, 2)
+    assert.strictEqual(
+      realizations.every(
+        (realization) =>
+          realization.runnerArguments.length === 1 &&
+          Type.isEffectIdentityArgument(realization.runnerArguments[0] ?? Type.unit),
+      ),
+      true,
+    )
+    assert.strictEqual(
+      new Set(
+        realizations.map((realization) =>
+          Type.genericArgumentKey(realization.runnerArguments[0] ?? Type.unit),
+        ),
+      ).size,
+      2,
+    )
+  }),
+)
+
+it('walks Effect owner arguments as canonical semantic children', () => {
+  const declaration = Object.freeze({ module: 'effect-field/owner-walk', name: 'retain' })
+  const open = Type.parameter(declaration, 0, 'T')
+  const marker = Type.nominal('effect-field/owner-walk', 'Marker')
+  const contract = Type.effect('i32', [])
+  const holder = Type.nominal('effect-field/owner-walk', 'Holder', [
+    Type.exactRepresentationArgument(
+      Type.effectIdentityArgument('effect-field/owner-walk.effect', {
+        declaration,
+        typeArguments: [open, marker],
+      }),
+      contract,
+    ),
+  ])
+
+  assert.strictEqual(Type.isConcrete(holder), false)
+  assert.deepEqual(Type.parameters(holder), [open])
+  assert.strictEqual(
+    Type.nominals(holder).some((nominal) => Type.equals(nominal, marker)),
+    true,
+  )
+  assert.strictEqual(
+    Type.isConcrete(
+      Type.specializeExecutableOwner(holder, {
+        declaration,
+        typeArguments: ['bool', marker],
+      }),
+    ),
+    true,
+  )
+})
+
 it.effect('publishes nested Effect and callable identities for local binding captures', () =>
   Effect.gen(function* () {
     const snapshot = yield* realized(

--- a/packages/compiler/test/CallableFieldRealization.test.ts
+++ b/packages/compiler/test/CallableFieldRealization.test.ts
@@ -33,11 +33,26 @@ const realizationsOf = (snapshot: Analysis.Snapshot): CallableFieldRealization.I
 
 const soleRealization = (
   index: CallableFieldRealization.Index,
-): CallableFieldRealization.Realization => {
+): CallableFieldRealization.CallableRealization => {
   const supported = index.entries.flatMap((entry) =>
-    entry.support._tag === 'Supported' ? [entry.support.realization] : [],
+    entry.support._tag === 'Supported' &&
+    CallableFieldRealization.isCallableRealization(entry.support.realization)
+      ? [entry.support.realization]
+      : [],
   )
   return supported.at(0) ?? unreachable('expected one supported callable field realization')
+}
+
+const soleEffectRealization = (
+  index: CallableFieldRealization.Index,
+): CallableFieldRealization.EffectRealization => {
+  const supported = index.entries.flatMap((entry) =>
+    entry.support._tag === 'Supported' &&
+    CallableFieldRealization.isEffectRealization(entry.support.realization)
+      ? [entry.support.realization]
+      : [],
+  )
+  return supported.at(0) ?? unreachable('expected one supported Effect field realization')
 }
 
 const namedCallable = `struct Parser<F: fn(i32) -> i32> { parse: F }
@@ -97,6 +112,85 @@ it.effect('realizes a capturing section field with one ordered inline capture la
     assert.deepEqual(realization.loans, [])
     assert.deepEqual(realization.cleanup.lanes, [])
     assert.strictEqual(realization.invocation, 'Shared')
+  }),
+)
+
+it.effect(
+  'records exactly-once cleanup for an unrun stored Effect without crossing its fence',
+  () =>
+    Effect.gen(function* () {
+      const module = 'effect-field/unrun-cleanup'
+      const snapshot = yield* realized(
+        module,
+        `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+pub fn main() -> i32 {
+  let token = Token { value: 1 }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  return 0
+}`,
+      )
+      const realization = soleEffectRealization(realizationsOf(snapshot))
+
+      assert.include(
+        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+        'SEM0107',
+      )
+      assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+      assert.deepEqual(realization.runner, {
+        _tag: 'CanonicalDeclarationId',
+        module,
+        name: 'main$effect$0',
+      })
+      assert.deepEqual(realization.runnerArguments, [])
+      assert.strictEqual(realization.access, 'Take')
+      assert.strictEqual(realization.suspendable, false)
+      assert.deepEqual(realization.rows.failures, [])
+      assert.deepEqual(realization.rows.requirements, [])
+      assert.strictEqual(realization.environment.length, 1)
+      const capture =
+        realization.environment.at(0) ?? unreachable('expected one owned Effect environment slot')
+      assert.strictEqual(capture.source, 'Binding')
+      assert.strictEqual(capture.sourceOrdinal, 0)
+      assert.strictEqual(capture.access, 'Take')
+      assert.strictEqual(Type.encode(capture.type), `${module}.Token`)
+      assert.strictEqual(capture.owned, true)
+      assert.deepEqual(realization.cleanup.unrunLanes, [0])
+      assert.strictEqual(realization.cleanup.consumedByRun, true)
+    }),
+)
+
+it.effect('realizes a suspending stored runner with exact rows and no structural Effect ABI', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'effect-field/suspending',
+      `struct Deferred<F: Effect<i32>> { operation: F }
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+effect fn delayed() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  let provided = Effect.suspend(effect { return 42 }) |> Effect.provideMut(&mut allocator)
+  return run Effect.catch(move provided, recover)
+}
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return run delayed() } }
+  return 0
+}`,
+    )
+    const realization = soleEffectRealization(realizationsOf(snapshot))
+
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'SEM0107',
+    )
+    assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+    assert.strictEqual(realization.suspendable, true)
+    assert.strictEqual(realization.runner.module, 'effect-field/suspending')
+    assert.strictEqual(realization.runner.name, 'main$effect$0')
+    assert.strictEqual(realization.runnerArguments.every(Type.isConcreteGenericArgument), true)
+    assert.deepEqual(realization.rows.failures, [])
+    assert.deepEqual(realization.rows.requirements, [])
+    assert.deepEqual(realization.environment, [])
   }),
 )
 
@@ -181,14 +275,18 @@ it.effect('reports an unresolved representation field as explicitly unsupported'
         plan.id,
       ) ?? unreachable('expected an unavailable representation field resolution')
     assert.strictEqual(openResolution._tag, 'UnavailableRepresentationField')
-    const open = CallableFieldRealization.realizeField(openResolution, snapshot.instances.callables)
+    const open = CallableFieldRealization.realizeField(
+      openResolution,
+      snapshot.instances.callables,
+      snapshot.instances.effects,
+    )
     assert.strictEqual(open._tag, 'Unsupported')
     assert.strictEqual(
       open._tag === 'Unsupported' ? open.reason._tag : undefined,
       'UnresolvedRepresentation',
     )
 
-    // An Effect identity is a resolved representation, but never a callable realization.
+    // An Effect identity without its canonical discovered runner stays explicitly unsupported.
     const effect = Type.effect('i32', [])
     const stored = CallableFieldRealization.realizeField(
       Object.freeze({
@@ -203,11 +301,12 @@ it.effect('reports an unresolved representation field as explicitly unsupported'
         admissibility: Object.freeze({ _tag: 'Admitted' }),
       }),
       snapshot.instances.callables,
+      snapshot.instances.effects,
     )
     assert.strictEqual(stored._tag, 'Unsupported')
     assert.strictEqual(
       stored._tag === 'Unsupported' ? stored.reason._tag : undefined,
-      'EffectRepresentation',
+      'MissingEffectRunner',
     )
 
     // A section identity whose specialized environment was never discovered stays unsupported.
@@ -243,6 +342,7 @@ it.effect('reports an unresolved representation field as explicitly unsupported'
         admissibility: Object.freeze({ _tag: 'Admitted' }),
       }),
       snapshot.instances.callables,
+      snapshot.instances.effects,
     )
     assert.strictEqual(missing._tag, 'Unsupported')
     assert.strictEqual(
@@ -320,6 +420,7 @@ pub fn main() -> i32 {
     assert.deepEqual(Analysis.diagnostics(snapshot), [])
     const realizations = realizationsOf(snapshot).entries.flatMap((entry) =>
       entry.support._tag === 'Supported' &&
+      CallableFieldRealization.isCallableRealization(entry.support.realization) &&
       entry.support.realization.target._tag === 'Declaration' &&
       entry.support.realization.target.name === 'consume'
         ? [entry.support.realization]
@@ -355,7 +456,10 @@ pub fn main() -> i32 { return apply<i32>(0, 20) + apply<bool>(true, 20) }`
     const snapshot = yield* realized('callable-field/equal-specializations', source)
     assert.deepEqual(Analysis.diagnostics(snapshot), [])
     const realizations = realizationsOf(snapshot).entries.flatMap((entry) =>
-      entry.support._tag === 'Supported' ? [entry.support.realization] : [],
+      entry.support._tag === 'Supported' &&
+      CallableFieldRealization.isCallableRealization(entry.support.realization)
+        ? [entry.support.realization]
+        : [],
     )
 
     assert.strictEqual(realizations.length, 2)
@@ -392,6 +496,27 @@ it.effect('mints the callable environment identity in exactly one frontend modul
 
     // HIR is the only actor allowed to project an executable site into a semantic environment
     // identity. Every later phase delegates to that projection rather than parsing an encoding.
+    assert.deepEqual(minting, ['Hir.ts'])
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+)
+
+it.effect('mints the represented Effect origin in exactly one frontend module', () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const sourceRoot = yield* path.fromFileUrl(new URL('../src/', import.meta.url))
+    const sources = (yield* fileSystem.readDirectory(sourceRoot)).filter((name) =>
+      name.endsWith('.ts'),
+    )
+    const minting: Array<string> = []
+    const originMint = '`effect:' + '$' + '{executableSiteKey(self)}`'
+    for (const name of sources) {
+      const source = yield* fileSystem.readFileString(path.join(sourceRoot, name))
+      if (source.includes(originMint)) minting.push(name)
+    }
+
+    // HIR owns the semantic origin projection. Realization and lowering both delegate to it, so a
+    // second minting site would be a syntax-recovery path around the shared Effect fact.
     assert.deepEqual(minting, ['Hir.ts'])
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 )

--- a/packages/compiler/test/StoredCallableCleanup.test.ts
+++ b/packages/compiler/test/StoredCallableCleanup.test.ts
@@ -1,7 +1,7 @@
 import { assert, it } from '@effect/vitest'
 import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
-import type * as CallableFieldRealization from '../src/CallableFieldRealization.js'
+import * as CallableFieldRealization from '../src/CallableFieldRealization.js'
 import * as Instances from '../src/Instances.js'
 import * as Ownership from '../src/Ownership.js'
 import * as Type from '../src/Type.js'
@@ -38,20 +38,27 @@ const bindingCleanup = (
   return binding?.cleanup ?? unreachable(`expected a cleanup plan for ${name}`)
 }
 
-const soleRealization = (snapshot: Analysis.Snapshot): CallableFieldRealization.Realization =>
+const soleRealization = (
+  snapshot: Analysis.Snapshot,
+): CallableFieldRealization.CallableRealization =>
   Instances.callableFieldRealizations(snapshot.instances, snapshot.index)
     .entries.flatMap((entry) =>
-      entry.support._tag === 'Supported' ? [entry.support.realization] : [],
+      entry.support._tag === 'Supported' &&
+      CallableFieldRealization.isCallableRealization(entry.support.realization)
+        ? [entry.support.realization]
+        : [],
     )
     .at(0) ?? unreachable('expected one supported callable field realization')
 
 const realizationOf = (
   snapshot: Analysis.Snapshot,
   owner: string,
-): CallableFieldRealization.Realization =>
+): CallableFieldRealization.CallableRealization =>
   Instances.callableFieldRealizations(snapshot.instances, snapshot.index)
     .entries.flatMap((entry) =>
-      entry.support._tag === 'Supported' && entry.support.realization.instance.name === owner
+      entry.support._tag === 'Supported' &&
+      CallableFieldRealization.isCallableRealization(entry.support.realization) &&
+      entry.support.realization.instance.name === owner
         ? [entry.support.realization]
         : [],
     )


### PR DESCRIPTION
Refs #190

## Summary
- extend the shared resolved-field realization index with a tagged Effect realization
- retain canonical runner, concrete arguments, exact rows, access, ordered environment, cleanup, and suspendability
- prove unrun-cleanup and suspending-run realization seams while keeping SEM0107 active

## Scope
This PR implements OpenSpec tasks 2.1-2.3 only. It does not add ownership, layout, HIR/MIR execution, evaluator, native, or Wasm support and retires no fence.