### PR TITLE
#192 PR3: infer generic interface witness targets

### DIFF
--- a/openspec/changes/support-complete-interface-contracts/tasks.md
+++ b/openspec/changes/support-complete-interface-contracts/tasks.md
@@ -18,10 +18,10 @@
 
 ## 3. Generic Witness Targets
 
-- [ ] 3.1 Infer mapped target type, row, and representation binders from substituted conformance and operation contracts.
-- [ ] 3.2 Preserve inferred target arguments in HIR witness questions and concrete instance keys.
-- [ ] 3.3 Add two-specialization acceptance plus unresolved and conflicting binder diagnostics.
-- [ ] 3.4 Lower every admitted witness to one static target with no runtime dictionary or service slot.
+- [x] 3.1 Infer mapped target type, row, and representation binders from substituted conformance and operation contracts.
+- [x] 3.2 Preserve inferred target arguments in HIR witness questions and concrete instance keys.
+- [x] 3.3 Add two-specialization acceptance plus unresolved and conflicting binder diagnostics.
+- [x] 3.4 Lower every admitted witness to one static target with no runtime dictionary or service slot.
 
 ## 4. Interface Migration
 

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -5357,14 +5357,16 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
             if (inference === undefined || inference._tag === 'Failed') {
               if (inference?._tag === 'Failed') {
                 const problem = inference.problem
+                if (problem._tag === 'IncompatibleConstraint') {
+                  rejectIncompatibleMapping()
+                  continue
+                }
                 const detail =
                   problem._tag === 'UnresolvedBinder'
                     ? `cannot infer witness target binder ${problem.binder.name}`
                     : problem._tag === 'ConflictingBinder'
                       ? `witness target binder ${problem.binder.name} is ${Type.encodeGenericArgument(problem.previous)} from ${problem.previousConstraint} but ${Type.encodeGenericArgument(problem.conflicting)} from ${problem.conflictingConstraint}`
-                      : problem._tag === 'IncompatibleArguments'
-                        ? `witness target binder ${problem.binder.name} cannot accept ${Type.encodeGenericArgument(problem.argument)}`
-                        : `${problem.constraint} cannot determine a compatible witness target`
+                      : `witness target binder ${problem.binder.name} cannot accept ${Type.encodeGenericArgument(problem.argument)}`
                 diagnostics.push(
                   invalidDiagnostic(`${target.spelling}: ${detail}`, mapping.syntax.span),
                 )

--- a/packages/compiler/src/DeclarationIndex.ts
+++ b/packages/compiler/src/DeclarationIndex.ts
@@ -2,6 +2,7 @@ import * as Option from 'effect/Option'
 import * as ConformanceGoal from './ConformanceGoal.js'
 import * as ConformanceHead from './ConformanceHead.js'
 import * as Diagnostic from './Diagnostic.js'
+import * as InterfaceWitnessInference from './InterfaceWitnessInference.js'
 import * as Intrinsic from './Intrinsic.js'
 import * as DigitSeparator from './internal/DigitSeparator.js'
 import * as IntegerLiteral from './internal/IntegerLiteral.js'
@@ -873,6 +874,8 @@ export interface ConformanceFact {
       | TypePathFact
       | { readonly _tag: 'Unavailable'; readonly syntax: SyntaxTree.Element }
     readonly contract?: InterfaceOperationApplicationFact
+    /** The mapped declaration's binders expressed over this conformance header. */
+    readonly targetArguments?: ReadonlyArray<Type.GenericArgument>
     readonly syntax: SyntaxTree.Node
   }>
   readonly hook?: DropHookFact
@@ -4096,16 +4099,91 @@ const witnessBinding = (
   })
 }
 
+/** Infers an interface witness declaration's own binders without assuming header position. */
+const inferInterfaceWitnessTarget = (
+  implementation: DeclarationFact,
+  contract: InterfaceOperationApplicationFact | undefined,
+): InterfaceWitnessInference.Inference | undefined => {
+  if (
+    contract === undefined ||
+    implementation.parameters.length !== contract.operands.length ||
+    implementation.returnType._tag !== 'Resolved'
+  )
+    return undefined
+  const constraints: Array<InterfaceWitnessInference.Constraint> = []
+  for (const [ordinal, operand] of contract.operands.entries()) {
+    const pattern = implementation.parameters.at(ordinal)?.declaredType
+    if (pattern?._tag !== 'Resolved' || operand.type._tag !== 'Resolved') return undefined
+    const name =
+      operand.parameter.name._tag === 'Present'
+        ? operand.parameter.name.spelling
+        : `#${ordinal + 1}`
+    constraints.push(
+      Object.freeze({
+        label: Type.equals(
+          Type.isReference(operand.type.type) ? operand.type.type.target : operand.type.type,
+          contract.provider,
+        )
+          ? `receiver ${name}`
+          : `parameter ${name}`,
+        pattern: pattern.type,
+        // PR3 infers through the existing witness ABI. PR4 replaces this one adapter together with
+        // the atomic Order/HashKey literal-ownership migration.
+        actual: Type.reference('Shared', operand.type.type),
+      }),
+    )
+  }
+  constraints.push(
+    Object.freeze({
+      label: 'success',
+      pattern: implementation.returnType.type,
+      actual: contract.success._tag === 'Resolved' ? contract.success.type : 'never',
+    }),
+  )
+  constraints.push(
+    Object.freeze({
+      label: 'failure and requirement rows',
+      pattern: Type.effect(
+        Type.unit,
+        implementation.failureRow.failures,
+        'Shared',
+        implementation.requirementRow.requirements,
+        implementation.failureRow.parameters,
+        implementation.requirementRow.parameters,
+      ),
+      actual: Type.effect(
+        Type.unit,
+        contract.failureRow.failures,
+        'Shared',
+        contract.requirementRow.requirements,
+        contract.failureRow.parameters,
+        contract.requirementRow.parameters,
+      ),
+    }),
+  )
+  return InterfaceWitnessInference.infer(
+    implementation.typeParameters
+      .filter((parameter) => parameter.duplicateOf === undefined)
+      .map((parameter) => parameter.type),
+    constraints,
+  )
+}
+
 /** Finds the first implementation bound the conformance header never promises. */
 const unpromisedWitnessBound = (
   binding: ReturnType<typeof witnessBinding>,
-  declaredParameters: ReadonlyArray<Type.Parameter>,
+  arguments_: ReadonlyArray<Type.GenericArgument>,
   conformance: ConformanceFact,
 ): TypeParameterFact | undefined =>
   binding.binders.find((binder, position) => {
     const bound = binder.bound
     if (bound?._tag !== 'ResolvedBound') return bound !== undefined
-    const header = declaredParameters.at(position)
+    const argument = arguments_.at(position)
+    const header =
+      argument !== undefined && Type.isTypeArgument(argument) && Type.isParameter(argument)
+        ? conformance.typeParameters.find((parameter) => Type.equals(parameter.type, argument))
+            ?.type
+        : undefined
     return (
       header === undefined ||
       !conformance.requirements.some(
@@ -5037,6 +5115,10 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
   }
 
   const invalidConformances = new Set<ConformanceFact>()
+  const inferredWitnessArguments = new Map<
+    ConformanceFact['operations'][number],
+    ReadonlyArray<Type.GenericArgument>
+  >()
   for (const module of modules) {
     for (const conformance of module.conformances) {
       const markInvalid = (): void => {
@@ -5271,16 +5353,33 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
               )
               continue
             }
-            // A conditional conformance's witness is generic in the same binders its header
-            // declares, so the witness function's own parameters are bound to the header's
-            // positionally. That correspondence is what lets one witness serve every
-            // specialization the header covers, and it is the same shape the hidden Drop hook
-            // already uses. A conformance that declares no binders still admits no generic witness.
+            const inference = inferInterfaceWitnessTarget(implementation, mapping.contract)
+            if (inference === undefined || inference._tag === 'Failed') {
+              if (inference?._tag === 'Failed') {
+                const problem = inference.problem
+                const detail =
+                  problem._tag === 'UnresolvedBinder'
+                    ? `cannot infer witness target binder ${problem.binder.name}`
+                    : problem._tag === 'ConflictingBinder'
+                      ? `witness target binder ${problem.binder.name} is ${Type.encodeGenericArgument(problem.previous)} from ${problem.previousConstraint} but ${Type.encodeGenericArgument(problem.conflicting)} from ${problem.conflictingConstraint}`
+                      : problem._tag === 'IncompatibleArguments'
+                        ? `witness target binder ${problem.binder.name} cannot accept ${Type.encodeGenericArgument(problem.argument)}`
+                        : `${problem.constraint} cannot determine a compatible witness target`
+                diagnostics.push(
+                  invalidDiagnostic(`${target.spelling}: ${detail}`, mapping.syntax.span),
+                )
+              } else rejectIncompatibleMapping()
+              continue
+            }
             const binding = witnessBinding(implementation, declaredParameters)
             // A witness may only ask for what the header already promises. Its own bounds are the
             // obligations its body will discharge, so a bound the header never requires would be
             // proved nowhere and would surface as a call with no lowering rather than a diagnostic.
-            const unpromisedBound = unpromisedWitnessBound(binding, declaredParameters, conformance)
+            const unpromisedBound = unpromisedWitnessBound(
+              binding,
+              inference.arguments,
+              conformance,
+            )
             if (unpromisedBound !== undefined) {
               diagnostics.push(
                 invalidDiagnostic(
@@ -5291,11 +5390,8 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
               continue
             }
             const specialize = (type: Type.Type): Type.Type =>
-              binding.substitution === undefined
-                ? type
-                : Type.substitute(type, binding.substitution)
+              Type.substitute(type, inference.substitution)
             const validParameters =
-              binding.substitution !== undefined &&
               implementation.parameters.length === contract.parameters.length &&
               contract.parameters.every((parameter, ordinal) => {
                 const actual = implementation.parameters.at(ordinal)?.declaredType
@@ -5322,11 +5418,11 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
               !validParameters ||
               !validResult ||
               implementation.functionKind !== 'Ordinary' ||
-              binding.parameters.length !== declaredParameters.length ||
               implementation.failureRow.failures.length > 0 ||
               implementation.requirementRow.requirements.length > 0
-            )
+            ) {
               rejectIncompatibleMapping()
+            } else inferredWitnessArguments.set(mapping, inference.arguments)
             continue
           }
           const operation =
@@ -5464,7 +5560,11 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
             continue
           }
           const binding = witnessBinding(implementation, declaredParameters)
-          const unpromisedBound = unpromisedWitnessBound(binding, declaredParameters, conformance)
+          const unpromisedBound = unpromisedWitnessBound(
+            binding,
+            declaredParameters.map(Type.parameterArgument),
+            conformance,
+          )
           if (unpromisedBound !== undefined) {
             diagnostics.push(
               invalidDiagnostic(
@@ -5671,6 +5771,14 @@ export const complete = (self: Index, resolvers: ResolutionSeams.ResolutionSeams
         module.conformances.map((conformance) =>
           Object.freeze({
             ...conformance,
+            operations: Object.freeze(
+              conformance.operations.map((operation) => {
+                const targetArguments = inferredWitnessArguments.get(operation)
+                return targetArguments === undefined
+                  ? operation
+                  : Object.freeze({ ...operation, targetArguments })
+              }),
+            ),
             validity:
               invalidConformances.has(conformance) ||
               conformance.coherence._tag !== 'Coherent' ||
@@ -5983,8 +6091,6 @@ const interfaceByCapability = (self: Index, capability: Type.Nominal): Interface
  */
 const proofMemos = new WeakMap<Index, Map<string, ConformanceGoal.Proof>>()
 
-const noGenericArguments: ReadonlyArray<Type.GenericArgument> = Object.freeze([])
-
 /** One conformance whose head covers a concrete goal, with the arguments matching it bound. */
 interface ConformanceCandidate {
   readonly module: string
@@ -6281,6 +6387,25 @@ export interface InterfaceWitnessTarget {
   readonly structuralProvider?: Type.Type
 }
 
+const inferredTargetArguments = (
+  conformance: ConformanceFact,
+  mapping: ConformanceFact['operations'][number],
+  proof: Extract<ConformanceGoal.Proof, { readonly _tag: 'Proved' }>,
+): ReadonlyArray<Type.GenericArgument> | undefined => {
+  if (mapping.targetArguments === undefined) return undefined
+  const headerParameters = conformance.typeParameters
+    .filter((parameter) => parameter.duplicateOf === undefined)
+    .map((parameter) => parameter.type)
+  const headerSubstitution = Type.substitution(headerParameters, proof.typeArguments)
+  if (headerSubstitution === undefined) return undefined
+  const arguments_ = Object.freeze(
+    mapping.targetArguments.map((argument) =>
+      Type.substituteGenericArgument(argument, headerSubstitution),
+    ),
+  )
+  return arguments_.every(Type.isConcreteGenericArgument) ? arguments_ : undefined
+}
+
 /**
  * Selects the provider's own function one interface operation maps to, with its type arguments.
  *
@@ -6295,15 +6420,21 @@ export const interfaceWitnessTarget = (
   capability: Type.Nominal,
   operation: string,
 ): InterfaceWitnessTarget | undefined => {
-  const implementation = interfaceWitnessImplementation(self, provider, capability, operation)
-  if (implementation === undefined) return undefined
   const proof = prove(self, provider, capability)
+  if (proof._tag !== 'Proved' || proof.selection._tag !== 'SourceSelection') return undefined
+  const conformance = selectedConformance(self, proof.selection)
+  if (conformance === undefined) return undefined
+  const mapping = conformance.operations.find(
+    (candidate) => candidate.name._tag === 'Present' && candidate.name.spelling === operation,
+  )
+  if (mapping === undefined) return undefined
+  const implementation = witnessImplementation(self, provider, conformance, operation)
+  const typeArguments = inferredTargetArguments(conformance, mapping, proof)
+  if (implementation === undefined || typeArguments === undefined) return undefined
   return Object.freeze({
     implementation,
-    typeArguments: proof._tag === 'Proved' ? proof.typeArguments : noGenericArguments,
-    ...(proof._tag === 'Proved' && proof.requirements.length > 0
-      ? { structuralProvider: provider }
-      : {}),
+    typeArguments,
+    ...(proof.requirements.length > 0 ? { structuralProvider: provider } : {}),
   })
 }
 
@@ -6337,17 +6468,18 @@ export const witnessDependencyTargets = (
         conformance,
         mapping.name.spelling,
       )
-      if (implementation === undefined) continue
+      const typeArguments = inferredTargetArguments(conformance, mapping, dependency)
+      if (implementation === undefined || typeArguments === undefined) continue
       const identity = Specialization.key({
         declaration: implementation,
-        typeArguments: dependency.typeArguments,
+        typeArguments,
       })
       if (!found.has(identity))
         found.set(
           identity,
           Object.freeze({
             implementation,
-            typeArguments: dependency.typeArguments,
+            typeArguments,
             structuralProvider: dependency.goal.provider,
           }),
         )

--- a/packages/compiler/src/InterfaceWitnessInference.ts
+++ b/packages/compiler/src/InterfaceWitnessInference.ts
@@ -56,7 +56,8 @@ export const infer = (
   const sources = new Map<string, string>()
   for (const constraint of constraints) {
     const trial = new Map(inferred)
-    if (Type.infer(constraint.pattern, constraint.actual, trial, true)) {
+    const result = Type.inferOpenGenericArguments(constraint.pattern, constraint.actual, trial)
+    if (result.matches) {
       for (const binder of binders) {
         const identity = Type.key(binder)
         if (!inferred.has(identity) && trial.has(identity)) sources.set(identity, constraint.label)
@@ -66,34 +67,26 @@ export const infer = (
       continue
     }
 
-    const isolated = new Map<string, Type.GenericArgument>()
-    if (Type.infer(constraint.pattern, constraint.actual, isolated, true)) {
-      const conflict = binders.find((binder) => {
-        const identity = Type.key(binder)
-        const previous = inferred.get(identity)
-        const next = isolated.get(identity)
-        return (
-          previous !== undefined &&
-          next !== undefined &&
-          !Type.equalsGenericArgument(previous, next)
-        )
-      })
-      if (conflict !== undefined) {
-        const identity = Type.key(conflict)
-        const previous = inferred.get(identity)
-        const conflicting = isolated.get(identity)
-        if (previous !== undefined && conflicting !== undefined)
-          return failed(
-            Object.freeze({
-              _tag: 'ConflictingBinder',
-              binder: conflict,
-              previous,
-              conflicting,
-              previousConstraint: sources.get(identity) ?? 'an earlier contract position',
-              conflictingConstraint: constraint.label,
-            }),
-          )
-      }
+    const conflict = binders.flatMap((binder) => {
+      const found = result.conflicts.find((candidate) => Type.equals(candidate.parameter, binder))
+      return found === undefined ? [] : [{ binder, conflict: found }]
+    })[0]
+    if (conflict !== undefined) {
+      const identity = Type.key(conflict.binder)
+      const previousSource = sources.get(identity)
+      return failed(
+        Object.freeze({
+          _tag: 'ConflictingBinder',
+          binder: conflict.binder,
+          previous: conflict.conflict.previous,
+          conflicting: conflict.conflict.conflicting,
+          previousConstraint: previousSource ?? `${constraint.label} (earlier occurrence)`,
+          conflictingConstraint:
+            previousSource === undefined
+              ? `${constraint.label} (later occurrence)`
+              : constraint.label,
+        }),
+      )
     }
     return failed(Object.freeze({ _tag: 'IncompatibleConstraint', constraint: constraint.label }))
   }

--- a/packages/compiler/src/InterfaceWitnessInference.ts
+++ b/packages/compiler/src/InterfaceWitnessInference.ts
@@ -1,0 +1,130 @@
+import * as Type from './Type.js'
+
+/** One ordered piece of the mapped target contract used to infer its declaration binders. */
+export interface Constraint {
+  readonly label: string
+  readonly pattern: Type.Type
+  readonly actual: Type.Type
+}
+
+export type Problem =
+  | {
+      readonly _tag: 'UnresolvedBinder'
+      readonly binder: Type.Parameter
+    }
+  | {
+      readonly _tag: 'ConflictingBinder'
+      readonly binder: Type.Parameter
+      readonly previous: Type.GenericArgument
+      readonly conflicting: Type.GenericArgument
+      readonly previousConstraint: string
+      readonly conflictingConstraint: string
+    }
+  | {
+      readonly _tag: 'IncompatibleConstraint'
+      readonly constraint: string
+    }
+  | {
+      readonly _tag: 'IncompatibleArguments'
+      readonly binder: Type.Parameter
+      readonly argument: Type.GenericArgument
+    }
+
+export type Inference =
+  | {
+      readonly _tag: 'Inferred'
+      readonly arguments: ReadonlyArray<Type.GenericArgument>
+      readonly substitution: Type.Substitution
+    }
+  | { readonly _tag: 'Failed'; readonly problem: Problem }
+
+const failed = (problem: Problem): Inference => Object.freeze({ _tag: 'Failed', problem })
+
+/**
+ * Infers one mapped declaration's binders from source-ordered substituted contract constraints.
+ *
+ * Each constraint is first checked against the evidence accumulated before it. If that fails but
+ * the constraint is independently meaningful, the first declaration-ordered binder whose evidence
+ * differs is the conflict. This keeps diagnostics stable even when normalized row members have a
+ * different internal order from the source declarations that introduced their binders.
+ */
+export const infer = (
+  binders: ReadonlyArray<Type.Parameter>,
+  constraints: ReadonlyArray<Constraint>,
+): Inference => {
+  const inferred = new Map<string, Type.GenericArgument>()
+  const sources = new Map<string, string>()
+  for (const constraint of constraints) {
+    const trial = new Map(inferred)
+    if (Type.infer(constraint.pattern, constraint.actual, trial, true)) {
+      for (const binder of binders) {
+        const identity = Type.key(binder)
+        if (!inferred.has(identity) && trial.has(identity)) sources.set(identity, constraint.label)
+      }
+      inferred.clear()
+      for (const [identity, argument] of trial) inferred.set(identity, argument)
+      continue
+    }
+
+    const isolated = new Map<string, Type.GenericArgument>()
+    if (Type.infer(constraint.pattern, constraint.actual, isolated, true)) {
+      const conflict = binders.find((binder) => {
+        const identity = Type.key(binder)
+        const previous = inferred.get(identity)
+        const next = isolated.get(identity)
+        return (
+          previous !== undefined &&
+          next !== undefined &&
+          !Type.equalsGenericArgument(previous, next)
+        )
+      })
+      if (conflict !== undefined) {
+        const identity = Type.key(conflict)
+        const previous = inferred.get(identity)
+        const conflicting = isolated.get(identity)
+        if (previous !== undefined && conflicting !== undefined)
+          return failed(
+            Object.freeze({
+              _tag: 'ConflictingBinder',
+              binder: conflict,
+              previous,
+              conflicting,
+              previousConstraint: sources.get(identity) ?? 'an earlier contract position',
+              conflictingConstraint: constraint.label,
+            }),
+          )
+      }
+    }
+    return failed(Object.freeze({ _tag: 'IncompatibleConstraint', constraint: constraint.label }))
+  }
+
+  const unresolved = binders.find((binder) => !inferred.has(Type.key(binder)))
+  if (unresolved !== undefined)
+    return failed(Object.freeze({ _tag: 'UnresolvedBinder', binder: unresolved }))
+  const arguments_ = Object.freeze(
+    binders.flatMap((binder) => {
+      const argument = inferred.get(Type.key(binder))
+      return argument === undefined ? [] : [argument]
+    }),
+  )
+  const substitution = Type.substitution(binders, arguments_)
+  if (substitution === undefined) {
+    const incompatible = binders.find((binder, ordinal) => {
+      const argument = arguments_.at(ordinal)
+      return argument !== undefined && Type.substitution([binder], [argument]) === undefined
+    })
+    const ordinal = incompatible === undefined ? -1 : binders.indexOf(incompatible)
+    const argument = ordinal < 0 ? undefined : arguments_.at(ordinal)
+    if (incompatible !== undefined && argument !== undefined)
+      return failed(
+        Object.freeze({ _tag: 'IncompatibleArguments', binder: incompatible, argument }),
+      )
+    return failed(
+      Object.freeze({
+        _tag: 'IncompatibleConstraint',
+        constraint: 'the complete inferred argument list',
+      }),
+    )
+  }
+  return Object.freeze({ _tag: 'Inferred', arguments: arguments_, substitution })
+}

--- a/packages/compiler/src/Type.ts
+++ b/packages/compiler/src/Type.ts
@@ -2026,11 +2026,28 @@ export const substituteGenericArgument = (
                     )
                   : substitute(self, substitution)
 
+export interface GenericArgumentConflict {
+  readonly parameter: Parameter
+  readonly previous: GenericArgument
+  readonly conflicting: GenericArgument
+}
+
+export interface OpenGenericInference {
+  readonly matches: boolean
+  readonly conflicts: ReadonlyArray<GenericArgumentConflict>
+}
+
+interface InferenceContext {
+  readonly allowOpenGenericArguments: boolean
+  readonly conflicts?: Array<GenericArgumentConflict>
+}
+
 /** Adds structural constraints from one declared type pattern to one supplied concrete type. */
 const bindGenericArgument = (
   parameter_: Parameter,
   actual: GenericArgument,
   inferred: Map<string, GenericArgument>,
+  context: InferenceContext,
 ): boolean => {
   const identity = key(parameter_)
   const existing = inferred.get(identity)
@@ -2038,7 +2055,11 @@ const bindGenericArgument = (
     inferred.set(identity, actual)
     return true
   }
-  return genericArgumentKey(existing) === genericArgumentKey(actual)
+  if (genericArgumentKey(existing) === genericArgumentKey(actual)) return true
+  context.conflicts?.push(
+    Object.freeze({ parameter: parameter_, previous: existing, conflicting: actual }),
+  )
+  return false
 }
 
 const commitInference = (
@@ -2087,15 +2108,17 @@ const inferFailureRowArgument = (
   pattern: FailureRowArgument,
   actual: FailureRowArgument,
   inferred: Map<string, GenericArgument>,
-  allowOpenActual = true,
+  allowOpenActual: boolean,
+  context: InferenceContext,
 ): boolean => {
   if (!allowOpenActual && actual.parameters.length > 0) return false
   if (genericArgumentKey(pattern) === genericArgumentKey(actual)) return true
+  const memberContext = Object.freeze({ ...context, allowOpenGenericArguments: false })
   const matched = inferRowMembers(
     pattern.failures,
     actual.failures,
     inferred,
-    (failure, supplied, trial) => infer(failure, supplied, trial),
+    (failure, supplied, trial) => inferType(failure, supplied, trial, memberContext),
     (remaining, trial) => {
       if (pattern.parameters.length === 0)
         return remaining.length === 0 && actual.parameters.length === 0
@@ -2103,7 +2126,12 @@ const inferFailureRowArgument = (
       return (
         pattern.parameters.length === 1 &&
         parameter_ !== undefined &&
-        bindGenericArgument(parameter_, failureRowArgument(remaining, actual.parameters), trial)
+        bindGenericArgument(
+          parameter_,
+          failureRowArgument(remaining, actual.parameters),
+          trial,
+          context,
+        )
       )
     },
   )
@@ -2118,10 +2146,12 @@ const inferRequirementRowArgument = (
   pattern: RequirementRowArgument,
   actual: RequirementRowArgument,
   inferred: Map<string, GenericArgument>,
-  allowOpenActual = true,
+  allowOpenActual: boolean,
+  context: InferenceContext,
 ): boolean => {
   if (!allowOpenActual && actual.parameters.length > 0) return false
   if (genericArgumentKey(pattern) === genericArgumentKey(actual)) return true
+  const memberContext = Object.freeze({ ...context, allowOpenGenericArguments: false })
   const matched = inferRowMembers(
     pattern.requirements,
     actual.requirements,
@@ -2132,7 +2162,7 @@ const inferRequirementRowArgument = (
         requirement.role !== supplied.role
       )
         return false
-      return infer(requirement.capability, supplied.capability, trial)
+      return inferType(requirement.capability, supplied.capability, trial, memberContext)
     },
     (remaining, trial) => {
       if (pattern.parameters.length === 0)
@@ -2141,7 +2171,12 @@ const inferRequirementRowArgument = (
       return (
         pattern.parameters.length === 1 &&
         parameter_ !== undefined &&
-        bindGenericArgument(parameter_, requirementRowArgument(remaining, actual.parameters), trial)
+        bindGenericArgument(
+          parameter_,
+          requirementRowArgument(remaining, actual.parameters),
+          trial,
+          context,
+        )
       )
     },
   )
@@ -2155,18 +2190,31 @@ const inferGenericArgument = (
   pattern: GenericArgument,
   actual: GenericArgument,
   inferred: Map<string, GenericArgument>,
-  allowOpenActual: boolean,
+  context: InferenceContext,
 ): boolean => {
   if (isRepresentationParameterArgument(pattern))
     return (
-      isRepresentationArgument(actual) && bindGenericArgument(pattern.parameter, actual, inferred)
+      isRepresentationArgument(actual) &&
+      bindGenericArgument(pattern.parameter, actual, inferred, context)
     )
   if (isFailureRowArgument(pattern) && isFailureRowArgument(actual))
-    return inferFailureRowArgument(pattern, actual, inferred, allowOpenActual)
+    return inferFailureRowArgument(
+      pattern,
+      actual,
+      inferred,
+      context.allowOpenGenericArguments,
+      context,
+    )
   if (isRequirementRowArgument(pattern) && isRequirementRowArgument(actual))
-    return inferRequirementRowArgument(pattern, actual, inferred, allowOpenActual)
+    return inferRequirementRowArgument(
+      pattern,
+      actual,
+      inferred,
+      context.allowOpenGenericArguments,
+      context,
+    )
   if (isTypeArgument(pattern) && isTypeArgument(actual))
-    return infer(pattern, actual, inferred, allowOpenActual)
+    return inferType(pattern, actual, inferred, context)
   return genericArgumentKey(pattern) === genericArgumentKey(actual)
 }
 
@@ -2174,22 +2222,28 @@ const inferFailureRows = (
   pattern: Effect,
   actual: Effect,
   inferred: Map<string, GenericArgument>,
+  context: InferenceContext,
 ): boolean =>
   inferFailureRowArgument(
     failureRowArgument(pattern.failures, pattern.failureParameters),
     failureRowArgument(actual.failures, actual.failureParameters),
     inferred,
+    true,
+    context,
   )
 
 const inferRequirementRows = (
   pattern: Effect,
   actual: Effect,
   inferred: Map<string, GenericArgument>,
+  context: InferenceContext,
 ): boolean =>
   inferRequirementRowArgument(
     requirementRowArgument(pattern.requirements, pattern.requirementParameters),
     requirementRowArgument(actual.requirements, actual.requirementParameters),
     inferred,
+    true,
+    context,
   )
 
 /** Explains a failed Effect-row decomposition without replacing ordinary type diagnostics. */
@@ -2283,14 +2337,14 @@ export const rowInferenceFailure = (
   return undefined
 }
 
-export const infer = (
+const inferType = (
   pattern: Type,
   actual: Type,
   inferred: Map<string, GenericArgument>,
-  allowOpenGenericArguments = false,
+  context: InferenceContext,
 ): boolean => {
   if (isParameter(pattern)) {
-    return pattern.kind === 'Value' && bindGenericArgument(pattern, actual, inferred)
+    return pattern.kind === 'Value' && bindGenericArgument(pattern, actual, inferred, context)
   }
   if (isFailureProjection(pattern)) {
     const failures = isNever(actual)
@@ -2302,12 +2356,13 @@ export const infer = (
           : undefined
     return (
       (failures !== undefined &&
-        bindGenericArgument(pattern.parameter, failureRowArgument(failures), inferred)) ||
+        bindGenericArgument(pattern.parameter, failureRowArgument(failures), inferred, context)) ||
       (isFailureProjection(actual) &&
         bindGenericArgument(
           pattern.parameter,
           failureRowArgument([], [actual.parameter]),
           inferred,
+          context,
         ))
     )
   }
@@ -2320,28 +2375,25 @@ export const infer = (
       return false
     return pattern.arguments.every((argument, index) => {
       const supplied = actual.arguments.at(index)
-      return (
-        supplied !== undefined &&
-        inferGenericArgument(argument, supplied, inferred, allowOpenGenericArguments)
-      )
+      return supplied !== undefined && inferGenericArgument(argument, supplied, inferred, context)
     })
   }
   if (isFixedArray(pattern) && isFixedArray(actual)) {
     return (
       pattern.length === actual.length &&
-      infer(pattern.element, actual.element, inferred, allowOpenGenericArguments)
+      inferType(pattern.element, actual.element, inferred, context)
     )
   }
   if (isSlice(pattern) && isSlice(actual)) {
     return (
       pattern.access === actual.access &&
-      infer(pattern.element, actual.element, inferred, allowOpenGenericArguments)
+      inferType(pattern.element, actual.element, inferred, context)
     )
   }
   if (isReference(pattern) && isReference(actual)) {
     return (
       pattern.access === actual.access &&
-      infer(pattern.target, actual.target, inferred, allowOpenGenericArguments)
+      inferType(pattern.target, actual.target, inferred, context)
     )
   }
   if (isCallable(pattern) && isCallable(actual)) {
@@ -2352,11 +2404,9 @@ export const infer = (
       pattern.parameters.length === actual.parameters.length &&
       pattern.parameters.every((parameter_, index) => {
         const supplied = actual.parameters.at(index)
-        return (
-          supplied !== undefined && infer(parameter_, supplied, inferred, allowOpenGenericArguments)
-        )
+        return supplied !== undefined && inferType(parameter_, supplied, inferred, context)
       }) &&
-      infer(pattern.result, actual.result, inferred, allowOpenGenericArguments)
+      inferType(pattern.result, actual.result, inferred, context)
     )
   }
   if (isEffect(pattern) && isEffect(actual)) {
@@ -2364,21 +2414,44 @@ export const infer = (
     const actualRank = actual.access === 'Shared' ? 0 : actual.access === 'Exclusive' ? 1 : 2
     return (
       actualRank <= patternRank &&
-      infer(pattern.success, actual.success, inferred, allowOpenGenericArguments) &&
-      inferFailureRows(pattern, actual, inferred) &&
-      inferRequirementRows(pattern, actual, inferred)
+      inferType(pattern.success, actual.success, inferred, context) &&
+      inferFailureRows(pattern, actual, inferred, context) &&
+      inferRequirementRows(pattern, actual, inferred, context)
     )
   }
   if (isRepresented(pattern) && isRepresented(actual)) {
-    if (!infer(pattern.contract, actual.contract, inferred, allowOpenGenericArguments)) return false
+    if (!inferType(pattern.contract, actual.contract, inferred, context)) return false
     return inferGenericArgument(
       pattern.representation.argument,
       actual.representation.argument,
       inferred,
-      allowOpenGenericArguments,
+      context,
     )
   }
   return equals(pattern, actual)
+}
+
+export const infer = (
+  pattern: Type,
+  actual: Type,
+  inferred: Map<string, GenericArgument>,
+): boolean =>
+  inferType(pattern, actual, inferred, Object.freeze({ allowOpenGenericArguments: false }))
+
+/** Infers through generic arguments that remain open over an enclosing declaration. */
+export const inferOpenGenericArguments = (
+  pattern: Type,
+  actual: Type,
+  inferred: Map<string, GenericArgument>,
+): OpenGenericInference => {
+  const conflicts: Array<GenericArgumentConflict> = []
+  const matches = inferType(
+    pattern,
+    actual,
+    inferred,
+    Object.freeze({ allowOpenGenericArguments: true, conflicts }),
+  )
+  return Object.freeze({ matches, conflicts: Object.freeze(conflicts) })
 }
 
 /**

--- a/packages/compiler/src/Type.ts
+++ b/packages/compiler/src/Type.ts
@@ -2155,16 +2155,18 @@ const inferGenericArgument = (
   pattern: GenericArgument,
   actual: GenericArgument,
   inferred: Map<string, GenericArgument>,
+  allowOpenActual: boolean,
 ): boolean => {
   if (isRepresentationParameterArgument(pattern))
     return (
       isRepresentationArgument(actual) && bindGenericArgument(pattern.parameter, actual, inferred)
     )
   if (isFailureRowArgument(pattern) && isFailureRowArgument(actual))
-    return inferFailureRowArgument(pattern, actual, inferred, false)
+    return inferFailureRowArgument(pattern, actual, inferred, allowOpenActual)
   if (isRequirementRowArgument(pattern) && isRequirementRowArgument(actual))
-    return inferRequirementRowArgument(pattern, actual, inferred, false)
-  if (isTypeArgument(pattern) && isTypeArgument(actual)) return infer(pattern, actual, inferred)
+    return inferRequirementRowArgument(pattern, actual, inferred, allowOpenActual)
+  if (isTypeArgument(pattern) && isTypeArgument(actual))
+    return infer(pattern, actual, inferred, allowOpenActual)
   return genericArgumentKey(pattern) === genericArgumentKey(actual)
 }
 
@@ -2285,6 +2287,7 @@ export const infer = (
   pattern: Type,
   actual: Type,
   inferred: Map<string, GenericArgument>,
+  allowOpenGenericArguments = false,
 ): boolean => {
   if (isParameter(pattern)) {
     return pattern.kind === 'Value' && bindGenericArgument(pattern, actual, inferred)
@@ -2317,17 +2320,29 @@ export const infer = (
       return false
     return pattern.arguments.every((argument, index) => {
       const supplied = actual.arguments.at(index)
-      return supplied !== undefined && inferGenericArgument(argument, supplied, inferred)
+      return (
+        supplied !== undefined &&
+        inferGenericArgument(argument, supplied, inferred, allowOpenGenericArguments)
+      )
     })
   }
   if (isFixedArray(pattern) && isFixedArray(actual)) {
-    return pattern.length === actual.length && infer(pattern.element, actual.element, inferred)
+    return (
+      pattern.length === actual.length &&
+      infer(pattern.element, actual.element, inferred, allowOpenGenericArguments)
+    )
   }
   if (isSlice(pattern) && isSlice(actual)) {
-    return pattern.access === actual.access && infer(pattern.element, actual.element, inferred)
+    return (
+      pattern.access === actual.access &&
+      infer(pattern.element, actual.element, inferred, allowOpenGenericArguments)
+    )
   }
   if (isReference(pattern) && isReference(actual)) {
-    return pattern.access === actual.access && infer(pattern.target, actual.target, inferred)
+    return (
+      pattern.access === actual.access &&
+      infer(pattern.target, actual.target, inferred, allowOpenGenericArguments)
+    )
   }
   if (isCallable(pattern) && isCallable(actual)) {
     const patternRank = pattern.mode === 'Shared' ? 0 : pattern.mode === 'Exclusive' ? 1 : 2
@@ -2337,9 +2352,11 @@ export const infer = (
       pattern.parameters.length === actual.parameters.length &&
       pattern.parameters.every((parameter_, index) => {
         const supplied = actual.parameters.at(index)
-        return supplied !== undefined && infer(parameter_, supplied, inferred)
+        return (
+          supplied !== undefined && infer(parameter_, supplied, inferred, allowOpenGenericArguments)
+        )
       }) &&
-      infer(pattern.result, actual.result, inferred)
+      infer(pattern.result, actual.result, inferred, allowOpenGenericArguments)
     )
   }
   if (isEffect(pattern) && isEffect(actual)) {
@@ -2347,17 +2364,18 @@ export const infer = (
     const actualRank = actual.access === 'Shared' ? 0 : actual.access === 'Exclusive' ? 1 : 2
     return (
       actualRank <= patternRank &&
-      infer(pattern.success, actual.success, inferred) &&
+      infer(pattern.success, actual.success, inferred, allowOpenGenericArguments) &&
       inferFailureRows(pattern, actual, inferred) &&
       inferRequirementRows(pattern, actual, inferred)
     )
   }
   if (isRepresented(pattern) && isRepresented(actual)) {
-    if (!infer(pattern.contract, actual.contract, inferred)) return false
+    if (!infer(pattern.contract, actual.contract, inferred, allowOpenGenericArguments)) return false
     return inferGenericArgument(
       pattern.representation.argument,
       actual.representation.argument,
       inferred,
+      allowOpenGenericArguments,
     )
   }
   return equals(pattern, actual)

--- a/packages/compiler/test/ConditionalConformance.test.ts
+++ b/packages/compiler/test/ConditionalConformance.test.ts
@@ -661,6 +661,14 @@ fn mix<T>(left: &Box<T>, right: &T) -> i32 { return 0 }
 impl Mixer<Box<i32>, bool> for Box<i32> { mix: Box.mix }
 pub fn main() -> i32 { return 0 }`,
     )
+    const repeated = yield* analyze(
+      'conditional-conformance/repeated-conflicting-target-binder',
+      `interface Inspect<S> { fn inspect(value: S) -> i32 }
+struct Pair<A, B> { left: A right: B }
+fn inspect<T>(value: &Pair<T, T>) -> i32 { return 0 }
+impl Inspect<Pair<i32, bool>> for Pair<i32, bool> { inspect: Pair.inspect }
+pub fn main() -> i32 { return 0 }`,
+    )
 
     assert.deepEqual(
       Analysis.diagnostics(unresolved).map((diagnostic) => diagnostic.message),
@@ -670,6 +678,12 @@ pub fn main() -> i32 { return 0 }`,
       Analysis.diagnostics(conflicting).map((diagnostic) => diagnostic.message),
       [
         'Invalid conformance: Box.mix: witness target binder T is i32 from receiver left but bool from parameter right',
+      ],
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(repeated).map((diagnostic) => diagnostic.message),
+      [
+        'Invalid conformance: Pair.inspect: witness target binder T is i32 from receiver value (earlier occurrence) but bool from receiver value (later occurrence)',
       ],
     )
   }),

--- a/packages/compiler/test/ConditionalConformance.test.ts
+++ b/packages/compiler/test/ConditionalConformance.test.ts
@@ -554,6 +554,127 @@ pub fn main() -> i32 {
   }),
 )
 
+it.effect('infers reordered target binders and discovers two exact static specializations', () =>
+  Effect.gen(function* () {
+    const module = 'conditional-conformance/generic-targets'
+    const snapshot = yield* analyze(
+      module,
+      `interface Renderer<T> { fn render(value: T) -> i32 }
+
+struct Box<A, F: fn(i32) -> i32> { value: A }
+
+fn box<F: fn(i32) -> i32>(value: i32, operation: F) -> Box<i32, F> {
+  drop operation
+  return Box<i32, F> { value: value }
+}
+
+fn render<F: fn(i32) -> i32, A>(value: &Box<A, F>) -> i32 { return 21 }
+impl<A, F: fn(i32) -> i32> Renderer<Box<A, F>> for Box<A, F> {
+  render: Box.render
+}
+
+fn first(value: i32) -> i32 { return value + 1 }
+fn second(value: i32) -> i32 { return value + 2 }
+fn renderOf<T: Renderer>(value: T) -> i32 { return Renderer.render(value) }
+
+pub fn main() -> i32 {
+  let left = box(1, first)
+  let right = box(2, second)
+  return renderOf(move left) + renderOf(move right)
+}`,
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(snapshot).map(
+        (diagnostic) => `${diagnostic.code}: ${diagnostic.message}`,
+      ),
+      [],
+    )
+    const conformance = Analysis.declarationIndex(snapshot)
+      .modules.flatMap((candidate) => candidate.conformances)
+      .at(0)
+    assert.deepEqual(
+      conformance?.operations.at(0)?.targetArguments?.map(Type.encodeGenericArgument),
+      ['F', 'A'],
+    )
+
+    const hir = Analysis.hirOf(snapshot, module)
+    assert.isDefined(hir)
+    if (hir === undefined) return
+    const encodedHir = Hir.encode(hir)
+    assert.include(encodedHir, `bound ${module}.Renderer<T>.render over T`)
+
+    const renderInstances = Analysis.instancesOf(snapshot).instances.filter(
+      (instance) => instance.key.declaration.name === 'render',
+    )
+    assert.strictEqual(renderInstances.length, 2)
+    assert.isTrue(
+      renderInstances.every(
+        (instance) =>
+          Type.isExactRepresentationArgument(instance.key.typeArguments.at(0) ?? 'never') &&
+          Type.equalsGenericArgument(instance.key.typeArguments.at(1) ?? 'never', 'i32'),
+      ),
+    )
+    assert.strictEqual(
+      new Set(
+        renderInstances.map((instance) =>
+          instance.key.typeArguments.map(Type.genericArgumentKey).join('|'),
+        ),
+      ).size,
+      2,
+    )
+
+    const mir = Analysis.loweredMir(snapshot)
+    const witnessCalls = mir.functions.flatMap((fn) =>
+      fn.regions.flatMap((region) =>
+        region._tag === 'OperationRegion'
+          ? region.operations.filter(
+              (operation) => operation._tag === 'Call' && operation.target.name === 'render',
+            )
+          : [],
+      ),
+    )
+    assert.strictEqual(witnessCalls.length, 2)
+    const encodedMir = Mir.encode(mir)
+    for (const spelling of ['dictionary', 'vtable', 'witnessTable', 'interfaceTag', 'typeTag'])
+      assert.isFalse(encodedMir.includes(spelling), `${spelling} reached MIR`)
+    const outcome = Analysis.evaluate(snapshot)
+    assert.strictEqual(outcome._tag, 'Completed')
+    if (outcome._tag === 'Completed') assert.strictEqual(outcome.result.value, 42)
+  }),
+)
+
+it.effect('diagnoses unresolved and conflicting target binders deterministically', () =>
+  Effect.gen(function* () {
+    const unresolved = yield* analyze(
+      'conditional-conformance/unresolved-target-binder',
+      `interface Mixer<S, A> { fn mix(left: S, right: A) -> i32 }
+struct Box<T> { value: T }
+fn mix<T, U>(left: &Box<T>, right: &bool) -> i32 { return 0 }
+impl Mixer<Box<i32>, bool> for Box<i32> { mix: Box.mix }
+pub fn main() -> i32 { return 0 }`,
+    )
+    const conflicting = yield* analyze(
+      'conditional-conformance/conflicting-target-binder',
+      `interface Mixer<S, A> { fn mix(left: S, right: A) -> i32 }
+struct Box<T> { value: T }
+fn mix<T>(left: &Box<T>, right: &T) -> i32 { return 0 }
+impl Mixer<Box<i32>, bool> for Box<i32> { mix: Box.mix }
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.deepEqual(
+      Analysis.diagnostics(unresolved).map((diagnostic) => diagnostic.message),
+      ['Invalid conformance: Box.mix: cannot infer witness target binder U'],
+    )
+    assert.deepEqual(
+      Analysis.diagnostics(conflicting).map((diagnostic) => diagnostic.message),
+      [
+        'Invalid conformance: Box.mix: witness target binder T is i32 from receiver left but bool from parameter right',
+      ],
+    )
+  }),
+)
+
 it.effect('keeps the conditional witness question unresolved in generic HIR', () =>
   Effect.gen(function* () {
     const snapshot = yield* analyze(

--- a/packages/compiler/test/InterfaceWitnessInference.test.ts
+++ b/packages/compiler/test/InterfaceWitnessInference.test.ts
@@ -1,0 +1,111 @@
+import { assert, it } from '@effect/vitest'
+import * as InterfaceWitnessInference from '../src/InterfaceWitnessInference.js'
+import * as Type from '../src/Type.js'
+
+const owner = Object.freeze({ module: 'witness-inference', name: 'target' })
+
+const binder = (
+  ordinal: number,
+  name: string,
+  kind: Type.ParameterKind = 'Value',
+  representationBound?: Type.RepresentationBound,
+): Type.Parameter => Type.parameter(owner, ordinal, name, kind, representationBound)
+
+it('infers type, row, callable, and Effect representation binders in declaration order', () => {
+  const value = binder(0, 'T')
+  const failures = binder(1, 'E', 'FailureRow')
+  const requirements = binder(2, 'R', 'RequirementRow')
+  const callableBound = Type.callable(['i32'], 'bool')
+  const representation = binder(3, 'F', 'CallableRepresentation', callableBound)
+  const effectBound = Type.effect('bool', [])
+  const effectRepresentation = binder(4, 'G', 'EffectRepresentation', effectBound)
+  const decodeError = Type.nominal('witness-inference', 'DecodeError')
+  const clock = Type.nominal('witness-inference', 'Clock')
+  const callable = Type.exactRepresentationArgument(
+    Type.callableIdentityArgument(
+      'declaration:witness-inference:predicate',
+      Object.freeze({
+        _tag: 'Declaration',
+        module: 'witness-inference',
+        name: 'predicate',
+      }),
+    ),
+    callableBound,
+  )
+  const effect = Type.exactRepresentationArgument(
+    Type.effectIdentityArgument('effect:witness-inference:predicate'),
+    effectBound,
+  )
+  const inference = InterfaceWitnessInference.infer(
+    [value, failures, requirements, representation, effectRepresentation],
+    [
+      Object.freeze({
+        label: 'provider',
+        pattern: Type.nominal('witness-inference', 'Schema', [
+          value,
+          Type.representationParameterArgument(representation),
+          Type.representationParameterArgument(effectRepresentation),
+        ]),
+        actual: Type.nominal('witness-inference', 'Schema', ['i32', callable, effect]),
+      }),
+      Object.freeze({
+        label: 'rows',
+        pattern: Type.effect('bool', [], 'Shared', [], [failures], [requirements]),
+        actual: Type.effect('bool', [decodeError], 'Shared', [
+          Object.freeze({ capability: clock, role: 'DefaultRole', access: 'Shared' }),
+        ]),
+      }),
+    ],
+  )
+
+  assert.strictEqual(inference._tag, 'Inferred')
+  if (inference._tag !== 'Inferred') return
+  assert.deepEqual(inference.arguments.map(Type.genericArgumentKey), [
+    Type.key('i32'),
+    Type.genericArgumentKey(Type.failureRowArgument([decodeError])),
+    Type.genericArgumentKey(
+      Type.requirementRowArgument([
+        Object.freeze({ capability: clock, role: 'DefaultRole', access: 'Shared' }),
+      ]),
+    ),
+    Type.genericArgumentKey(callable),
+    Type.genericArgumentKey(effect),
+  ])
+})
+
+it('reports the first declaration-ordered unresolved binder', () => {
+  const inferred = binder(0, 'T')
+  const unresolved = binder(1, 'U')
+  const inference = InterfaceWitnessInference.infer(
+    [inferred, unresolved],
+    [Object.freeze({ label: 'receiver', pattern: inferred, actual: 'i32' })],
+  )
+
+  assert.deepEqual(inference, {
+    _tag: 'Failed',
+    problem: { _tag: 'UnresolvedBinder', binder: unresolved },
+  })
+})
+
+it('reports deterministic conflicting evidence with both contract positions', () => {
+  const value = binder(0, 'T')
+  const inference = InterfaceWitnessInference.infer(
+    [value],
+    [
+      Object.freeze({ label: 'receiver', pattern: value, actual: 'i32' }),
+      Object.freeze({ label: 'success', pattern: value, actual: 'bool' }),
+    ],
+  )
+
+  assert.deepEqual(inference, {
+    _tag: 'Failed',
+    problem: {
+      _tag: 'ConflictingBinder',
+      binder: value,
+      previous: 'i32',
+      conflicting: 'bool',
+      previousConstraint: 'receiver',
+      conflictingConstraint: 'success',
+    },
+  })
+})

--- a/packages/compiler/test/InterfaceWitnessInference.test.ts
+++ b/packages/compiler/test/InterfaceWitnessInference.test.ts
@@ -109,3 +109,29 @@ it('reports deterministic conflicting evidence with both contract positions', ()
     },
   })
 })
+
+it('reports repeated conflicting evidence within one structural contract position', () => {
+  const value = binder(0, 'T')
+  const inference = InterfaceWitnessInference.infer(
+    [value],
+    [
+      Object.freeze({
+        label: 'receiver value',
+        pattern: Type.nominal('witness-inference', 'Pair', [value, value]),
+        actual: Type.nominal('witness-inference', 'Pair', ['i32', 'bool']),
+      }),
+    ],
+  )
+
+  assert.deepEqual(inference, {
+    _tag: 'Failed',
+    problem: {
+      _tag: 'ConflictingBinder',
+      binder: value,
+      previous: 'i32',
+      conflicting: 'bool',
+      previousConstraint: 'receiver value (earlier occurrence)',
+      conflictingConstraint: 'receiver value (later occurrence)',
+    },
+  })
+})


### PR DESCRIPTION
## Summary

- infer mapped witness target type, failure-row, requirement-row, callable, and Effect-representation binders from substituted contracts
- preserve inferred target arguments through witness resolution into concrete specialization keys and direct static MIR calls
- diagnose unresolved and conflicting binders deterministically, including repeated evidence within one contract position

## Scope

Completes OpenSpec tasks 3.1–3.4 only. PR4 literal-operand admission remains deferred; this adds no runtime dictionaries, service slots, existential packaging, or indirect dispatch. OpenSpec sync/archive and PR5 validation tasks are untouched.

## Validation

- pnpm typecheck
- pnpm exec biome check .
- pnpm test
- pnpm check
- three-axis read-only review plus affected-axis re-review

## Review ledger

No merge or downstream blockers remain. PRESSURE-DEBT: generic HIR intentionally keeps the witness question unresolved, so target-argument coverage is proven through declaration-index preservation and per-specialization instance resolution rather than a target-argument field on HIR.