### PR TITLE
compiler: implement stored Effect ownership, layout, and MIR

### DIFF
--- a/apps/docs/app/labs/row/project-backend.tsx
+++ b/apps/docs/app/labs/row/project-backend.tsx
@@ -359,10 +359,8 @@ const cleanupText = (cleanup: Ownership.CleanupPlan): string => {
       return `${typeText(cleanup.type)} captures ${cleanup.slots
         .map(({ ordinal, cleanup: slot }) => `#${ordinal}:${cleanupText(slot)}`)
         .join(' → ')}`
-    case 'RepresentedCallableCleanup':
-      return `${typeText(cleanup.type)} · stored callable cleanup after specialization`
     case 'RepresentedEffectCleanup':
-      return `${typeText(cleanup.type)} · stored Effect cleanup after specialization`
+      return `${typeText(cleanup.type)} stored ${typeText(cleanup.contract)} · lanes resolved at the complete instance`
     case 'EffectCleanup':
       return `${typeText(cleanup.type)} captures ${cleanup.slots
         .map(({ ordinal, cleanup: slot }) => `#${ordinal}:${cleanupText(slot)}`)

--- a/apps/docs/app/labs/row/project-backend.tsx
+++ b/apps/docs/app/labs/row/project-backend.tsx
@@ -359,6 +359,10 @@ const cleanupText = (cleanup: Ownership.CleanupPlan): string => {
       return `${typeText(cleanup.type)} captures ${cleanup.slots
         .map(({ ordinal, cleanup: slot }) => `#${ordinal}:${cleanupText(slot)}`)
         .join(' → ')}`
+    case 'RepresentedCallableCleanup':
+      return `${typeText(cleanup.type)} · stored callable cleanup after specialization`
+    case 'RepresentedEffectCleanup':
+      return `${typeText(cleanup.type)} · stored Effect cleanup after specialization`
     case 'EffectCleanup':
       return `${typeText(cleanup.type)} captures ${cleanup.slots
         .map(({ ordinal, cleanup: slot }) => `#${ordinal}:${cleanupText(slot)}`)
@@ -629,17 +633,19 @@ export const layoutRows = (
             ? 'aggregate'
             : entry.representation._tag === 'CallableEnvironment'
               ? `stored callable · ${entry.representation.fields.length} capture${entry.representation.fields.length === 1 ? '' : 's'}`
-            : entry.representation._tag === 'Repeated'
-              ? `${entry.representation.length} × ${typeText(entry.representation.element)} · stride ${entry.representation.stride}`
-              : entry.representation._tag === 'Slice'
-                ? `address i${entry.representation.address.bits} + length i32 · stride ${entry.representation.stride}`
-              : entry.representation._tag === 'String'
-                ? `UTF-8 address i${entry.representation.storage.bits} + byte length i${entry.representation.byteLength.size * 8}`
-              : entry.representation._tag === 'Union'
-                ? `sum · tag i${entry.representation.tag.bits} · payload +${entry.representation.payloadOffset}/${entry.representation.payloadSize}`
-              : entry.representation._tag === 'Reference'
-                ? `reference · address i${entry.representation.address.bits}`
-                : `i${entry.representation.bits}`
+              : entry.representation._tag === 'StoredEffectEnvironment'
+                ? `stored Effect · ${entry.representation.fields.length} capture${entry.representation.fields.length === 1 ? '' : 's'}`
+                : entry.representation._tag === 'Repeated'
+                  ? `${entry.representation.length} × ${typeText(entry.representation.element)} · stride ${entry.representation.stride}`
+                  : entry.representation._tag === 'Slice'
+                    ? `address i${entry.representation.address.bits} + length i32 · stride ${entry.representation.stride}`
+                    : entry.representation._tag === 'String'
+                      ? `UTF-8 address i${entry.representation.storage.bits} + byte length i${entry.representation.byteLength.size * 8}`
+                      : entry.representation._tag === 'Union'
+                        ? `sum · tag i${entry.representation.tag.bits} · payload +${entry.representation.payloadOffset}/${entry.representation.payloadSize}`
+                        : entry.representation._tag === 'Reference'
+                          ? `reference · address i${entry.representation.address.bits}`
+                          : `i${entry.representation.bits}`
         }`,
       })
     }

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -12,7 +12,7 @@
 
 ## 3. Ownership, Layout, and MIR
 
-- [ ] 3.1 Preserve Effect loans, exact rows, whole-value moves, nesting, and direct-field-extraction rejection.
+- [x] 3.1 Preserve Effect loans, exact rows, whole-value moves, nesting, and direct-field-extraction rejection.
 - [ ] 3.2 Plan inline concrete environments and suspendability dependencies in the enclosing build-internal nominal ABI.
 - [ ] 3.3 Carry lazy construction, run, suspension/resume, typed failure, and cleanup through HIR and MIR.
 

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -14,7 +14,7 @@
 
 - [x] 3.1 Preserve Effect loans, exact rows, whole-value moves, nesting, and direct-field-extraction rejection.
 - [x] 3.2 Plan inline concrete environments and suspendability dependencies in the enclosing build-internal nominal ABI.
-- [ ] 3.3 Carry lazy construction, run, suspension/resume, typed failure, and cleanup through HIR and MIR.
+- [x] 3.3 Carry lazy construction, run, suspension/resume, typed failure, and cleanup through HIR and MIR.
 
 ## 4. Engine Parity and Invalidation
 

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -13,7 +13,7 @@
 ## 3. Ownership, Layout, and MIR
 
 - [x] 3.1 Preserve Effect loans, exact rows, whole-value moves, nesting, and direct-field-extraction rejection.
-- [ ] 3.2 Plan inline concrete environments and suspendability dependencies in the enclosing build-internal nominal ABI.
+- [x] 3.2 Plan inline concrete environments and suspendability dependencies in the enclosing build-internal nominal ABI.
 - [ ] 3.3 Carry lazy construction, run, suspension/resume, typed failure, and cleanup through HIR and MIR.
 
 ## 4. Engine Parity and Invalidation

--- a/packages/compiler/src/BootstrapEvaluation.ts
+++ b/packages/compiler/src/BootstrapEvaluation.ts
@@ -1659,10 +1659,13 @@ function* executeFunction(
     }
     if (cleanup._tag === 'RawBufferCleanup') return Object.freeze([cleanup.type])
     if (cleanup._tag === 'HookCleanup') return cleanupMembers(cleanup.inner, owner)
-    // An unresolved stored-callable obligation never reaches evaluation: `specializeCleanup`
-    // resolves it to the realization's `CallableCleanup` before lowering, and `SEM0103` fences
-    // every path that has no realization.
-    if (cleanup._tag === 'RepresentedCallableCleanup') return Object.freeze([])
+    // Unresolved stored-executable obligations never reach evaluation: specialization resolves
+    // them before lowering, while the executable fences retain every incomplete engine path.
+    if (
+      cleanup._tag === 'RepresentedCallableCleanup' ||
+      cleanup._tag === 'RepresentedEffectCleanup'
+    )
+      return Object.freeze([])
     if (owner._tag !== 'AggregateValue') return Object.freeze([])
     return Object.freeze(
       cleanup.fields.flatMap((field) => {

--- a/packages/compiler/src/CallableFieldRealization.ts
+++ b/packages/compiler/src/CallableFieldRealization.ts
@@ -269,6 +269,16 @@ const compareEffectEnvironmentSlots = (
   right: EffectEnvironmentSlot,
 ): number => left.ordinal - right.ordinal || left.sourceOrdinal - right.sourceOrdinal
 
+/**
+ * Returns the canonical target-independent environment seam for any discovered Effect instance.
+ * Stored-field realization and recursive layout both consume this function, so nested Effects do
+ * not grow a second capture model or rediscover captures from source syntax.
+ */
+export const effectEnvironmentOf = (
+  effect: Instances.EffectInstance,
+): ReadonlyArray<EffectEnvironmentSlot> =>
+  Object.freeze([...effect.captures.map(effectEnvironmentSlot)].sort(compareEffectEnvironmentSlots))
+
 const effectRows = (contract: Type.Effect): EffectRows =>
   Object.freeze({
     _tag: 'EffectFieldRows',
@@ -513,9 +523,7 @@ const realizeEffectField = (
         actual: selected.type,
       }),
     )
-  const environment = Object.freeze(
-    [...selected.captures.map(effectEnvironmentSlot)].sort(compareEffectEnvironmentSlots),
-  )
+  const environment = effectEnvironmentOf(selected)
   return Object.freeze({
     _tag: 'Supported',
     realization: Object.freeze({

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -3316,8 +3316,8 @@ export const partialMove = (span: SourceSpan.SourceSpan): Diagnostic =>
 
 /**
  * Extracting an owned representation-bearing field would leave the aggregate holding a partially
- * released callable environment, so its captures could be cleaned twice. Consuming invocation takes
- * the whole aggregate instead.
+ * released executable environment, so its captures could be cleaned twice. Consuming invocation or
+ * execution takes the whole aggregate instead.
  */
 export const representationFieldExtraction = (
   aggregate: string,
@@ -3330,7 +3330,7 @@ export const representationFieldExtraction = (
     phase: 'ownership',
     code: representationFieldExtractionCode,
     severity: 'error',
-    message: `Cannot move field ${field} out of ${aggregate}: it stores the callable representation ${contract}, whose captures are cleaned with the whole aggregate`,
+    message: `Cannot move field ${field} out of ${aggregate}: it stores the executable representation ${contract}, whose captures are cleaned with the whole aggregate`,
     reason: Object.freeze({ _tag: 'RepresentationFieldExtraction', aggregate, field, contract }),
     span,
   })

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -2818,8 +2818,23 @@ const representationEquals = (left: Representation, right: Representation): bool
       })
     )
   }
+  const cleanupHooksEqual = (
+    leftHook: Extract<Representation, { readonly _tag: 'Aggregate' }>['cleanupHook'],
+    rightHook: Extract<Representation, { readonly _tag: 'Aggregate' }>['cleanupHook'],
+  ): boolean =>
+    leftHook === undefined
+      ? rightHook === undefined
+      : rightHook !== undefined &&
+        leftHook.hook.module === rightHook.hook.module &&
+        leftHook.hook.name === rightHook.hook.name &&
+        leftHook.typeArguments.length === rightHook.typeArguments.length &&
+        leftHook.typeArguments.every((argument, ordinal) => {
+          const other = rightHook.typeArguments.at(ordinal)
+          return other !== undefined && Type.equalsGenericArgument(argument, other)
+        })
   return (
     right._tag === 'Aggregate' &&
+    cleanupHooksEqual(left.cleanupHook, right.cleanupHook) &&
     left.tailPadding === right.tailPadding &&
     left.fields.length === right.fields.length &&
     left.fields.every((field, index) => {
@@ -3141,6 +3156,21 @@ const verifyEntry = (
     ])
   }
   const violations: Array<Violation> = []
+  const cleanupHook = candidate.representation.cleanupHook
+  if (
+    cleanupHook !== undefined &&
+    (cleanupHook.hook.module.length === 0 ||
+      cleanupHook.hook.name.length === 0 ||
+      cleanupHook.typeArguments.some((argument) => !Type.isConcreteGenericArgument(argument)))
+  ) {
+    violations.push(
+      invalid(
+        'InvalidAggregate',
+        candidate.type,
+        `${Type.encode(candidate.type)} has a non-canonical cleanup hook`,
+      ),
+    )
+  }
   let cursor = 0
   let alignment = 1
   let previousOrdinal = -1
@@ -3579,7 +3609,11 @@ const representationText = (representation: Representation): string =>
                       ? `reference target=${Type.encode(representation.target)} address=i${representation.address.bits}@${representation.address.offset}/${representation.address.size}/${representation.address.alignment}`
                       : representation._tag === 'Union'
                         ? `union tag=i${representation.tag.bits} payload-offset=${representation.payloadOffset} payload-size=${representation.payloadSize} payload-align=${representation.payloadAlignment} tag-padding=${representation.tagPadding} tail-padding=${representation.tailPadding}`
-                        : `aggregate tail-padding=${representation.tailPadding}`
+                        : `aggregate cleanup-hook=${
+                            representation.cleanupHook === undefined
+                              ? 'none'
+                              : `${representation.cleanupHook.hook.module}.${representation.cleanupHook.hook.name}<${representation.cleanupHook.typeArguments.map(Type.encodeGenericArgument).join(',')}>`
+                          } tail-padding=${representation.tailPadding}`
 
 const entryLines = (candidate: Entry): ReadonlyArray<string> => [
   `layout ${Type.encode(candidate.type)} size=${candidate.size} align=${candidate.alignment} repr=${representationText(candidate.representation)}`,

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -1522,14 +1522,24 @@ const effectEnvironments = (
       for (const block of blocks) {
         const structuralEffect = Type.substitute(block.type, instance.substitution)
         if (!Type.isEffect(structuralEffect)) continue
+        const effectInstance = discovery.effects.find(
+          (candidate) => candidate.identity === Instances.effectIdentity(instance.key, block.site),
+        )
+        const realizedSlots =
+          effectInstance === undefined
+            ? Object.freeze([])
+            : CallableFieldRealization.effectEnvironmentOf(effectInstance)
         let effect = structuralEffect
         let cursor = 0
         let environmentAlignment = 1
         let unavailable: string | undefined
         const fields: Array<EffectEnvironmentField> = []
-        for (const capture of block.captures) {
-          const source = capture.binding === undefined ? 'Parameter' : 'Binding'
-          const ordinal = capture.binding?.ordinal ?? capture.parameter?.ordinal
+        for (const [captureOrdinal, capture] of block.captures.entries()) {
+          const realized = realizedSlots.find((slot) => slot.ordinal === captureOrdinal)
+          const source =
+            realized?.source ?? (capture.binding === undefined ? 'Parameter' : 'Binding')
+          const ordinal =
+            realized?.sourceOrdinal ?? capture.binding?.ordinal ?? capture.parameter?.ordinal
           const type =
             capture.binding === undefined
               ? instance.function.contract._tag === 'Contract' && ordinal !== undefined
@@ -1542,11 +1552,20 @@ const effectEnvironments = (
             unavailable = `capture ${source.toLowerCase()} has no concrete type`
             break
           }
-          const specialized = Type.substitute(type, instance.substitution)
+          const specialized = realized?.type ?? Type.substitute(type, instance.substitution)
           const capturedEffectIdentity =
-            Type.isEffect(specialized) && source === 'Parameter'
+            realized?.effectIdentity ??
+            (Type.isEffect(specialized) && source === 'Parameter'
               ? Instances.parameterEffectIdentity(instance.function, instance.key, ordinal)
-              : undefined
+              : undefined)
+          const capturedEffectInstance =
+            capturedEffectIdentity === undefined
+              ? undefined
+              : discovery.effects.find(
+                  (candidate) =>
+                    candidate.identity === capturedEffectIdentity ||
+                    candidate.representationIdentity === capturedEffectIdentity,
+                )
           const capturedEffectEnvironment =
             capturedEffectIdentity === undefined
               ? undefined
@@ -1558,13 +1577,18 @@ const effectEnvironments = (
                     { readonly _tag: 'EffectEnvironment' }
                   > =>
                     candidate._tag === 'EffectEnvironment' &&
-                    Instances.effectIdentity(candidate.instance, candidate.site) ===
-                      capturedEffectIdentity,
+                    (Instances.effectIdentity(candidate.instance, candidate.site) ===
+                      capturedEffectIdentity ||
+                      candidate.successEffectIdentity === capturedEffectIdentity ||
+                      (capturedEffectInstance !== undefined &&
+                        Instances.effectIdentity(candidate.instance, candidate.site) ===
+                          capturedEffectInstance.identity)),
                 )
           const capturedCallableIdentity =
-            Type.isCallable(specialized) && source === 'Parameter'
+            realized?.callableIdentity ??
+            (Type.isCallable(specialized) && source === 'Parameter'
               ? Instances.parameterCallableIdentity(instance.function, instance.key, ordinal)
-              : undefined
+              : undefined)
           const capturedCallableEnvironment =
             capturedCallableIdentity?.environment === undefined
               ? undefined

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -41,6 +41,12 @@ export type Representation =
       readonly tailPadding: number
     }
   | {
+      readonly _tag: 'StoredEffectEnvironment'
+      readonly realization: CallableFieldRealization.EffectRealization
+      readonly fields: ReadonlyArray<StoredEffectEnvironmentField>
+      readonly tailPadding: number
+    }
+  | {
       readonly _tag: 'Repeated'
       readonly element: DeclarationIndex.SemanticType
       readonly length: number
@@ -208,6 +214,11 @@ export interface EffectEnvironmentField {
   readonly callableIdentity?: Type.CallableIdentityArgument
 }
 
+/** One realized Effect slot after target placement inside its enclosing nominal field. */
+export interface StoredEffectEnvironmentField extends EffectEnvironmentField {
+  readonly capture: number
+}
+
 /** Target-owned storage and call-scoped view for one concrete callable section identity. */
 export type CallableEnvironment =
   | {
@@ -282,6 +293,7 @@ export type Selector =
   | DeclarationIndex.FieldId
   | { readonly _tag: 'ElementSelector'; readonly index: number }
   | { readonly _tag: 'CallableCaptureSelector'; readonly ordinal: number }
+  | { readonly _tag: 'EffectCaptureSelector'; readonly ordinal: number }
   | { readonly _tag: 'UnionTagSelector' }
   | { readonly _tag: 'UnionPayloadSelector'; readonly slot: number }
   | { readonly _tag: 'SliceAddressSelector' }
@@ -337,6 +349,15 @@ export type CallingShapeNode =
     }
   | {
       readonly _tag: 'CallableEnvironmentShape'
+      readonly type: Type.Represented
+      readonly fields: ReadonlyArray<{
+        readonly capture: number
+        readonly shape: CallingShapeNode
+      }>
+      readonly laneCount: number
+    }
+  | {
+      readonly _tag: 'EffectEnvironmentShape'
       readonly type: Type.Represented
       readonly fields: ReadonlyArray<{
         readonly capture: number
@@ -633,6 +654,105 @@ export const catalog = (
   const callableRealizations =
     discovery === undefined ? undefined : Instances.callableFieldRealizations(discovery, index)
 
+  interface InlineEnvironmentLayout {
+    readonly fields: ReadonlyArray<StoredEffectEnvironmentField>
+    readonly size: number
+    readonly alignment: number
+    readonly tailPadding: number
+  }
+
+  const layoutEffectSlots = (
+    slots: ReadonlyArray<CallableFieldRealization.EffectEnvironmentSlot>,
+    active: ReadonlySet<string>,
+  ): InlineEnvironmentLayout | undefined => {
+    let cursor = 0
+    let environmentAlignment = 1
+    const fields: Array<StoredEffectEnvironmentField> = []
+    for (const slot of slots) {
+      const nestedEffect =
+        slot.effectIdentity === undefined
+          ? undefined
+          : discovery?.effects.find(
+              (candidate) =>
+                candidate.identity === slot.effectIdentity ||
+                candidate.representationIdentity === slot.effectIdentity,
+            )
+      const callableIdentity = slot.callableIdentity
+      const nestedCallable =
+        callableIdentity === undefined
+          ? undefined
+          : discovery?.callables.find((candidate) =>
+              CallableFieldRealization.matchesIdentity(callableIdentity, candidate),
+            )
+      const stableDescriptor = Type.isSlice(slot.type) || Type.isReference(slot.type)
+      const borrowed =
+        (slot.access === 'Shared' || slot.access === 'Exclusive') &&
+        nestedEffect === undefined &&
+        nestedCallable === undefined &&
+        !stableDescriptor
+      let nestedLayout: { readonly size: number; readonly alignment: number } | undefined
+      if (nestedEffect !== undefined) {
+        if (active.has(nestedEffect.identity)) return undefined
+        nestedLayout = layoutEffectSlots(
+          CallableFieldRealization.effectEnvironmentOf(nestedEffect),
+          new Set([...active, nestedEffect.identity]),
+        )
+      } else if (nestedCallable !== undefined) {
+        let callableCursor = 0
+        let callableAlignment = 1
+        for (const capture of nestedCallable.captures) {
+          const captureBorrowed = capture.access === 'Shared' || capture.access === 'Exclusive'
+          const captureLayout = captureBorrowed ? undefined : layoutType(capture.type)
+          if (captureLayout?._tag === 'UnavailableLayoutEntry') return undefined
+          const size = captureBorrowed ? target.pointerSize : (captureLayout?.size ?? 0)
+          const alignment = captureBorrowed
+            ? target.pointerAlignment
+            : (captureLayout?.alignment ?? 1)
+          callableCursor = alignUp(callableCursor, alignment) + size
+          callableAlignment = Math.max(callableAlignment, alignment)
+        }
+        nestedLayout = Object.freeze({
+          size: alignUp(callableCursor, callableAlignment),
+          alignment: callableAlignment,
+        })
+      } else if (!borrowed) {
+        const candidate = layoutType(slot.type)
+        if (candidate._tag === 'UnavailableLayoutEntry') return undefined
+        nestedLayout = candidate
+      }
+      const size = borrowed ? target.pointerSize : (nestedLayout?.size ?? 0)
+      const alignment = borrowed ? target.pointerAlignment : (nestedLayout?.alignment ?? 1)
+      const offset = alignUp(cursor, alignment)
+      fields.push(
+        Object.freeze({
+          capture: slot.ordinal,
+          source: slot.source,
+          ordinal: slot.sourceOrdinal,
+          access: slot.access,
+          type: nestedEffect?.type ?? slot.type,
+          offset,
+          size,
+          alignment,
+          padding: offset - cursor,
+          representation: borrowed ? 'Borrow' : nestedCallable === undefined ? 'Value' : 'Callable',
+          ...(slot.effectIdentity === undefined ? {} : { effectIdentity: slot.effectIdentity }),
+          ...(slot.callableIdentity === undefined
+            ? {}
+            : { callableIdentity: slot.callableIdentity }),
+        }),
+      )
+      cursor = offset + size
+      environmentAlignment = Math.max(environmentAlignment, alignment)
+    }
+    const size = alignUp(cursor, environmentAlignment)
+    return Object.freeze({
+      fields: Object.freeze(fields),
+      size,
+      alignment: environmentAlignment,
+      tailPadding: size - cursor,
+    })
+  }
+
   const layoutRepresentedCallable = (
     type: Type.Represented,
     realization: CallableFieldRealization.CallableRealization,
@@ -686,6 +806,41 @@ export const catalog = (
         realization,
         fields: Object.freeze(fields),
         tailPadding: size - cursor,
+      }),
+    })
+    completed.set(key, result)
+    return result
+  }
+
+  const layoutRepresentedEffect = (
+    type: Type.Represented,
+    realization: CallableFieldRealization.EffectRealization,
+  ): CatalogEntry => {
+    const key = Type.key(type)
+    const existing = completed.get(key)
+    if (existing !== undefined) return existing
+    const environment = layoutEffectSlots(
+      realization.environment,
+      new Set([realization.runnerIdentity]),
+    )
+    if (environment === undefined) {
+      const result = unavailable(type, Object.freeze(Type.nominals(type)), {
+        _tag: 'InvalidDeclaration',
+        detail: 'stored Effect environment has an unavailable or recursive capture layout',
+      })
+      completed.set(key, result)
+      return result
+    }
+    const result: Entry = Object.freeze({
+      _tag: 'LayoutEntry',
+      type,
+      size: environment.size,
+      alignment: environment.alignment,
+      representation: Object.freeze({
+        _tag: 'StoredEffectEnvironment',
+        realization,
+        fields: environment.fields,
+        tailPadding: environment.tailPadding,
       }),
     })
     completed.set(key, result)
@@ -871,14 +1026,16 @@ export const catalog = (
           const realization =
             plan === undefined || callableRealizations === undefined
               ? undefined
-              : CallableFieldRealization.callableRealizationOf(callableRealizations, type, plan.id)
+              : CallableFieldRealization.realizationOf(callableRealizations, type, plan.id)
           if (realization === undefined) {
             return unavailable(candidate, Object.freeze(Type.nominals(candidate)), {
               _tag: 'InvalidDeclaration',
               detail: 'represented executable values remain unavailable to layout',
             })
           }
-          return layoutRepresentedCallable(candidate, realization)
+          return CallableFieldRealization.isCallableRealization(realization)
+            ? layoutRepresentedCallable(candidate, realization)
+            : layoutRepresentedEffect(candidate, realization)
         }
         if (Type.isFixedArray(candidate)) {
           const element = layoutFieldType(candidate.element)
@@ -1731,7 +1888,10 @@ export const plan = (self: Catalog, discovery: Instances.Discovery): Plan => {
     entries.set(key, candidate)
     if (candidate.representation._tag === 'Aggregate') {
       for (const field of candidate.representation.fields) add(field.type)
-    } else if (candidate.representation._tag === 'CallableEnvironment') {
+    } else if (
+      candidate.representation._tag === 'CallableEnvironment' ||
+      candidate.representation._tag === 'StoredEffectEnvironment'
+    ) {
       for (const field of candidate.representation.fields) add(field.type)
     } else if (candidate.representation._tag === 'Repeated') {
       add(candidate.representation.element)
@@ -1893,14 +2053,21 @@ const shapeNode = (
   }
   if (Type.isRepresented(type)) {
     const representation = entries.get(Type.key(type))?.representation
-    if (representation?._tag !== 'CallableEnvironment') {
+    if (
+      representation?._tag !== 'CallableEnvironment' &&
+      representation?._tag !== 'StoredEffectEnvironment'
+    ) {
       throw new RangeError(
         `represented executable ${Type.encode(type)} is unavailable to calling-shape planning`,
       )
     }
-    const fields = representation.fields.map((field) =>
+    const environmentFields =
+      representation._tag === 'CallableEnvironment'
+        ? representation.fields.map((field) => Object.freeze({ capture: field.ordinal, field }))
+        : representation.fields.map((field) => Object.freeze({ capture: field.capture, field }))
+    const fields = environmentFields.map(({ capture, field }) =>
       Object.freeze({
-        capture: field.ordinal,
+        capture,
         shape:
           field.representation === 'Borrow'
             ? Object.freeze({
@@ -1920,7 +2087,10 @@ const shapeNode = (
       }),
     )
     return Object.freeze({
-      _tag: 'CallableEnvironmentShape',
+      _tag:
+        representation._tag === 'CallableEnvironment'
+          ? ('CallableEnvironmentShape' as const)
+          : ('EffectEnvironmentShape' as const),
       type,
       fields: Object.freeze(fields),
       laneCount: fields.reduce((total, field) => total + field.shape.laneCount, 0),
@@ -2100,15 +2270,16 @@ const materializeLanes = (
       ),
     )
   }
-  if (node._tag === 'CallableEnvironmentShape') {
+  if (node._tag === 'CallableEnvironmentShape' || node._tag === 'EffectEnvironmentShape') {
+    const selectorTag =
+      node._tag === 'CallableEnvironmentShape'
+        ? ('CallableCaptureSelector' as const)
+        : ('EffectCaptureSelector' as const)
     return Object.freeze(
       node.fields.flatMap((field) =>
         materializeLanes(
           field.shape,
-          Object.freeze([
-            ...path,
-            Object.freeze({ _tag: 'CallableCaptureSelector' as const, ordinal: field.capture }),
-          ]),
+          Object.freeze([...path, Object.freeze({ _tag: selectorTag, ordinal: field.capture })]),
         ),
       ),
     )
@@ -2403,6 +2574,35 @@ const representationEquals = (left: Representation, right: Representation): bool
       })
     )
   }
+  if (left._tag === 'StoredEffectEnvironment') {
+    return (
+      right._tag === 'StoredEffectEnvironment' &&
+      CallableFieldRealization.equals(left.realization, right.realization) &&
+      left.tailPadding === right.tailPadding &&
+      left.fields.length === right.fields.length &&
+      left.fields.every((field, ordinal) => {
+        const other = right.fields.at(ordinal)
+        return (
+          other !== undefined &&
+          field.capture === other.capture &&
+          field.source === other.source &&
+          field.ordinal === other.ordinal &&
+          field.access === other.access &&
+          Type.equals(field.type, other.type) &&
+          field.offset === other.offset &&
+          field.size === other.size &&
+          field.alignment === other.alignment &&
+          field.padding === other.padding &&
+          field.representation === other.representation &&
+          field.effectIdentity === other.effectIdentity &&
+          ((field.callableIdentity === undefined && other.callableIdentity === undefined) ||
+            (field.callableIdentity !== undefined &&
+              other.callableIdentity !== undefined &&
+              Type.equalsGenericArgument(field.callableIdentity, other.callableIdentity)))
+        )
+      })
+    )
+  }
   if (left._tag === 'Repeated') {
     return (
       right._tag === 'Repeated' &&
@@ -2641,6 +2841,83 @@ const verifyEntry = (
         ])
   }
   if (Type.isRepresented(candidate.type)) {
+    if (candidate.representation._tag === 'StoredEffectEnvironment') {
+      const violations: Array<Violation> = []
+      let cursor = 0
+      let alignment = 1
+      for (const [ordinal, field] of candidate.representation.fields.entries()) {
+        const slot = candidate.representation.realization.environment.at(ordinal)
+        const borrowed = field.representation === 'Borrow'
+        const executable =
+          field.effectIdentity !== undefined || field.callableIdentity !== undefined
+        const fieldLayout =
+          borrowed || executable
+            ? undefined
+            : Type.isBuiltin(field.type)
+              ? scalarEntry(target, field.type)
+              : available.get(Type.key(field.type))
+        const expectedSize = borrowed
+          ? target.pointerSize
+          : executable
+            ? field.size
+            : fieldLayout?.size
+        const expectedAlignment = borrowed
+          ? target.pointerAlignment
+          : executable
+            ? field.alignment
+            : fieldLayout?.alignment
+        const offset =
+          expectedAlignment === undefined ? undefined : alignUp(cursor, expectedAlignment)
+        if (
+          slot === undefined ||
+          slot.ordinal !== field.capture ||
+          slot.source !== field.source ||
+          slot.sourceOrdinal !== field.ordinal ||
+          slot.access !== field.access ||
+          !Type.equals(slot.type, field.type) ||
+          slot.effectIdentity !== field.effectIdentity ||
+          (slot.callableIdentity === undefined && field.callableIdentity !== undefined) ||
+          (slot.callableIdentity !== undefined &&
+            (field.callableIdentity === undefined ||
+              !Type.equalsGenericArgument(slot.callableIdentity, field.callableIdentity))) ||
+          expectedSize === undefined ||
+          expectedAlignment === undefined ||
+          offset === undefined ||
+          expectedAlignment < 1 ||
+          expectedSize < 0 ||
+          field.offset !== offset ||
+          field.size !== expectedSize ||
+          field.alignment !== expectedAlignment ||
+          field.padding !== offset - cursor
+        ) {
+          violations.push(
+            invalid(
+              'InvalidAggregate',
+              candidate.type,
+              `Effect capture ${field.capture} has non-canonical physical facts`,
+            ),
+          )
+          continue
+        }
+        cursor = offset + expectedSize
+        alignment = Math.max(alignment, expectedAlignment)
+      }
+      const size = alignUp(cursor, alignment)
+      if (
+        candidate.size !== size ||
+        candidate.alignment !== alignment ||
+        candidate.representation.tailPadding !== size - cursor
+      ) {
+        violations.push(
+          invalid(
+            'InvalidAggregate',
+            candidate.type,
+            `${Type.encode(candidate.type)} has non-canonical stored Effect environment size or alignment`,
+          ),
+        )
+      }
+      return Object.freeze(violations)
+    }
     if (candidate.representation._tag !== 'CallableEnvironment') {
       return Object.freeze([
         invalid(
@@ -2841,21 +3118,23 @@ export const selectorEquals = (left: Selector, right: Selector): boolean =>
     ? right._tag === 'ElementSelector' && left.index === right.index
     : left._tag === 'CallableCaptureSelector'
       ? right._tag === 'CallableCaptureSelector' && left.ordinal === right.ordinal
-      : left._tag === 'UnionTagSelector'
-        ? right._tag === 'UnionTagSelector'
-        : left._tag === 'UnionPayloadSelector'
-          ? right._tag === 'UnionPayloadSelector' && left.slot === right.slot
-          : left._tag === 'SliceAddressSelector'
-            ? right._tag === 'SliceAddressSelector'
-            : left._tag === 'SliceLengthSelector'
-              ? right._tag === 'SliceLengthSelector'
-              : left._tag === 'StringStorageSelector'
-                ? right._tag === 'StringStorageSelector'
-                : left._tag === 'StringByteLengthSelector'
-                  ? right._tag === 'StringByteLengthSelector'
-                  : left._tag === 'ReferenceAddressSelector'
-                    ? right._tag === 'ReferenceAddressSelector'
-                    : right._tag === 'FieldId' && fieldIdEquals(left, right)
+      : left._tag === 'EffectCaptureSelector'
+        ? right._tag === 'EffectCaptureSelector' && left.ordinal === right.ordinal
+        : left._tag === 'UnionTagSelector'
+          ? right._tag === 'UnionTagSelector'
+          : left._tag === 'UnionPayloadSelector'
+            ? right._tag === 'UnionPayloadSelector' && left.slot === right.slot
+            : left._tag === 'SliceAddressSelector'
+              ? right._tag === 'SliceAddressSelector'
+              : left._tag === 'SliceLengthSelector'
+                ? right._tag === 'SliceLengthSelector'
+                : left._tag === 'StringStorageSelector'
+                  ? right._tag === 'StringStorageSelector'
+                  : left._tag === 'StringByteLengthSelector'
+                    ? right._tag === 'StringByteLengthSelector'
+                    : left._tag === 'ReferenceAddressSelector'
+                      ? right._tag === 'ReferenceAddressSelector'
+                      : right._tag === 'FieldId' && fieldIdEquals(left, right)
 
 /** Resolves one compiler-planned scalar lane to its byte offset within a logical value. */
 export const laneOffset = (
@@ -2887,6 +3166,16 @@ export const laneOffset = (
       if (candidate.representation._tag !== 'CallableEnvironment') return undefined
       const field = candidate.representation.fields.find(
         (capture) => capture.ordinal === selector.ordinal,
+      )
+      if (field === undefined) return undefined
+      offset += field.offset
+      current = field.type
+      continue
+    }
+    if (selector._tag === 'EffectCaptureSelector') {
+      if (candidate.representation._tag !== 'StoredEffectEnvironment') return undefined
+      const field = candidate.representation.fields.find(
+        (capture) => capture.capture === selector.ordinal,
       )
       if (field === undefined) return undefined
       offset += field.offset
@@ -3125,17 +3414,19 @@ const representationText = (representation: Representation): string =>
                   ? `${representation.realization.target.module}.${representation.realization.target.name}`
                   : `${representation.realization.target.actor}.${representation.realization.target.operation}`
               } environment=${representation.realization.environment === undefined ? 'none' : Type.callableEnvironmentKey(representation.realization.environment)} tail-padding=${representation.tailPadding}`
-            : representation._tag === 'Repeated'
-              ? `repeated element=${Type.encode(representation.element)} length=${representation.length} stride=${representation.stride}`
-              : representation._tag === 'Slice'
-                ? `slice element=${Type.encode(representation.element)} address=i${representation.address.bits}@${representation.address.offset}/${representation.address.size}/${representation.address.alignment} length=usize@${representation.length.offset}/${representation.length.size} address-padding=${representation.addressPadding} tail-padding=${representation.tailPadding} stride=${representation.stride}`
-                : representation._tag === 'String'
-                  ? `string storage=${representation.storage.provenance}:i${representation.storage.bits}@${representation.storage.offset}/${representation.storage.size}/${representation.storage.alignment} byte-length=usize@${representation.byteLength.offset}/${representation.byteLength.size} storage-padding=${representation.storagePadding} tail-padding=${representation.tailPadding}`
-                  : representation._tag === 'Reference'
-                    ? `reference target=${Type.encode(representation.target)} address=i${representation.address.bits}@${representation.address.offset}/${representation.address.size}/${representation.address.alignment}`
-                    : representation._tag === 'Union'
-                      ? `union tag=i${representation.tag.bits} payload-offset=${representation.payloadOffset} payload-size=${representation.payloadSize} payload-align=${representation.payloadAlignment} tag-padding=${representation.tagPadding} tail-padding=${representation.tailPadding}`
-                      : `aggregate tail-padding=${representation.tailPadding}`
+            : representation._tag === 'StoredEffectEnvironment'
+              ? `stored-effect-environment runner=${representation.realization.runner.module}.${representation.realization.runner.name} identity=${representation.realization.runnerIdentity} access=${representation.realization.access.toLowerCase()} suspendable=${representation.realization.suspendable ? 'yes' : 'no'} tail-padding=${representation.tailPadding}`
+              : representation._tag === 'Repeated'
+                ? `repeated element=${Type.encode(representation.element)} length=${representation.length} stride=${representation.stride}`
+                : representation._tag === 'Slice'
+                  ? `slice element=${Type.encode(representation.element)} address=i${representation.address.bits}@${representation.address.offset}/${representation.address.size}/${representation.address.alignment} length=usize@${representation.length.offset}/${representation.length.size} address-padding=${representation.addressPadding} tail-padding=${representation.tailPadding} stride=${representation.stride}`
+                  : representation._tag === 'String'
+                    ? `string storage=${representation.storage.provenance}:i${representation.storage.bits}@${representation.storage.offset}/${representation.storage.size}/${representation.storage.alignment} byte-length=usize@${representation.byteLength.offset}/${representation.byteLength.size} storage-padding=${representation.storagePadding} tail-padding=${representation.tailPadding}`
+                    : representation._tag === 'Reference'
+                      ? `reference target=${Type.encode(representation.target)} address=i${representation.address.bits}@${representation.address.offset}/${representation.address.size}/${representation.address.alignment}`
+                      : representation._tag === 'Union'
+                        ? `union tag=i${representation.tag.bits} payload-offset=${representation.payloadOffset} payload-size=${representation.payloadSize} payload-align=${representation.payloadAlignment} tag-padding=${representation.tagPadding} tail-padding=${representation.tailPadding}`
+                        : `aggregate tail-padding=${representation.tailPadding}`
 
 const entryLines = (candidate: Entry): ReadonlyArray<string> => [
   `layout ${Type.encode(candidate.type)} size=${candidate.size} align=${candidate.alignment} repr=${representationText(candidate.representation)}`,
@@ -3149,30 +3440,35 @@ const entryLines = (candidate: Entry): ReadonlyArray<string> => [
           (field) =>
             `  capture ${field.ordinal}->p${field.parameterOrdinal}: ${Type.encode(field.type)} access=${field.access.toLowerCase()} representation=${field.representation.toLowerCase()} offset=${field.offset} size=${field.size} align=${field.alignment} padding=${field.padding}`,
         )
-      : candidate.representation._tag === 'Repeated'
-        ? [
-            `  elements ${Type.encode(candidate.representation.element)} count=${candidate.representation.length} stride=${candidate.representation.stride}`,
-          ]
-        : candidate.representation._tag === 'Slice'
+      : candidate.representation._tag === 'StoredEffectEnvironment'
+        ? candidate.representation.fields.map(
+            (field) =>
+              `  effect-capture ${field.capture} ${field.source.toLowerCase()}${field.ordinal}: ${Type.encode(field.type)} access=${field.access.toLowerCase()} representation=${field.representation.toLowerCase()} offset=${field.offset} size=${field.size} align=${field.alignment} padding=${field.padding}`,
+          )
+        : candidate.representation._tag === 'Repeated'
           ? [
-              `  address Address<${Type.encode(candidate.representation.element)}> bits=${candidate.representation.address.bits} offset=${candidate.representation.address.offset} size=${candidate.representation.address.size} align=${candidate.representation.address.alignment}`,
-              `  length usize offset=${candidate.representation.length.offset} size=${candidate.representation.length.size} stride=${candidate.representation.stride}`,
+              `  elements ${Type.encode(candidate.representation.element)} count=${candidate.representation.length} stride=${candidate.representation.stride}`,
             ]
-          : candidate.representation._tag === 'String'
+          : candidate.representation._tag === 'Slice'
             ? [
-                `  storage StringUtf8 bits=${candidate.representation.storage.bits} offset=${candidate.representation.storage.offset} size=${candidate.representation.storage.size} align=${candidate.representation.storage.alignment}`,
-                `  byte-length usize offset=${candidate.representation.byteLength.offset} size=${candidate.representation.byteLength.size}`,
+                `  address Address<${Type.encode(candidate.representation.element)}> bits=${candidate.representation.address.bits} offset=${candidate.representation.address.offset} size=${candidate.representation.address.size} align=${candidate.representation.address.alignment}`,
+                `  length usize offset=${candidate.representation.length.offset} size=${candidate.representation.length.size} stride=${candidate.representation.stride}`,
               ]
-            : candidate.representation._tag === 'Reference'
+            : candidate.representation._tag === 'String'
               ? [
-                  `  address Address<${Type.encode(candidate.representation.target)}> bits=${candidate.representation.address.bits} offset=0 size=${candidate.representation.address.size} align=${candidate.representation.address.alignment}`,
+                  `  storage StringUtf8 bits=${candidate.representation.storage.bits} offset=${candidate.representation.storage.offset} size=${candidate.representation.storage.size} align=${candidate.representation.storage.alignment}`,
+                  `  byte-length usize offset=${candidate.representation.byteLength.offset} size=${candidate.representation.byteLength.size}`,
                 ]
-              : candidate.representation._tag === 'Union'
-                ? candidate.representation.members.map(
-                    (member) =>
-                      `  member ${member.ordinal} ${Type.encode(member.type)} size=${member.size} align=${member.alignment}`,
-                  )
-                : []),
+              : candidate.representation._tag === 'Reference'
+                ? [
+                    `  address Address<${Type.encode(candidate.representation.target)}> bits=${candidate.representation.address.bits} offset=0 size=${candidate.representation.address.size} align=${candidate.representation.address.alignment}`,
+                  ]
+                : candidate.representation._tag === 'Union'
+                  ? candidate.representation.members.map(
+                      (member) =>
+                        `  member ${member.ordinal} ${Type.encode(member.type)} size=${member.size} align=${member.alignment}`,
+                    )
+                  : []),
 ]
 
 /** Deterministic textual encoding of a complete runtime layout plan. */
@@ -3209,21 +3505,23 @@ export const encode = (self: Plan): string =>
                           ? `[${selector.index}]`
                           : selector._tag === 'CallableCaptureSelector'
                             ? `capture[${selector.ordinal}]`
-                            : selector._tag === 'UnionTagSelector'
-                              ? 'tag'
-                              : selector._tag === 'UnionPayloadSelector'
-                                ? `payload[${selector.slot}]`
-                                : selector._tag === 'SliceAddressSelector'
-                                  ? 'address'
-                                  : selector._tag === 'SliceLengthSelector'
-                                    ? 'length'
-                                    : selector._tag === 'StringStorageSelector'
-                                      ? 'storage'
-                                      : selector._tag === 'StringByteLengthSelector'
-                                        ? 'byte-length'
-                                        : selector._tag === 'ReferenceAddressSelector'
-                                          ? 'address'
-                                          : `${selector.struct.sourceId}#${selector.struct.ordinal}.${selector.ordinal}`,
+                            : selector._tag === 'EffectCaptureSelector'
+                              ? `effect-capture[${selector.ordinal}]`
+                              : selector._tag === 'UnionTagSelector'
+                                ? 'tag'
+                                : selector._tag === 'UnionPayloadSelector'
+                                  ? `payload[${selector.slot}]`
+                                  : selector._tag === 'SliceAddressSelector'
+                                    ? 'address'
+                                    : selector._tag === 'SliceLengthSelector'
+                                      ? 'length'
+                                      : selector._tag === 'StringStorageSelector'
+                                        ? 'storage'
+                                        : selector._tag === 'StringByteLengthSelector'
+                                          ? 'byte-length'
+                                          : selector._tag === 'ReferenceAddressSelector'
+                                            ? 'address'
+                                            : `${selector.struct.sourceId}#${selector.struct.ordinal}.${selector.ordinal}`,
                       )
                       .join('.')}]`,
                 )

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -349,7 +349,7 @@ export type CallingShapeNode =
     }
   | {
       readonly _tag: 'CallableEnvironmentShape'
-      readonly type: Type.Represented
+      readonly type: DeclarationIndex.SemanticType
       readonly fields: ReadonlyArray<{
         readonly capture: number
         readonly shape: CallingShapeNode
@@ -358,7 +358,7 @@ export type CallingShapeNode =
     }
   | {
       readonly _tag: 'EffectEnvironmentShape'
-      readonly type: Type.Represented
+      readonly type: DeclarationIndex.SemanticType
       readonly fields: ReadonlyArray<{
         readonly capture: number
         readonly shape: CallingShapeNode
@@ -1956,6 +1956,8 @@ export const plan = (self: Catalog, discovery: Instances.Discovery): Plan => {
       self.target,
       orderedEntries,
       [...specializedShapeTypes.values()].sort(Type.compare),
+      effectPlans,
+      callablePlans,
     ),
     staticData,
     literalVerdicts: literals.verdicts,
@@ -1982,11 +1984,108 @@ export const make = (target: Target.Target, types: ReadonlyArray<Type.Builtin>):
   })
 }
 
-const shapeNode = (
-  target: Target.Target,
+interface ShapeContext {
+  readonly target: Target.Target
+  readonly entries: ReadonlyMap<string, Entry>
+  readonly effectEnvironments: ReadonlyArray<EffectEnvironment>
+  readonly callableEnvironments: ReadonlyArray<CallableEnvironment>
+  readonly active: ReadonlySet<string>
+}
+
+const withActiveShape = (context: ShapeContext, identity: string): ShapeContext => {
+  if (context.active.has(identity))
+    throw new RangeError(`recursive executable environment ${identity} has no calling shape`)
+  return Object.freeze({ ...context, active: new Set([...context.active, identity]) })
+}
+
+const borrowedShape = (
+  context: ShapeContext,
   type: DeclarationIndex.SemanticType,
-  entries: ReadonlyMap<string, Entry>,
+): Extract<CallingShapeNode, { readonly _tag: 'AddressShape' }> =>
+  Object.freeze({
+    _tag: 'AddressShape',
+    type,
+    address: Object.freeze({
+      type: Object.freeze({
+        _tag: 'Address',
+        element: type,
+        bits: context.target.pointerSize === 4 ? 32 : 64,
+      }),
+      lane: 0,
+    }),
+    laneCount: 1,
+  })
+
+const executableEnvironmentFieldShape = (
+  context: ShapeContext,
+  field: EffectEnvironmentField,
 ): CallingShapeNode => {
+  if (field.representation === 'Borrow') return borrowedShape(context, field.type)
+  if (field.callableIdentity !== undefined) {
+    const identity = field.callableIdentity
+    const environment = context.callableEnvironments.find(
+      (
+        candidate,
+      ): candidate is Extract<CallableEnvironment, { readonly _tag: 'CallableEnvironment' }> =>
+        candidate._tag === 'CallableEnvironment' &&
+        CallableFieldRealization.matchesIdentity(identity, candidate.callable),
+    )
+    if (environment === undefined)
+      throw new RangeError(
+        `callable environment ${Type.genericArgumentKey(identity)} is unavailable to calling-shape planning`,
+      )
+    const nested = withActiveShape(context, `callable:${Type.genericArgumentKey(identity)}`)
+    const fields = environment.fields.map((capture) =>
+      Object.freeze({
+        capture: capture.ordinal,
+        shape:
+          capture.representation === 'Borrow'
+            ? borrowedShape(nested, capture.type)
+            : shapeNode(capture.type, nested),
+      }),
+    )
+    return Object.freeze({
+      _tag: 'CallableEnvironmentShape',
+      type: field.type,
+      fields: Object.freeze(fields),
+      laneCount: fields.reduce((total, capture) => total + capture.shape.laneCount, 0),
+    })
+  }
+  if (field.effectIdentity !== undefined) {
+    const environment = context.effectEnvironments.find(
+      (
+        candidate,
+      ): candidate is Extract<EffectEnvironment, { readonly _tag: 'EffectEnvironment' }> =>
+        candidate._tag === 'EffectEnvironment' &&
+        (Instances.effectIdentity(candidate.instance, candidate.site) === field.effectIdentity ||
+          candidate.successEffectIdentity === field.effectIdentity),
+    )
+    if (environment === undefined)
+      throw new RangeError(
+        `Effect environment ${field.effectIdentity} is unavailable to calling-shape planning`,
+      )
+    const nested = withActiveShape(context, `effect:${field.effectIdentity}`)
+    const fields = environment.fields.map((capture) =>
+      Object.freeze({
+        capture: capture.ordinal,
+        shape: executableEnvironmentFieldShape(nested, capture),
+      }),
+    )
+    return Object.freeze({
+      _tag: 'EffectEnvironmentShape',
+      type: field.type,
+      fields: Object.freeze(fields),
+      laneCount: fields.reduce((total, capture) => total + capture.shape.laneCount, 0),
+    })
+  }
+  return shapeNode(field.type, context)
+}
+
+const shapeNode = (
+  type: DeclarationIndex.SemanticType,
+  context: ShapeContext,
+): CallingShapeNode => {
+  const { target, entries } = context
   if (Type.isBuiltin(type)) {
     return Object.freeze({ _tag: 'ScalarShape', type, laneCount: 1 })
   }
@@ -2061,31 +2160,23 @@ const shapeNode = (
         `represented executable ${Type.encode(type)} is unavailable to calling-shape planning`,
       )
     }
-    const environmentFields =
+    const fields =
       representation._tag === 'CallableEnvironment'
-        ? representation.fields.map((field) => Object.freeze({ capture: field.ordinal, field }))
-        : representation.fields.map((field) => Object.freeze({ capture: field.capture, field }))
-    const fields = environmentFields.map(({ capture, field }) =>
-      Object.freeze({
-        capture,
-        shape:
-          field.representation === 'Borrow'
-            ? Object.freeze({
-                _tag: 'AddressShape' as const,
-                type: field.type,
-                address: Object.freeze({
-                  type: Object.freeze({
-                    _tag: 'Address' as const,
-                    element: field.type,
-                    bits: target.pointerSize === 4 ? (32 as const) : (64 as const),
-                  }),
-                  lane: 0 as const,
-                }),
-                laneCount: 1 as const,
-              })
-            : shapeNode(target, field.type, entries),
-      }),
-    )
+        ? representation.fields.map((field) =>
+            Object.freeze({
+              capture: field.ordinal,
+              shape:
+                field.representation === 'Borrow'
+                  ? borrowedShape(context, field.type)
+                  : shapeNode(field.type, context),
+            }),
+          )
+        : representation.fields.map((field) =>
+            Object.freeze({
+              capture: field.capture,
+              shape: executableEnvironmentFieldShape(context, field),
+            }),
+          )
     return Object.freeze({
       _tag:
         representation._tag === 'CallableEnvironment'
@@ -2098,7 +2189,7 @@ const shapeNode = (
   }
   const candidate = entries.get(Type.key(type))
   if (Type.isFixedArray(type)) {
-    const element = shapeNode(target, type.element, entries)
+    const element = shapeNode(type.element, context)
     const laneCount = element.laneCount * type.length
     if (!Number.isSafeInteger(laneCount)) {
       throw new RangeError(`Calling shape lane count overflows for ${Type.encode(type)}`)
@@ -2114,7 +2205,7 @@ const shapeNode = (
   if (Type.isUnion(type)) {
     const members = Object.freeze(
       type.members.map((member, ordinal) => {
-        const shape = shapeNode(target, member, entries)
+        const shape = shapeNode(member, context)
         return Object.freeze({
           member,
           ordinal,
@@ -2160,12 +2251,12 @@ const shapeNode = (
     })
   }
   if (Type.isEffect(type)) {
-    const success = shapeNode(target, type.success, entries)
+    const success = shapeNode(type.success, context)
     const failures = type.failures.map((failure, index) =>
       Object.freeze({
         type: failure,
         tag: index + 1,
-        shape: shapeNode(target, failure, entries),
+        shape: shapeNode(failure, context),
       }),
     )
     const variants = [success, ...failures.map((failure) => failure.shape)]
@@ -2207,7 +2298,7 @@ const shapeNode = (
   const fields =
     candidate?.representation._tag === 'Aggregate'
       ? candidate.representation.fields.map((field) =>
-          Object.freeze({ field: field.id, shape: shapeNode(target, field.type, entries) }),
+          Object.freeze({ field: field.id, shape: shapeNode(field.type, context) }),
         )
       : []
   return Object.freeze({
@@ -2334,8 +2425,19 @@ const shapeOf = (
   target: Target.Target,
   type: DeclarationIndex.SemanticType,
   entries: ReadonlyMap<string, Entry>,
+  effectEnvironments: ReadonlyArray<EffectEnvironment>,
+  callableEnvironments: ReadonlyArray<CallableEnvironment>,
 ): CallingShape => {
-  const tree = shapeNode(target, type, entries)
+  const tree = shapeNode(
+    type,
+    Object.freeze({
+      target,
+      entries,
+      effectEnvironments,
+      callableEnvironments,
+      active: new Set<string>(),
+    }),
+  )
   let materialized: ReadonlyArray<CallingLane> | undefined
   return Object.freeze({
     _tag: 'CallingShape' as const,
@@ -2353,9 +2455,13 @@ const callingShapes = (
   target: Target.Target,
   entries: ReadonlyArray<Entry>,
   types: ReadonlyArray<DeclarationIndex.SemanticType> = entries.map((entry) => entry.type),
+  effectEnvironments: ReadonlyArray<EffectEnvironment> = Object.freeze([]),
+  callableEnvironments: ReadonlyArray<CallableEnvironment> = Object.freeze([]),
 ): ReadonlyArray<CallingShape> => {
   const byType = new Map(entries.map((candidate) => [Type.key(candidate.type), candidate]))
-  return Object.freeze(types.map((type) => shapeOf(target, type, byType)))
+  return Object.freeze(
+    types.map((type) => shapeOf(target, type, byType, effectEnvironments, callableEnvironments)),
+  )
 }
 
 /** Looks up one canonical runtime-plan entry. */
@@ -2418,7 +2524,9 @@ export const effectEnvironmentLanes = (
         const captured = self.effectEnvironments.find(
           (candidate) =>
             candidate._tag === 'EffectEnvironment' &&
-            Instances.effectIdentity(candidate.instance, candidate.site) === field.effectIdentity,
+            (Instances.effectIdentity(candidate.instance, candidate.site) ===
+              field.effectIdentity ||
+              candidate.successEffectIdentity === field.effectIdentity),
         )
         return captured?._tag === 'EffectEnvironment'
           ? effectEnvironmentLanes(self, captured)
@@ -3242,7 +3350,13 @@ const callingScalarEquals = (left: CallingScalar, right: CallingScalar): boolean
       left.bits === right.bits
 
 const verifyCallingShapes = (self: Plan): ReadonlyArray<Violation> => {
-  const expected = callingShapes(self.target, self.entries)
+  const expected = callingShapes(
+    self.target,
+    self.entries,
+    self.entries.map((entry) => entry.type),
+    self.effectEnvironments,
+    self.callableEnvironments,
+  )
   const violations: Array<Violation> = []
   for (const entry of self.entries) {
     const actual = callingShape(self, entry.type)

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -3,6 +3,7 @@ import type * as DeclarationIndex from './DeclarationIndex.js'
 import * as Diagnostic from './Diagnostic.js'
 import * as Hir from './Hir.js'
 import * as Instances from './Instances.js'
+import * as Ownership from './Ownership.js'
 import * as RepresentationField from './RepresentationField.js'
 import * as Scalar from './Scalar.js'
 import type * as SourceSpan from './SourceSpan.js'
@@ -33,6 +34,11 @@ export type Representation =
       readonly _tag: 'Aggregate'
       readonly fields: ReadonlyArray<Field>
       readonly tailPadding: number
+      /** Static cleanup hook required before structural field cleanup; contributes no ABI bytes. */
+      readonly cleanupHook?: {
+        readonly hook: DeclarationIndex.CanonicalId
+        readonly typeArguments: ReadonlyArray<Type.GenericArgument>
+      }
     }
   | {
       readonly _tag: 'CallableEnvironment'
@@ -1088,6 +1094,7 @@ export const catalog = (
       return failure
     }
     const size = alignUp(cursor, aggregateAlignment)
+    const cleanup = Ownership.cleanupPlan(index, type)
     const entry: Entry = Object.freeze({
       _tag: 'LayoutEntry',
       type,
@@ -1097,6 +1104,14 @@ export const catalog = (
         _tag: 'Aggregate',
         fields: Object.freeze(fields),
         tailPadding: size - cursor,
+        ...(cleanup._tag === 'HookCleanup'
+          ? {
+              cleanupHook: Object.freeze({
+                hook: cleanup.hook,
+                typeArguments: cleanup.typeArguments,
+              }),
+            }
+          : {}),
       }),
     })
     completed.set(key, entry)

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -172,6 +172,7 @@ class FunctionLowering {
     const specialized = Type.substitute(type, this.substitution)
     return (
       storedCallableValueType(this.layout, specialized) ??
+      storedEffectValueType(this.layout, specialized) ??
       representedValueType(this.layout, this.opaqueRealizations, type, this.substitution) ??
       mirType(specialized)
     )
@@ -606,6 +607,39 @@ const storedCallableValueType = (
   })
 }
 
+const storedEffectValueType = (
+  layout: Layout.Plan,
+  type: Type.Type,
+): Extract<Mir.Type, { readonly _tag: 'EffectValue' }> | undefined => {
+  if (!Type.isRepresented(type) || !Type.isEffect(type.contract)) return undefined
+  const entry = Layout.entry(layout, type)
+  const representation = entry?.representation
+  if (entry === undefined || representation?._tag !== 'StoredEffectEnvironment') return undefined
+  const realization = representation.realization
+  const environment: Extract<Layout.EffectEnvironment, { readonly _tag: 'EffectEnvironment' }> =
+    Object.freeze({
+      _tag: 'EffectEnvironment',
+      instance: realization.runnerInstance,
+      site: realization.site,
+      effect: realization.contract,
+      fields: representation.fields,
+      size: entry.size,
+      alignment: entry.alignment,
+      tailPadding: representation.tailPadding,
+    })
+  return Object.freeze({
+    _tag: 'EffectValue',
+    type: realization.contract,
+    site: realization.site,
+    environment,
+    storage: Object.freeze({
+      _tag: 'StoredEffectField',
+      type,
+      realization,
+    }),
+  })
+}
+
 const requirementsFor = (
   available: ReadonlyArray<ProvidedRequirement>,
   effect: Type.Effect,
@@ -784,8 +818,11 @@ const lowerRunEffectValue = (
       effect,
       runner:
         providedRunner ??
+        effectType.storage?.realization.runner ??
         Hir.effectRunnerId(effectType.environment.instance.declaration, effectType.site),
-      runnerTypeArguments: effectType.environment.instance.typeArguments,
+      runnerTypeArguments:
+        effectType.storage?.realization.runnerArguments ??
+        effectType.environment.instance.typeArguments,
       arguments: runtimeRequirementArguments(provided),
       outcomeType,
       ...(propagationType === undefined ? {} : { propagationType }),
@@ -889,7 +926,10 @@ const lowerPlace = (
       root: place.root,
       selectors: place.selectors,
       type,
-      ...(type._tag === 'CallableValue' && type.storage !== undefined && type.type.mode === 'Take'
+      ...((type._tag === 'CallableValue' &&
+        type.storage !== undefined &&
+        type.type.mode === 'Take') ||
+      (type._tag === 'EffectValue' && type.storage !== undefined && type.type.access === 'Take')
         ? { consume: true as const }
         : {}),
       provenance: Object.freeze({ span: expression.span, generated: false }),
@@ -1893,7 +1933,11 @@ function lowerExpressionInner(
         if (provided === undefined) return undefined
         const runner =
           provided.length === 0
-            ? Hir.effectRunnerId(protectedType.environment.instance.declaration, protectedType.site)
+            ? (protectedType.storage?.realization.runner ??
+              Hir.effectRunnerId(
+                protectedType.environment.instance.declaration,
+                protectedType.site,
+              ))
             : ensureProvidedRunner(fn, protectedType, provided)
         if (runner === undefined) return undefined
         const arguments_ = runtimeRequirementArguments(provided)
@@ -1963,7 +2007,9 @@ function lowerExpressionInner(
             outcome,
             effect: loweredProtected.result,
             runner,
-            runnerTypeArguments: protectedType.environment.instance.typeArguments,
+            runnerTypeArguments:
+              protectedType.storage?.realization.runnerArguments ??
+              protectedType.environment.instance.typeArguments,
             arguments: arguments_,
             outcomeType,
             resultType,
@@ -2055,11 +2101,14 @@ function lowerExpressionInner(
             effect: loweredSubject.result,
             runner:
               providedRunner ??
+              effectValueType.storage?.realization.runner ??
               Hir.effectRunnerId(
                 effectValueType.environment.instance.declaration,
                 effectValueType.site,
               ),
-            runnerTypeArguments: effectValueType.environment.instance.typeArguments,
+            runnerTypeArguments:
+              effectValueType.storage?.realization.runnerArguments ??
+              effectValueType.environment.instance.typeArguments,
             arguments: runtimeRequirementArguments(provided),
             outcomeType,
             ...(propagationType === undefined ? {} : { propagationType }),
@@ -2634,7 +2683,8 @@ function lowerExpressionInner(
         const stored =
           declared === undefined
             ? undefined
-            : storedCallableValueType(fn.layout, declared.type)?.storage
+            : (storedCallableValueType(fn.layout, declared.type)?.storage ??
+              storedEffectValueType(fn.layout, declared.type)?.storage)
         return value === undefined
           ? []
           : [
@@ -3602,8 +3652,74 @@ const concreteCleanup = (
     const representation = Layout.entry(fn.layout, specialized)?.representation
     if (representation?._tag === 'CallableEnvironment')
       return Ownership.realizedCallableCleanup(fn.index, representation.realization)
+    if (representation?._tag === 'StoredEffectEnvironment') {
+      const effectValue = storedEffectValueType(fn.layout, specialized)
+      if (effectValue !== undefined) return effectLocalCleanup(fn, effectValue, new Set())
+    }
   }
   return Ownership.cleanupPlan(fn.index, specialized, seen)
+}
+
+function effectLocalCleanup(
+  fn: FunctionLowering,
+  effectValue: Extract<Mir.Type, { readonly _tag: 'EffectValue' }>,
+  seen: ReadonlySet<string>,
+): Ownership.CleanupPlan {
+  const identity =
+    effectValue.storage?.realization.runnerIdentity ??
+    Instances.effectIdentity(effectValue.environment.instance, effectValue.site)
+  if (seen.has(identity)) return Object.freeze({ _tag: 'NoCleanup', type: effectValue.type })
+  const next = new Set(seen).add(identity)
+  let laneOffset = 0
+  const slots = effectValue.environment.fields
+    .flatMap((field, ordinal) => {
+      const nested =
+        field.effectIdentity === undefined
+          ? undefined
+          : effectValueByIdentity(fn.layout, field.effectIdentity)
+      const callable =
+        field.callableIdentity === undefined || !Type.isCallable(field.type)
+          ? undefined
+          : callableValueByIdentity(fn.layout, field.callableIdentity, field.type)
+      const laneCount =
+        field.representation === 'Borrow'
+          ? 1
+          : callable === undefined
+            ? nested === undefined
+              ? (Layout.callingShape(fn.layout, field.type)?.laneCount ?? 0)
+              : Layout.effectEnvironmentLanes(fn.layout, nested.environment).length
+            : callable.environment === undefined
+              ? 0
+              : Layout.callableEnvironmentLanes(fn.layout, callable.environment).length
+      const currentOffset = laneOffset
+      laneOffset += laneCount
+      if (field.representation === 'Borrow') return []
+      const fieldCleanup =
+        callable === undefined
+          ? nested === undefined
+            ? concreteCleanup(fn, field.type)
+            : effectLocalCleanup(fn, nested, next)
+          : callableLocalCleanup(fn, callable)
+      return fieldCleanup._tag === 'NoCleanup'
+        ? []
+        : [
+            Object.freeze({
+              ordinal: effectValue.storage?.realization.environment.at(ordinal)?.ordinal ?? ordinal,
+              laneOffset: currentOffset,
+              laneCount,
+              cleanup: fieldCleanup,
+            }),
+          ]
+    })
+    .reverse()
+  return slots.length === 0
+    ? Object.freeze({ _tag: 'NoCleanup', type: effectValue.type })
+    : Object.freeze({
+        _tag: 'EffectCleanup',
+        type: effectValue.type,
+        site: effectValue.site,
+        slots: Object.freeze(slots),
+      })
 }
 
 const specializedCleanup = (
@@ -3619,65 +3735,7 @@ const cleanupForLocal = (
 ): Ownership.CleanupPlan => {
   const specialized = specializedCleanup(fn, cleanup)
   if (localType._tag === 'EffectValue') {
-    const cleanupForEnvironment = (
-      effectValue: Extract<Mir.Type, { readonly _tag: 'EffectValue' }>,
-      seen: ReadonlySet<string>,
-    ): Ownership.CleanupPlan => {
-      const identity = Instances.effectIdentity(effectValue.environment.instance, effectValue.site)
-      if (seen.has(identity)) return Object.freeze({ _tag: 'NoCleanup', type: effectValue.type })
-      const next = new Set(seen).add(identity)
-      let laneOffset = 0
-      const slots = effectValue.environment.fields
-        .flatMap((field, ordinal) => {
-          const nested =
-            field.effectIdentity === undefined
-              ? undefined
-              : effectValueByIdentity(fn.layout, field.effectIdentity)
-          const callable =
-            field.callableIdentity === undefined || !Type.isCallable(field.type)
-              ? undefined
-              : callableValueByIdentity(fn.layout, field.callableIdentity, field.type)
-          const laneCount =
-            field.representation === 'Borrow'
-              ? 1
-              : callable === undefined
-                ? nested === undefined
-                  ? (Layout.callingShape(fn.layout, field.type)?.laneCount ?? 0)
-                  : Layout.effectEnvironmentLanes(fn.layout, nested.environment).length
-                : callable.environment === undefined
-                  ? 0
-                  : Layout.callableEnvironmentLanes(fn.layout, callable.environment).length
-          const currentOffset = laneOffset
-          laneOffset += laneCount
-          if (field.representation === 'Borrow') return []
-          const fieldCleanup =
-            callable === undefined
-              ? nested === undefined
-                ? concreteCleanup(fn, field.type)
-                : cleanupForEnvironment(nested, next)
-              : callableLocalCleanup(fn, callable)
-          return fieldCleanup._tag === 'NoCleanup'
-            ? []
-            : [
-                Object.freeze({
-                  ordinal,
-                  laneOffset: currentOffset,
-                  laneCount,
-                  cleanup: fieldCleanup,
-                }),
-              ]
-        })
-        .reverse()
-      return slots.length === 0
-        ? Object.freeze({ _tag: 'NoCleanup', type: effectValue.type })
-        : Object.freeze({
-            _tag: 'EffectCleanup',
-            type: effectValue.type,
-            site: effectValue.site,
-            slots: Object.freeze(slots),
-          })
-    }
-    return cleanupForEnvironment(localType, new Set())
+    return effectLocalCleanup(fn, localType, new Set())
   }
   if (localType._tag !== 'CallableValue') {
     return specialized
@@ -4716,6 +4774,8 @@ const lowerInstance = (
             return callable === undefined ? [] : [callable]
           }
           const lowered =
+            storedCallableValueType(layout, specialized) ??
+            storedEffectValueType(layout, specialized) ??
             representedValueType(layout, opaqueRealizations, type, instance.substitution) ??
             mirType(type, instance.substitution)
           return lowered === undefined ? [] : [lowered]
@@ -4747,12 +4807,21 @@ const lowerInstance = (
     specializedEffectResult ??
     hiddenEffectResult ??
     (contract._tag === 'Contract'
-      ? (representedValueType(
+      ? (storedCallableValueType(
+          layout,
+          Type.substitute(effectOutcome ?? contract.result, instance.substitution),
+        ) ??
+        storedEffectValueType(
+          layout,
+          Type.substitute(effectOutcome ?? contract.result, instance.substitution),
+        ) ??
+        representedValueType(
           layout,
           opaqueRealizations,
           effectOutcome ?? contract.result,
           instance.substitution,
-        ) ?? mirType(effectOutcome ?? contract.result, instance.substitution))
+        ) ??
+        mirType(effectOutcome ?? contract.result, instance.substitution))
       : i32)
   if (resultType === undefined) {
     return trapFunction(instance, 'unavailable contract type', bodySpan(fn))

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -422,7 +422,8 @@ const effectValueByIdentity = (
       candidate,
     ): candidate is Extract<Layout.EffectEnvironment, { readonly _tag: 'EffectEnvironment' }> =>
       candidate._tag === 'EffectEnvironment' &&
-      Instances.effectIdentity(candidate.instance, candidate.site) === identity,
+      (Instances.effectIdentity(candidate.instance, candidate.site) === identity ||
+        candidate.successEffectIdentity === identity),
   )
   return environment === undefined
     ? undefined
@@ -699,6 +700,24 @@ const runtimeRequirementArguments = (
     ) ?? [],
   )
 
+const providerBindings = (
+  requirements: ReadonlyArray<ProvidedRequirement> | undefined,
+): Extract<Mir.Operation, { readonly _tag: 'RunEffectValue' }>['providers'] =>
+  Object.freeze(
+    requirements?.map((requirement) =>
+      Object.freeze({
+        capability: requirement.capability,
+        providerType: requirement.providerType,
+        role: requirement.role,
+        access: requirement.access,
+        ...(requirement.witness._tag === 'SourceConformanceWitness' &&
+        requirement.local !== undefined
+          ? { argument: requirement.local }
+          : {}),
+      }),
+    ) ?? [],
+  )
+
 const sameSite = (left: Hir.CallableSiteId, right: Hir.CallableSiteId): boolean =>
   Hir.sameExecutableSite(left, right)
 
@@ -810,19 +829,28 @@ const lowerRunEffectValue = (
       : ensureProvidedRunner(fn, effectType, provided)
   if (provided !== undefined && provided.length > 0 && providedRunner === undefined)
     return undefined
+  const baseRunner =
+    effectType.storage?.realization.runner ??
+    Hir.effectRunnerId(effectType.environment.instance.declaration, effectType.site)
+  const baseRunnerTypeArguments =
+    effectType.storage?.realization.runnerArguments ?? effectType.environment.instance.typeArguments
   fn.emit(
     Object.freeze({
       _tag: 'RunEffectValue',
       destination,
       outcome,
       effect,
-      runner:
-        providedRunner ??
-        effectType.storage?.realization.runner ??
-        Hir.effectRunnerId(effectType.environment.instance.declaration, effectType.site),
-      runnerTypeArguments:
-        effectType.storage?.realization.runnerArguments ??
-        effectType.environment.instance.typeArguments,
+      runner: providedRunner ?? baseRunner,
+      runnerTypeArguments: baseRunnerTypeArguments,
+      ...(providedRunner === undefined
+        ? {}
+        : {
+            runnerBase: Object.freeze({
+              declaration: baseRunner,
+              typeArguments: baseRunnerTypeArguments,
+            }),
+          }),
+      providers: providerBindings(provided),
       arguments: runtimeRequirementArguments(provided),
       outcomeType,
       ...(propagationType === undefined ? {} : { propagationType }),
@@ -2093,22 +2121,29 @@ function lowerExpressionInner(
             : ensureProvidedRunner(fn, effectValueType, provided)
         if (provided !== undefined && provided.length > 0 && providedRunner === undefined)
           return undefined
+        const baseRunner =
+          effectValueType.storage?.realization.runner ??
+          Hir.effectRunnerId(effectValueType.environment.instance.declaration, effectValueType.site)
+        const baseRunnerTypeArguments =
+          effectValueType.storage?.realization.runnerArguments ??
+          effectValueType.environment.instance.typeArguments
         fn.emit(
           Object.freeze({
             _tag: 'RunEffectValue',
             destination,
             outcome,
             effect: loweredSubject.result,
-            runner:
-              providedRunner ??
-              effectValueType.storage?.realization.runner ??
-              Hir.effectRunnerId(
-                effectValueType.environment.instance.declaration,
-                effectValueType.site,
-              ),
-            runnerTypeArguments:
-              effectValueType.storage?.realization.runnerArguments ??
-              effectValueType.environment.instance.typeArguments,
+            runner: providedRunner ?? baseRunner,
+            runnerTypeArguments: baseRunnerTypeArguments,
+            ...(providedRunner === undefined
+              ? {}
+              : {
+                  runnerBase: Object.freeze({
+                    declaration: baseRunner,
+                    typeArguments: baseRunnerTypeArguments,
+                  }),
+                }),
+            providers: providerBindings(provided),
             arguments: runtimeRequirementArguments(provided),
             outcomeType,
             ...(propagationType === undefined ? {} : { propagationType }),
@@ -3693,18 +3728,23 @@ function effectLocalCleanup(
               : Layout.callableEnvironmentLanes(fn.layout, callable.environment).length
       const currentOffset = laneOffset
       laneOffset += laneCount
-      if (field.representation === 'Borrow') return []
+      const realizationOrdinal =
+        effectValue.storage?.realization.environment.at(ordinal)?.ordinal ?? ordinal
+      const storedOwned =
+        effectValue.storage?.realization.cleanup.unrunLanes.includes(realizationOrdinal) ?? false
+      if (effectValue.storage === undefined ? field.representation === 'Borrow' : !storedOwned)
+        return []
       const fieldCleanup =
         callable === undefined
           ? nested === undefined
             ? concreteCleanup(fn, field.type)
             : effectLocalCleanup(fn, nested, next)
           : callableLocalCleanup(fn, callable)
-      return fieldCleanup._tag === 'NoCleanup'
+      return fieldCleanup._tag === 'NoCleanup' && effectValue.storage === undefined
         ? []
         : [
             Object.freeze({
-              ordinal: effectValue.storage?.realization.environment.at(ordinal)?.ordinal ?? ordinal,
+              ordinal: realizationOrdinal,
               laneOffset: currentOffset,
               laneCount,
               cleanup: fieldCleanup,

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -3695,7 +3695,9 @@ const concreteCleanup = (
       storedEffectValueType(fn.layout, concrete) ??
       representedValueType(fn.layout, fn.opaqueRealizations, concrete, new Map())
     return value?._tag === 'CallableValue'
-      ? callableLocalCleanup(fn, value)
+      ? value.storage?._tag === 'StoredCallableField'
+        ? Ownership.realizedCallableCleanup(fn.index, value.storage.realization)
+        : callableLocalCleanup(fn, value)
       : value?._tag === 'EffectValue'
         ? effectLocalCleanup(fn, value, new Set())
         : undefined

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -3693,7 +3693,11 @@ const concreteCleanup = (
       if (effectValue !== undefined) return effectLocalCleanup(fn, effectValue, new Set())
     }
   }
-  return Ownership.cleanupPlan(fn.index, specialized, seen)
+  return Ownership.specializeCleanup(
+    Ownership.cleanupPlan(fn.index, specialized, seen),
+    new Map(),
+    (nested) => concreteCleanup(fn, nested, seen),
+  )
 }
 
 function effectLocalCleanup(

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -417,14 +417,16 @@ const effectValueByIdentity = (
   layout: Layout.Plan,
   identity: string,
 ): Extract<Mir.Type, { readonly _tag: 'EffectValue' }> | undefined => {
-  const environment = layout.effectEnvironments.find(
+  const available = layout.effectEnvironments.filter(
     (
       candidate,
     ): candidate is Extract<Layout.EffectEnvironment, { readonly _tag: 'EffectEnvironment' }> =>
-      candidate._tag === 'EffectEnvironment' &&
-      (Instances.effectIdentity(candidate.instance, candidate.site) === identity ||
-        candidate.successEffectIdentity === identity),
+      candidate._tag === 'EffectEnvironment',
   )
+  const environment =
+    available.find(
+      (candidate) => Instances.effectIdentity(candidate.instance, candidate.site) === identity,
+    ) ?? available.find((candidate) => candidate.successEffectIdentity === identity)
   return environment === undefined
     ? undefined
     : Object.freeze({
@@ -613,6 +615,7 @@ const storedEffectValueType = (
   type: Type.Type,
 ): Extract<Mir.Type, { readonly _tag: 'EffectValue' }> | undefined => {
   if (!Type.isRepresented(type) || !Type.isEffect(type.contract)) return undefined
+  if (Type.isOpaqueRepresentationArgument(type.representation.argument)) return undefined
   const entry = Layout.entry(layout, type)
   const representation = entry?.representation
   if (entry === undefined || representation?._tag !== 'StoredEffectEnvironment') return undefined
@@ -3684,19 +3687,25 @@ const concreteCleanup = (
   seen = new Set<string>(),
 ): Ownership.CleanupPlan => {
   const specialized = Type.substitute(type, fn.substitution)
-  if (Type.isRepresented(specialized)) {
-    const representation = Layout.entry(fn.layout, specialized)?.representation
-    if (representation?._tag === 'CallableEnvironment')
-      return Ownership.realizedCallableCleanup(fn.index, representation.realization)
-    if (representation?._tag === 'StoredEffectEnvironment') {
-      const effectValue = storedEffectValueType(fn.layout, specialized)
-      if (effectValue !== undefined) return effectLocalCleanup(fn, effectValue, new Set())
-    }
+  const resolveRepresented = (candidate: Type.Type): Ownership.CleanupPlan | undefined => {
+    const concrete = Type.substitute(candidate, fn.substitution)
+    if (!Type.isRepresented(concrete)) return undefined
+    const value =
+      storedCallableValueType(fn.layout, concrete) ??
+      storedEffectValueType(fn.layout, concrete) ??
+      representedValueType(fn.layout, fn.opaqueRealizations, concrete, new Map())
+    return value?._tag === 'CallableValue'
+      ? callableLocalCleanup(fn, value)
+      : value?._tag === 'EffectValue'
+        ? effectLocalCleanup(fn, value, new Set())
+        : undefined
   }
+  const realized = resolveRepresented(specialized)
+  if (realized !== undefined) return realized
   return Ownership.specializeCleanup(
     Ownership.cleanupPlan(fn.index, specialized, seen),
     new Map(),
-    (nested) => concreteCleanup(fn, nested, seen),
+    (nested) => resolveRepresented(nested) ?? Ownership.cleanupPlan(fn.index, nested, seen),
   )
 }
 

--- a/packages/compiler/src/Lower.ts
+++ b/packages/compiler/src/Lower.ts
@@ -708,6 +708,7 @@ const providerBindings = (
       Object.freeze({
         capability: requirement.capability,
         providerType: requirement.providerType,
+        witness: requirement.witness,
         role: requirement.role,
         access: requirement.access,
         ...(requirement.witness._tag === 'SourceConformanceWitness' &&
@@ -5019,6 +5020,23 @@ const lowerEffectRunner = (
     regions: Object.freeze(
       lowering.regions.flatMap((region) => (region === undefined ? [] : [region])),
     ),
+    effectRunner: Object.freeze({
+      base: Object.freeze({
+        declaration: Hir.effectRunnerId(type.environment.instance.declaration, type.site),
+        typeArguments: type.environment.instance.typeArguments,
+      }),
+      providers: Object.freeze(
+        spec.providedRequirements.map((requirement) =>
+          Object.freeze({
+            capability: requirement.capability,
+            providerType: requirement.providerType,
+            witness: requirement.witness,
+            role: requirement.role,
+            access: requirement.access,
+          }),
+        ),
+      ),
+    }),
   })
 }
 

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -2441,14 +2441,14 @@ const cleanupMatchesSemanticType = (
 ): boolean => {
   if (SilkType.isRepresented(type)) {
     const representation = Layout.entry(layout, type)?.representation
+    const contractValid = TypeCompatibility.isCompatible(
+      TypeCompatibility.check(type.contract, cleanup.type),
+    )
     if (representation?._tag === 'CallableEnvironment')
-      return (
-        (cleanup._tag === 'CallableCleanup' || cleanup._tag === 'NoCleanup') &&
-        SilkType.equals(cleanup.type, type.contract)
-      )
+      return (cleanup._tag === 'CallableCleanup' || cleanup._tag === 'NoCleanup') && contractValid
     if (representation?._tag === 'StoredEffectEnvironment')
       return (
-        SilkType.equals(cleanup.type, type.contract) &&
+        contractValid &&
         (cleanup._tag === 'EffectCleanup'
           ? storedEffectCleanupPlanValid(layout, type, representation, cleanup)
           : cleanup._tag === 'NoCleanup' &&
@@ -2494,6 +2494,20 @@ const cleanupMatchesSemanticType = (
   if (seen.has(key)) return cleanup._tag === 'NoCleanup'
   const representation = Layout.entry(layout, type)?.representation
   if (representation?._tag !== 'Aggregate') return cleanup._tag === 'NoCleanup'
+  const requiredHook = representation.cleanupHook
+  if (requiredHook !== undefined) {
+    if (
+      cleanup._tag !== 'HookCleanup' ||
+      cleanup.hook.module !== requiredHook.hook.module ||
+      cleanup.hook.name !== requiredHook.hook.name ||
+      cleanup.typeArguments.length !== requiredHook.typeArguments.length ||
+      !cleanup.typeArguments.every((argument, ordinal) => {
+        const expected = requiredHook.typeArguments.at(ordinal)
+        return expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+      })
+    )
+      return false
+  } else if (cleanup._tag === 'HookCleanup') return false
   const concrete = cleanup._tag === 'HookCleanup' ? cleanup.inner : cleanup
   if (concrete._tag !== 'StructCleanup' || concrete.fields.length !== representation.fields.length)
     return false

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -722,6 +722,19 @@ export type Operation =
       readonly effect: LocalId
       readonly runner: DeclarationIndex.CanonicalId
       readonly runnerTypeArguments: ReadonlyArray<SilkType.GenericArgument>
+      /** Exact unsupplied runner retained when `runner` is a statically provided specialization. */
+      readonly runnerBase?: {
+        readonly declaration: DeclarationIndex.CanonicalId
+        readonly typeArguments: ReadonlyArray<SilkType.GenericArgument>
+      }
+      /** Ordered compile-time provider selections proving the exact requirement row. */
+      readonly providers: ReadonlyArray<{
+        readonly capability: SilkType.Nominal
+        readonly providerType: SilkType.Nominal
+        readonly role: string
+        readonly access: 'Shared' | 'Exclusive' | 'Take'
+        readonly argument?: LocalId
+      }>
       /** Statically selected service-provider references appended after the Effect captures. */
       readonly arguments: ReadonlyArray<LocalId>
       readonly outcomeType: Extract<Type, { readonly _tag: 'EffectOutcome' }>
@@ -2221,6 +2234,141 @@ const cleanupTypes = (cleanup: Ownership.CleanupPlan): ReadonlyArray<SilkType.Ty
   }
 }
 
+const cleanupMatchesSemanticType = (
+  layout: Layout.Plan,
+  cleanup: Ownership.CleanupPlan,
+  type: DeclarationIndex.SemanticType,
+  seen: ReadonlySet<string> = new Set(),
+): boolean => {
+  if (SilkType.isRepresented(type)) {
+    const representation = Layout.entry(layout, type)?.representation
+    if (representation?._tag === 'CallableEnvironment')
+      return (
+        (cleanup._tag === 'CallableCleanup' || cleanup._tag === 'NoCleanup') &&
+        SilkType.equals(cleanup.type, type.contract)
+      )
+    if (representation?._tag === 'StoredEffectEnvironment')
+      return (
+        SilkType.equals(cleanup.type, type.contract) &&
+        (cleanup._tag === 'EffectCleanup'
+          ? storedEffectCleanupPlanValid(layout, type, representation, cleanup)
+          : cleanup._tag === 'NoCleanup' &&
+            representation.realization.cleanup.unrunLanes.length === 0)
+      )
+    return false
+  }
+  if (!SilkType.equals(cleanup.type, type)) return false
+  if (
+    SilkType.isBuiltin(type) ||
+    SilkType.isString(type) ||
+    SilkType.isNever(type) ||
+    SilkType.isSlice(type) ||
+    SilkType.isReference(type) ||
+    SilkType.isEffect(type) ||
+    SilkType.isCallable(type)
+  )
+    return cleanup._tag === 'NoCleanup'
+  if (SilkType.equals(type, SilkType.allocation)) return cleanup._tag === 'AllocationCleanup'
+  if (SilkType.isRawBuffer(type)) return cleanup._tag === 'RawBufferCleanup'
+  if (SilkType.isFixedArray(type))
+    return (
+      cleanup._tag === 'ArrayCleanup' &&
+      cleanup.length === type.length &&
+      cleanupMatchesSemanticType(layout, cleanup.element, type.element, seen)
+    )
+  if (SilkType.isUnion(type))
+    return (
+      cleanup._tag === 'UnionCleanup' &&
+      cleanup.cases.length === type.members.length &&
+      cleanup.cases.every((entry, ordinal) => {
+        const member = type.members.at(ordinal)
+        return (
+          member !== undefined &&
+          entry.ordinal === ordinal &&
+          SilkType.equals(entry.member, member) &&
+          cleanupMatchesSemanticType(layout, entry.cleanup, member, seen)
+        )
+      })
+    )
+  if (!SilkType.isNominal(type)) return cleanup._tag === 'NoCleanup'
+  const key = SilkType.key(type)
+  if (seen.has(key)) return cleanup._tag === 'NoCleanup'
+  const representation = Layout.entry(layout, type)?.representation
+  if (representation?._tag !== 'Aggregate') return cleanup._tag === 'NoCleanup'
+  const concrete = cleanup._tag === 'HookCleanup' ? cleanup.inner : cleanup
+  if (concrete._tag !== 'StructCleanup' || concrete.fields.length !== representation.fields.length)
+    return false
+  const next = new Set(seen).add(key)
+  return concrete.fields.every((field, ordinal) => {
+    const expected = representation.fields.at(ordinal)
+    return (
+      expected !== undefined &&
+      field.field.ordinal === expected.id.ordinal &&
+      field.field.struct.sourceId === expected.id.struct.sourceId &&
+      field.field.struct.ordinal === expected.id.struct.ordinal &&
+      cleanupMatchesSemanticType(layout, field.cleanup, expected.type, next)
+    )
+  })
+}
+
+const storedEffectCleanupPlanValid = (
+  layout: Layout.Plan,
+  type: SilkType.Represented,
+  representation: Extract<Layout.Representation, { readonly _tag: 'StoredEffectEnvironment' }>,
+  cleanup: Extract<Ownership.CleanupPlan, { readonly _tag: 'EffectCleanup' }>,
+): boolean => {
+  if (!Hir.sameExecutableSite(cleanup.site, representation.realization.site)) return false
+  const shape = Layout.callingShape(layout, type)?.tree
+  if (shape?._tag !== 'EffectEnvironmentShape') return false
+  const ranges = representation.fields.map((field, ordinal) => {
+    const fieldShape = shape.fields.at(ordinal)
+    const laneOffset = shape.fields
+      .slice(0, ordinal)
+      .reduce((total, candidate) => total + candidate.shape.laneCount, 0)
+    return Object.freeze({ field, fieldShape, laneOffset })
+  })
+  const expected = [...representation.realization.cleanup.unrunLanes].reverse().flatMap((owned) => {
+    const range = ranges.find((candidate) => candidate.field.capture === owned)
+    return range === undefined ? [] : [Object.freeze({ owned, ...range })]
+  })
+  return (
+    expected.length === representation.realization.cleanup.unrunLanes.length &&
+    cleanup.slots.length === expected.length &&
+    cleanup.slots.every((slot, ordinal) => {
+      const candidate = expected.at(ordinal)
+      return (
+        candidate !== undefined &&
+        candidate.fieldShape !== undefined &&
+        slot.ordinal === candidate.owned &&
+        slot.laneOffset === candidate.laneOffset &&
+        slot.laneCount === candidate.fieldShape.shape.laneCount &&
+        (candidate.field.effectIdentity !== undefined
+          ? (slot.cleanup._tag === 'EffectCleanup' || slot.cleanup._tag === 'NoCleanup') &&
+            SilkType.equals(slot.cleanup.type, candidate.field.type)
+          : candidate.field.callableIdentity !== undefined
+            ? (slot.cleanup._tag === 'CallableCleanup' || slot.cleanup._tag === 'NoCleanup') &&
+              SilkType.equals(slot.cleanup.type, candidate.field.type)
+            : cleanupMatchesSemanticType(layout, slot.cleanup, candidate.field.type))
+      )
+    })
+  )
+}
+
+const storedEffectCleanupValid = (
+  layout: Layout.Plan,
+  dropped: Extract<Type, { readonly _tag: 'EffectValue' }> | undefined,
+  cleanup: Extract<Ownership.CleanupPlan, { readonly _tag: 'EffectCleanup' }>,
+): boolean => {
+  const storage = dropped?.storage
+  const representation =
+    storage === undefined ? undefined : Layout.entry(layout, storage.type)?.representation
+  return (
+    storage !== undefined &&
+    representation?._tag === 'StoredEffectEnvironment' &&
+    storedEffectCleanupPlanValid(layout, storage.type, representation, cleanup)
+  )
+}
+
 const operationTypes = (operation: Operation): ReadonlyArray<DeclarationIndex.SemanticType> => {
   switch (operation._tag) {
     case 'Literal':
@@ -2320,6 +2468,8 @@ const operationTypes = (operation: Operation): ReadonlyArray<DeclarationIndex.Se
           : [semanticType(operation.propagationType)]),
         semanticType(operation.type),
         ...operation.runnerTypeArguments.filter(SilkType.isTypeArgument),
+        ...(operation.runnerBase?.typeArguments.filter(SilkType.isTypeArgument) ?? []),
+        ...operation.providers.flatMap((provider) => [provider.capability, provider.providerType]),
       ]
     case 'RunStaticEffect':
       return [
@@ -4287,23 +4437,20 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
           const effectCleanupValid =
             cleanup._tag !== 'EffectCleanup' ||
             (dropped?._tag === 'EffectValue' &&
-              Hir.sameExecutableSite(cleanup.site, dropped.site) &&
-              (() => {
-                const owned = dropped.storage?.realization.cleanup.unrunLanes
-                if (owned === undefined) return true
-                let previous = Number.POSITIVE_INFINITY
-                return cleanup.slots.every((slot) => {
-                  const ordered = slot.ordinal < previous
-                  previous = slot.ordinal
-                  return ordered && owned.includes(slot.ordinal)
-                })
-              })())
+              (dropped.storage === undefined
+                ? Hir.sameExecutableSite(cleanup.site, dropped.site)
+                : storedEffectCleanupValid(self.layout, dropped, cleanup)))
+          const storedAggregateCleanupValid =
+            droppedSemantic !== undefined &&
+            (!SilkType.containsEffectRepresentation(droppedSemantic) ||
+              cleanupMatchesSemanticType(self.layout, cleanup, droppedSemantic))
           if (
             dropped === undefined ||
             !cleanupTypeMatches ||
             !unionCasesValid ||
             !callableCleanupValid ||
-            !effectCleanupValid
+            !effectCleanupValid ||
+            !storedAggregateCleanupValid
           ) {
             violations.push(
               Object.freeze({
@@ -4886,14 +5033,66 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
               }))
           const directStoredRunner =
             stored === undefined ||
-            operation.arguments.length > 0 ||
-            (operation.runner.module === stored.realization.runner.module &&
-              operation.runner.name === stored.realization.runner.name &&
-              operation.runnerTypeArguments.length === stored.realization.runnerArguments.length &&
-              operation.runnerTypeArguments.every((argument, ordinal) => {
-                const expected = stored.realization.runnerArguments.at(ordinal)
-                return expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
-              }))
+            (() => {
+              if (effectValue === undefined) return false
+              const base = operation.runnerBase
+              const selectedBase = base?.declaration ?? operation.runner
+              const selectedArguments = base?.typeArguments ?? operation.runnerTypeArguments
+              const baseMatches =
+                selectedBase.module === stored.realization.runner.module &&
+                selectedBase.name === stored.realization.runner.name &&
+                selectedArguments.length === stored.realization.runnerArguments.length &&
+                selectedArguments.every((argument, ordinal) => {
+                  const expected = stored.realization.runnerArguments.at(ordinal)
+                  return (
+                    expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+                  )
+                })
+              const requirementsMatch =
+                operation.providers.length === stored.realization.rows.requirements.length &&
+                operation.providers.every((provider, ordinal) => {
+                  const requirement = stored.realization.rows.requirements.at(ordinal)
+                  const argumentType =
+                    provider.argument === undefined
+                      ? undefined
+                      : fn.localTypes.at(provider.argument.ordinal)
+                  const semanticArgument =
+                    argumentType === undefined ? undefined : semanticType(argumentType)
+                  return (
+                    requirement !== undefined &&
+                    provider.role === requirement.role &&
+                    SilkType.equals(provider.capability, requirement.capability) &&
+                    (requirement.access === 'Shared' || provider.access === 'Exclusive') &&
+                    (provider.argument === undefined ||
+                      (semanticArgument !== undefined &&
+                        SilkType.isReference(semanticArgument) &&
+                        semanticArgument.access === provider.access &&
+                        SilkType.equals(semanticArgument.target, provider.providerType)))
+                  )
+                })
+              const runtimeArguments = operation.providers.flatMap((provider) =>
+                provider.argument === undefined ? [] : [provider.argument],
+              )
+              const argumentsMatch =
+                runtimeArguments.length === operation.arguments.length &&
+                runtimeArguments.every(
+                  (argument, ordinal) =>
+                    argument.ordinal === operation.arguments.at(ordinal)?.ordinal,
+                )
+              const wrapperShapeMatches =
+                runner !== undefined &&
+                runner.parameterCount ===
+                  effectValue.environment.fields.length + operation.arguments.length
+              return (
+                baseMatches &&
+                requirementsMatch &&
+                argumentsMatch &&
+                wrapperShapeMatches &&
+                (operation.providers.length === 0
+                  ? operation.runnerBase === undefined
+                  : operation.runnerBase !== undefined)
+              )
+            })()
           const valid =
             effectValue !== undefined &&
             outcome?._tag === 'EffectOutcome' &&
@@ -5256,7 +5455,7 @@ const operationText = (operation: Operation): string => {
     case 'RunEffect':
       return `${localText(operation.destination)} = run-effect ${targetText(operation.target)} propagate=${operation.tagMappings.map((mapping) => `${mapping.source}->${mapping.target}`).join(',')} : ${typeText(operation.type)} ${operation.releases === undefined || operation.releases.length === 0 ? '' : `releases=${operation.releases.map((release) => localText(release.local)).join(',')} `}${provenanceText(operation.provenance)}`
     case 'RunEffectValue':
-      return `${localText(operation.destination)} = run-effect-value ${localText(operation.effect)} runner=${targetText(operation.runner)} arguments=${operation.arguments.map(localText).join(',') || 'none'} propagate=${operation.tagMappings.map((mapping) => `${mapping.source}->${mapping.target}`).join(',')} : ${typeText(operation.type)} ${operation.releases === undefined || operation.releases.length === 0 ? '' : `releases=${operation.releases.map((release) => localText(release.local)).join(',')} `}${provenanceText(operation.provenance)}`
+      return `${localText(operation.destination)} = run-effect-value ${localText(operation.effect)} runner=${targetText(operation.runner)}${operation.runnerBase === undefined ? '' : ` base=${targetText(operation.runnerBase.declaration)}`} providers=${operation.providers.map((provider) => `${SilkType.encode(provider.capability)}@${provider.role}:${provider.access.toLowerCase()}`).join(',') || 'none'} arguments=${operation.arguments.map(localText).join(',') || 'none'} propagate=${operation.tagMappings.map((mapping) => `${mapping.source}->${mapping.target}`).join(',')} : ${typeText(operation.type)} ${operation.releases === undefined || operation.releases.length === 0 ? '' : `releases=${operation.releases.map((release) => localText(release.local)).join(',')} `}${provenanceText(operation.provenance)}`
     case 'RunStaticEffect':
       return `${localText(operation.destination)} = run-static-effect runner=${targetText(operation.runner)} captures=${operation.captures.map((capture) => `${localText(capture.source)}:${capture.access.toLowerCase()}`).join(',') || 'none'} arguments=${operation.arguments.map(localText).join(',') || 'none'} propagate=${operation.tagMappings.map((mapping) => `${mapping.source}->${mapping.target}`).join(',')} : ${typeText(operation.type)} ${operation.releases === undefined || operation.releases.length === 0 ? '' : `releases=${operation.releases.map((release) => localText(release.local)).join(',')} `}${provenanceText(operation.provenance)}`
     case 'ReifyEffect':

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -1,4 +1,5 @@
 import * as Option from 'effect/Option'
+import * as CallableFieldRealization from './CallableFieldRealization.js'
 import type * as DeclarationIndex from './DeclarationIndex.js'
 import * as Hir from './Hir.js'
 import * as Instances from './Instances.js'
@@ -731,6 +732,7 @@ export type Operation =
       readonly providers: ReadonlyArray<{
         readonly capability: SilkType.Nominal
         readonly providerType: SilkType.Nominal
+        readonly witness: DeclarationIndex.ConformanceWitness
         readonly role: string
         readonly access: 'Shared' | 'Exclusive' | 'Take'
         readonly argument?: LocalId
@@ -1268,6 +1270,20 @@ export interface MirFunction {
   readonly result: Type
   readonly entry: RegionId
   readonly regions: ReadonlyArray<Region>
+  /** Static origin of a generated Effect runner, including every selected provider witness. */
+  readonly effectRunner?: {
+    readonly base: {
+      readonly declaration: DeclarationIndex.CanonicalId
+      readonly typeArguments: ReadonlyArray<SilkType.GenericArgument>
+    }
+    readonly providers: ReadonlyArray<{
+      readonly capability: SilkType.Nominal
+      readonly providerType: SilkType.Nominal
+      readonly witness: DeclarationIndex.ConformanceWitness
+      readonly role: string
+      readonly access: 'Shared' | 'Exclusive' | 'Take'
+    }>
+  }
   readonly suspension?: {
     readonly classification: SuspensionClassification
     readonly regions: ReadonlyArray<SuspensionRegion>
@@ -1336,6 +1352,39 @@ export const matchesInstance = (
 /** Tests exact concrete instance identity, including the resolved contract row. */
 export const matchesInstanceKey = (fn: MirFunction, key: Instances.InstanceKey): boolean =>
   instanceText(fn.instance) === instanceText(key)
+
+const conformanceWitnessMatches = (
+  left: DeclarationIndex.ConformanceWitness,
+  right: DeclarationIndex.ConformanceWitness,
+): boolean => {
+  if (
+    left._tag !== right._tag ||
+    !SilkType.equals(left.capability, right.capability) ||
+    !SilkType.equals(left.provider, right.provider)
+  )
+    return false
+  if (left._tag !== 'SourceConformanceWitness') return true
+  if (right._tag !== 'SourceConformanceWitness') return false
+  return (
+    left.module === right.module &&
+    left.ordinal === right.ordinal &&
+    left.typeArguments.length === right.typeArguments.length &&
+    left.typeArguments.every((argument, ordinal) => {
+      const expected = right.typeArguments.at(ordinal)
+      return expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+    }) &&
+    left.operations.length === right.operations.length &&
+    left.operations.every((operation, ordinal) => {
+      const expected = right.operations.at(ordinal)
+      return (
+        expected !== undefined &&
+        operation.name === expected.name &&
+        operation.implementation.module === expected.implementation.module &&
+        operation.implementation.name === expected.implementation.name
+      )
+    })
+  )
+}
 
 export interface ControlEdge {
   readonly _tag: 'ControlEdge'
@@ -2234,6 +2283,156 @@ const cleanupTypes = (cleanup: Ownership.CleanupPlan): ReadonlyArray<SilkType.Ty
   }
 }
 
+type EffectEnvironment = Extract<Layout.EffectEnvironment, { readonly _tag: 'EffectEnvironment' }>
+
+type CallableEnvironment = Extract<
+  Layout.CallableEnvironment,
+  { readonly _tag: 'CallableEnvironment' }
+>
+
+const effectEnvironmentByIdentity = (
+  layout: Layout.Plan,
+  identity: string,
+): EffectEnvironment | undefined =>
+  layout.effectEnvironments.find(
+    (candidate): candidate is EffectEnvironment =>
+      candidate._tag === 'EffectEnvironment' &&
+      (Instances.effectIdentity(candidate.instance, candidate.site) === identity ||
+        candidate.successEffectIdentity === identity),
+  )
+
+const callableEnvironmentByIdentity = (
+  layout: Layout.Plan,
+  identity: SilkType.CallableIdentityArgument,
+): CallableEnvironment | undefined =>
+  layout.callableEnvironments.find(
+    (candidate): candidate is CallableEnvironment =>
+      candidate._tag === 'CallableEnvironment' &&
+      CallableFieldRealization.matchesIdentity(identity, candidate.callable),
+  )
+
+const effectFieldLaneCount = (
+  layout: Layout.Plan,
+  field: Layout.EffectEnvironmentField,
+): number | undefined => {
+  if (field.representation === 'Borrow') return 1
+  if (field.effectIdentity !== undefined) {
+    const environment = effectEnvironmentByIdentity(layout, field.effectIdentity)
+    return environment === undefined
+      ? undefined
+      : Layout.effectEnvironmentLanes(layout, environment).length
+  }
+  if (field.callableIdentity !== undefined) {
+    const environment = callableEnvironmentByIdentity(layout, field.callableIdentity)
+    return environment === undefined
+      ? undefined
+      : Layout.callableEnvironmentLanes(layout, environment).length
+  }
+  return Layout.callingShape(layout, field.type)?.laneCount
+}
+
+const callableEnvironmentCleanupValid = (
+  layout: Layout.Plan,
+  identity: SilkType.CallableIdentityArgument,
+  expectedType: SilkType.Callable,
+  cleanup: Ownership.CleanupPlan,
+  active: ReadonlySet<string>,
+): boolean => {
+  const environment = callableEnvironmentByIdentity(layout, identity)
+  if (environment === undefined || cleanup._tag !== 'CallableCleanup') return false
+  const environmentIdentity = Instances.callableEnvironmentIdentity(environment.callable)
+  const key = `callable:${SilkType.callableEnvironmentKey(environmentIdentity)}`
+  if (active.has(key)) return false
+  const expected = [...environment.fields]
+    .reverse()
+    .filter((field) => field.access === 'Take' && !isCopyType(field.type))
+  const next = new Set(active).add(key)
+  return (
+    SilkType.equals(cleanup.type, expectedType) &&
+    cleanup.environment._tag === 'CallableEnvironmentIdentity' &&
+    SilkType.equalsCallableEnvironmentIdentity(cleanup.environment.identity, environmentIdentity) &&
+    cleanup.slots.length === expected.length &&
+    cleanup.slots.every((slot, ordinal) => {
+      const field = expected.at(ordinal)
+      return (
+        field !== undefined &&
+        slot.ordinal === field.ordinal &&
+        cleanupMatchesSemanticType(layout, slot.cleanup, field.type, next)
+      )
+    })
+  )
+}
+
+const executableFieldCleanupValid = (
+  layout: Layout.Plan,
+  field: Layout.EffectEnvironmentField,
+  cleanup: Ownership.CleanupPlan,
+  active: ReadonlySet<string>,
+): boolean => {
+  if (field.effectIdentity !== undefined) {
+    const environment = effectEnvironmentByIdentity(layout, field.effectIdentity)
+    return (
+      environment !== undefined &&
+      effectEnvironmentCleanupValid(layout, field.effectIdentity, environment, cleanup, active)
+    )
+  }
+  if (field.callableIdentity !== undefined && SilkType.isCallable(field.type))
+    return callableEnvironmentCleanupValid(
+      layout,
+      field.callableIdentity,
+      field.type,
+      cleanup,
+      active,
+    )
+  return cleanupMatchesSemanticType(layout, cleanup, field.type, active)
+}
+
+const effectEnvironmentCleanupValid = (
+  layout: Layout.Plan,
+  identity: string,
+  environment: EffectEnvironment,
+  cleanup: Ownership.CleanupPlan,
+  active: ReadonlySet<string>,
+): boolean => {
+  const key = `effect:${identity}`
+  if (active.has(key))
+    return cleanup._tag === 'NoCleanup' && SilkType.equals(cleanup.type, environment.effect)
+  const next = new Set(active).add(key)
+  let laneOffset = 0
+  const expected = environment.fields.flatMap((field, ordinal) => {
+    const laneCount = effectFieldLaneCount(layout, field)
+    const currentOffset = laneOffset
+    if (laneCount !== undefined) laneOffset += laneCount
+    const noCleanup: Ownership.CleanupPlan = Object.freeze({
+      _tag: 'NoCleanup',
+      type: field.type,
+    })
+    return field.representation === 'Borrow' ||
+      executableFieldCleanupValid(layout, field, noCleanup, next)
+      ? []
+      : [Object.freeze({ field, ordinal, laneOffset: currentOffset, laneCount })]
+  })
+  if (expected.length === 0)
+    return cleanup._tag === 'NoCleanup' && SilkType.equals(cleanup.type, environment.effect)
+  return (
+    cleanup._tag === 'EffectCleanup' &&
+    SilkType.equals(cleanup.type, environment.effect) &&
+    Hir.sameExecutableSite(cleanup.site, environment.site) &&
+    cleanup.slots.length === expected.length &&
+    cleanup.slots.every((slot, ordinal) => {
+      const candidate = [...expected].reverse().at(ordinal)
+      return (
+        candidate !== undefined &&
+        candidate.laneCount !== undefined &&
+        slot.ordinal === candidate.ordinal &&
+        slot.laneOffset === candidate.laneOffset &&
+        slot.laneCount === candidate.laneCount &&
+        executableFieldCleanupValid(layout, candidate.field, slot.cleanup, next)
+      )
+    })
+  )
+}
+
 const cleanupMatchesSemanticType = (
   layout: Layout.Plan,
   cleanup: Ownership.CleanupPlan,
@@ -2331,6 +2530,7 @@ const storedEffectCleanupPlanValid = (
     const range = ranges.find((candidate) => candidate.field.capture === owned)
     return range === undefined ? [] : [Object.freeze({ owned, ...range })]
   })
+  const active = new Set([`effect:${representation.realization.runnerIdentity}`])
   return (
     expected.length === representation.realization.cleanup.unrunLanes.length &&
     cleanup.slots.length === expected.length &&
@@ -2342,13 +2542,7 @@ const storedEffectCleanupPlanValid = (
         slot.ordinal === candidate.owned &&
         slot.laneOffset === candidate.laneOffset &&
         slot.laneCount === candidate.fieldShape.shape.laneCount &&
-        (candidate.field.effectIdentity !== undefined
-          ? (slot.cleanup._tag === 'EffectCleanup' || slot.cleanup._tag === 'NoCleanup') &&
-            SilkType.equals(slot.cleanup.type, candidate.field.type)
-          : candidate.field.callableIdentity !== undefined
-            ? (slot.cleanup._tag === 'CallableCleanup' || slot.cleanup._tag === 'NoCleanup') &&
-              SilkType.equals(slot.cleanup.type, candidate.field.type)
-            : cleanupMatchesSemanticType(layout, slot.cleanup, candidate.field.type))
+        executableFieldCleanupValid(layout, candidate.field, slot.cleanup, active)
       )
     })
   )
@@ -5031,68 +5225,107 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                   SilkType.equals(requirement.capability, expected.capability)
                 )
               }))
-          const directStoredRunner =
-            stored === undefined ||
-            (() => {
-              if (effectValue === undefined) return false
-              const base = operation.runnerBase
-              const selectedBase = base?.declaration ?? operation.runner
-              const selectedArguments = base?.typeArguments ?? operation.runnerTypeArguments
-              const baseMatches =
-                selectedBase.module === stored.realization.runner.module &&
-                selectedBase.name === stored.realization.runner.name &&
-                selectedArguments.length === stored.realization.runnerArguments.length &&
-                selectedArguments.every((argument, ordinal) => {
-                  const expected = stored.realization.runnerArguments.at(ordinal)
-                  return (
-                    expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+          const staticRunnerValid =
+            stored === undefined && operation.runnerBase === undefined
+              ? true
+              : (() => {
+                  if (effectValue === undefined) return false
+                  const base = operation.runnerBase
+                  const selectedBase = base?.declaration ?? operation.runner
+                  const selectedArguments = base?.typeArguments ?? operation.runnerTypeArguments
+                  const expectedBase =
+                    stored?.realization.runner ??
+                    Hir.effectRunnerId(
+                      effectValue.environment.instance.declaration,
+                      effectValue.site,
+                    )
+                  const expectedBaseArguments =
+                    stored?.realization.runnerArguments ??
+                    effectValue.environment.instance.typeArguments
+                  const baseMatches =
+                    selectedBase.module === expectedBase.module &&
+                    selectedBase.name === expectedBase.name &&
+                    selectedArguments.length === expectedBaseArguments.length &&
+                    selectedArguments.every((argument, ordinal) => {
+                      const expected = expectedBaseArguments.at(ordinal)
+                      return (
+                        expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+                      )
+                    })
+                  const expectedRequirements =
+                    stored?.realization.rows.requirements ?? effectValue.type.requirements
+                  const requirementsMatch =
+                    operation.providers.length === expectedRequirements.length &&
+                    operation.providers.every((provider, ordinal) => {
+                      const requirement = expectedRequirements.at(ordinal)
+                      const argumentType =
+                        provider.argument === undefined
+                          ? undefined
+                          : fn.localTypes.at(provider.argument.ordinal)
+                      const semanticArgument =
+                        argumentType === undefined ? undefined : semanticType(argumentType)
+                      return (
+                        requirement !== undefined &&
+                        provider.role === requirement.role &&
+                        SilkType.equals(provider.capability, requirement.capability) &&
+                        SilkType.equals(provider.witness.capability, provider.capability) &&
+                        SilkType.equals(provider.witness.provider, provider.providerType) &&
+                        (requirement.access === 'Shared' || provider.access === 'Exclusive') &&
+                        (provider.argument === undefined ||
+                          (semanticArgument !== undefined &&
+                            SilkType.isReference(semanticArgument) &&
+                            semanticArgument.access === provider.access &&
+                            SilkType.equals(semanticArgument.target, provider.providerType)))
+                      )
+                    })
+                  const runtimeArguments = operation.providers.flatMap((provider) =>
+                    provider.argument === undefined ? [] : [provider.argument],
                   )
-                })
-              const requirementsMatch =
-                operation.providers.length === stored.realization.rows.requirements.length &&
-                operation.providers.every((provider, ordinal) => {
-                  const requirement = stored.realization.rows.requirements.at(ordinal)
-                  const argumentType =
-                    provider.argument === undefined
-                      ? undefined
-                      : fn.localTypes.at(provider.argument.ordinal)
-                  const semanticArgument =
-                    argumentType === undefined ? undefined : semanticType(argumentType)
+                  const argumentsMatch =
+                    runtimeArguments.length === operation.arguments.length &&
+                    runtimeArguments.every(
+                      (argument, ordinal) =>
+                        argument.ordinal === operation.arguments.at(ordinal)?.ordinal,
+                    )
+                  const wrapperShapeMatches =
+                    runner !== undefined &&
+                    runner.parameterCount ===
+                      effectValue.environment.fields.length + operation.arguments.length
+                  const runnerBinding = runner?.effectRunner
+                  const wrapperBindingMatches =
+                    runnerBinding !== undefined &&
+                    runnerBinding.base.declaration.module === selectedBase.module &&
+                    runnerBinding.base.declaration.name === selectedBase.name &&
+                    runnerBinding.base.typeArguments.length === selectedArguments.length &&
+                    runnerBinding.base.typeArguments.every((argument, ordinal) => {
+                      const expected = selectedArguments.at(ordinal)
+                      return (
+                        expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+                      )
+                    }) &&
+                    runnerBinding.providers.length === operation.providers.length &&
+                    runnerBinding.providers.every((bound, ordinal) => {
+                      const claimed = operation.providers.at(ordinal)
+                      return (
+                        claimed !== undefined &&
+                        bound.role === claimed.role &&
+                        bound.access === claimed.access &&
+                        SilkType.equals(bound.capability, claimed.capability) &&
+                        SilkType.equals(bound.providerType, claimed.providerType) &&
+                        conformanceWitnessMatches(bound.witness, claimed.witness)
+                      )
+                    })
                   return (
-                    requirement !== undefined &&
-                    provider.role === requirement.role &&
-                    SilkType.equals(provider.capability, requirement.capability) &&
-                    (requirement.access === 'Shared' || provider.access === 'Exclusive') &&
-                    (provider.argument === undefined ||
-                      (semanticArgument !== undefined &&
-                        SilkType.isReference(semanticArgument) &&
-                        semanticArgument.access === provider.access &&
-                        SilkType.equals(semanticArgument.target, provider.providerType)))
+                    baseMatches &&
+                    requirementsMatch &&
+                    argumentsMatch &&
+                    wrapperShapeMatches &&
+                    wrapperBindingMatches &&
+                    (operation.providers.length === 0
+                      ? operation.runnerBase === undefined
+                      : operation.runnerBase !== undefined)
                   )
-                })
-              const runtimeArguments = operation.providers.flatMap((provider) =>
-                provider.argument === undefined ? [] : [provider.argument],
-              )
-              const argumentsMatch =
-                runtimeArguments.length === operation.arguments.length &&
-                runtimeArguments.every(
-                  (argument, ordinal) =>
-                    argument.ordinal === operation.arguments.at(ordinal)?.ordinal,
-                )
-              const wrapperShapeMatches =
-                runner !== undefined &&
-                runner.parameterCount ===
-                  effectValue.environment.fields.length + operation.arguments.length
-              return (
-                baseMatches &&
-                requirementsMatch &&
-                argumentsMatch &&
-                wrapperShapeMatches &&
-                (operation.providers.length === 0
-                  ? operation.runnerBase === undefined
-                  : operation.runnerBase !== undefined)
-              )
-            })()
+                })()
           const valid =
             effectValue !== undefined &&
             outcome?._tag === 'EffectOutcome' &&
@@ -5105,16 +5338,16 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
               (suspensionRunner !== undefined &&
                 SilkType.equals(suspensionRunner.outcome, operation.outcomeType.type))) &&
             storedContractValid &&
-            directStoredRunner &&
+            staticRunnerValid &&
             mappingsValid
-          if (stored !== undefined && !valid)
+          if ((stored !== undefined || operation.runnerBase !== undefined) && !valid)
             violations.push(
               Object.freeze({
                 _tag: 'Violation',
                 rule: 'InvalidEffectOperation',
                 function: fn.id,
                 region: region.id,
-                detail: `stored Effect run disagrees with its static runner, exact rows, access, outcome, or propagation contract (target=${targetText(operation.runner)}, effect=${effectValue !== undefined}, runner=${runner !== undefined}, suspension-runner=${suspensionRunner !== undefined}, stored-contract=${storedContractValid}, static-runner=${directStoredRunner}, mappings=${mappingsValid})`,
+                detail: `Effect value run disagrees with its static runner, exact rows, access, outcome, or propagation contract (target=${targetText(operation.runner)}, effect=${effectValue !== undefined}, runner=${runner !== undefined}, suspension-runner=${suspensionRunner !== undefined}, stored-contract=${storedContractValid}, static-runner=${staticRunnerValid}, mappings=${mappingsValid})`,
               }),
             )
         }

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -3053,20 +3053,10 @@ const suspensionCallTargets = (operation: Operation): ReadonlyArray<SuspensionCa
 }
 
 const originReachableSuspensionFunctions = (self: Module): ReadonlySet<string> => {
-  const realizedSuspendableRunners = self.layout.entries.flatMap((entry) =>
-    entry.representation._tag === 'StoredEffectEnvironment' &&
-    entry.representation.realization.suspendable
-      ? [entry.representation.realization]
-      : [],
-  )
   const reachable = new Set(
     self.functions
-      .filter(
-        (fn) =>
-          fn.suspension?.regions.some((region) => region._tag === 'SuspendEffectRegion') ||
-          realizedSuspendableRunners.some((realization) =>
-            matchesInstance(fn, realization.runner, realization.runnerArguments),
-          ),
+      .filter((fn) =>
+        fn.suspension?.regions.some((region) => region._tag === 'SuspendEffectRegion'),
       )
       .map((fn) => instanceText(fn.instance)),
   )

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -46,6 +46,14 @@ export type Type =
         Layout.EffectEnvironment,
         { readonly _tag: 'EffectEnvironment' }
       >
+      readonly storage?: {
+        readonly _tag: 'StoredEffectField'
+        readonly type: SilkType.Represented
+        readonly realization: Extract<
+          Layout.Representation,
+          { readonly _tag: 'StoredEffectEnvironment' }
+        >['realization']
+      }
     }
   | {
       readonly _tag: 'CallableValue'
@@ -68,7 +76,8 @@ export type Type =
   | { readonly _tag: 'EffectOutcome'; readonly type: SilkType.Effect }
 
 export const semanticType = (self: Type): DeclarationIndex.SemanticType => {
-  if (self._tag === 'CallableValue') return self.storage?.type ?? self.type
+  if (self._tag === 'CallableValue' || self._tag === 'EffectValue')
+    return self.storage?.type ?? self.type
   return self._tag === 'Nominal' ||
     self._tag === 'Bottom' ||
     self._tag === 'FixedArray' ||
@@ -77,7 +86,6 @@ export const semanticType = (self: Type): DeclarationIndex.SemanticType => {
     self._tag === 'Reference' ||
     self._tag === 'Union' ||
     self._tag === 'EffectBorrow' ||
-    self._tag === 'EffectValue' ||
     self._tag === 'EffectOutcome'
     ? self.type
     : self._tag
@@ -802,7 +810,9 @@ export type Operation =
       readonly fields: ReadonlyArray<{
         readonly field: DeclarationIndex.FieldId
         readonly value: LocalId
-        readonly stored?: Extract<Type, { readonly _tag: 'CallableValue' }>['storage']
+        readonly stored?:
+          | Extract<Type, { readonly _tag: 'CallableValue' }>['storage']
+          | Extract<Type, { readonly _tag: 'EffectValue' }>['storage']
       }>
       readonly provenance: Provenance
     }
@@ -2169,6 +2179,15 @@ const callableTargetText = (target: Hir.CallableTarget): string =>
 const storedCallableTargetText = (target: SilkType.CallableIdentityArgument['target']): string =>
   callableTargetText(Hir.callableTargetFromIdentity(target))
 
+const storedExecutableText = (
+  stored: NonNullable<
+    Extract<Operation, { readonly _tag: 'Construct' }>['fields'][number]['stored']
+  >,
+): string =>
+  stored._tag === 'StoredCallableField'
+    ? storedCallableTargetText(stored.realization.target)
+    : targetText(stored.realization.runner)
+
 const borrowKey = (borrow: Hir.BorrowId): string =>
   `${borrow.function.sourceId}:${borrow.function.ordinal}:${borrow.callSpan.start}:${borrow.callSpan.end}:${borrow.ordinal}`
 
@@ -2197,6 +2216,7 @@ const cleanupTypes = (cleanup: Ownership.CleanupPlan): ReadonlyArray<SilkType.Ty
     case 'EffectCleanup':
       return [cleanup.type, ...cleanup.slots.flatMap((slot) => cleanupTypes(slot.cleanup))]
     case 'RepresentedCallableCleanup':
+    case 'RepresentedEffectCleanup':
       return [cleanup.type, cleanup.contract]
   }
 }
@@ -2675,10 +2695,20 @@ const suspensionCallTargets = (operation: Operation): ReadonlyArray<SuspensionCa
 }
 
 const originReachableSuspensionFunctions = (self: Module): ReadonlySet<string> => {
+  const realizedSuspendableRunners = self.layout.entries.flatMap((entry) =>
+    entry.representation._tag === 'StoredEffectEnvironment' &&
+    entry.representation.realization.suspendable
+      ? [entry.representation.realization]
+      : [],
+  )
   const reachable = new Set(
     self.functions
-      .filter((fn) =>
-        fn.suspension?.regions.some((region) => region._tag === 'SuspendEffectRegion'),
+      .filter(
+        (fn) =>
+          fn.suspension?.regions.some((region) => region._tag === 'SuspendEffectRegion') ||
+          realizedSuspendableRunners.some((realization) =>
+            matchesInstance(fn, realization.runner, realization.runnerArguments),
+          ),
       )
       .map((fn) => instanceText(fn.instance)),
   )
@@ -4200,6 +4230,9 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
               (dropped?._tag === 'CallableValue' &&
                 dropped.storage !== undefined &&
                 SilkType.equals(dropped.storage.realization.contract, cleanup.type)) ||
+              (dropped?._tag === 'EffectValue' &&
+                dropped.storage !== undefined &&
+                SilkType.equals(dropped.storage.realization.contract, cleanup.type)) ||
               (SilkType.isEffect(droppedSemantic) &&
                 SilkType.isEffect(cleanup.type) &&
                 (() => {
@@ -4251,11 +4284,26 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                   endedLoans >= borrowed
                 )
               })())
+          const effectCleanupValid =
+            cleanup._tag !== 'EffectCleanup' ||
+            (dropped?._tag === 'EffectValue' &&
+              Hir.sameExecutableSite(cleanup.site, dropped.site) &&
+              (() => {
+                const owned = dropped.storage?.realization.cleanup.unrunLanes
+                if (owned === undefined) return true
+                let previous = Number.POSITIVE_INFINITY
+                return cleanup.slots.every((slot) => {
+                  const ordered = slot.ordinal < previous
+                  previous = slot.ordinal
+                  return ordered && owned.includes(slot.ordinal)
+                })
+              })())
           if (
             dropped === undefined ||
             !cleanupTypeMatches ||
             !unionCasesValid ||
-            !callableCleanupValid
+            !callableCleanupValid ||
+            !effectCleanupValid
           ) {
             violations.push(
               Object.freeze({
@@ -4277,8 +4325,8 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
             operation.fields.every((field, ordinal) => {
               const declared = expected.at(ordinal)
               const valueType = fn.localTypes.at(field.value.ordinal)
-              const storedValid =
-                field.stored !== undefined &&
+              const storedCallableValid =
+                field.stored?._tag === 'StoredCallableField' &&
                 declared !== undefined &&
                 valueType?._tag === 'CallableValue' &&
                 SilkType.equals(field.stored.type, declared.type) &&
@@ -4292,11 +4340,30 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                 field.stored.realization.field.ordinal === field.field.ordinal &&
                 field.stored.realization.instance.module === operation.type.type.module &&
                 field.stored.realization.instance.name === operation.type.type.name
+              const storedEffectValid =
+                field.stored?._tag === 'StoredEffectField' &&
+                declared !== undefined &&
+                valueType?._tag === 'EffectValue' &&
+                SilkType.equals(field.stored.type, declared.type) &&
+                TypeCompatibility.isCompatible(
+                  TypeCompatibility.check(valueType.type, field.stored.realization.contract),
+                ) &&
+                Hir.sameExecutableSite(valueType.site, field.stored.realization.site) &&
+                Hir.effectRunnerId(valueType.environment.instance.declaration, valueType.site)
+                  .module === field.stored.realization.runner.module &&
+                Hir.effectRunnerId(valueType.environment.instance.declaration, valueType.site)
+                  .name === field.stored.realization.runner.name &&
+                field.stored.realization.field.ordinal === field.field.ordinal &&
+                field.stored.realization.instance.module === operation.type.type.module &&
+                field.stored.realization.instance.name === operation.type.type.name
               return (
                 declared !== undefined &&
                 declared.id.ordinal === field.field.ordinal &&
                 valueType !== undefined &&
-                (SilkType.equals(semanticType(valueType), declared.type) || storedValid)
+                ((field.stored === undefined &&
+                  SilkType.equals(semanticType(valueType), declared.type)) ||
+                  storedCallableValid ||
+                  storedEffectValid)
               )
             })
           if (!valid) {
@@ -4413,6 +4480,23 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                 candidate.callable?.ordinal === operation.destination.ordinal &&
                 (candidate.access === 'Shared' || candidate.access === 'Exclusive'),
             )
+          const effectViewProjection =
+            operation._tag === 'ReadPlace' &&
+            operation.consume !== true &&
+            operation.type._tag === 'EffectValue' &&
+            operation.type.storage !== undefined &&
+            (operation.type.type.access === 'Shared' ||
+              operation.type.type.access === 'Exclusive') &&
+            operations.filter((candidate) =>
+              accessedOwnerLocals(candidate).some(
+                (local) => local.ordinal === operation.destination.ordinal,
+              ),
+            ).length === 1 &&
+            operations.some(
+              (candidate) =>
+                candidate._tag === 'RunEffectValue' &&
+                candidate.effect.ordinal === operation.destination.ordinal,
+            )
           if (
             selected === undefined ||
             !SilkType.equals(selected, semanticType(operation.type)) ||
@@ -4421,7 +4505,8 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
               operation.consume !== true &&
               !sharedMatchProjection &&
               !sharedBorrowProjection &&
-              !callableViewProjection)
+              !callableViewProjection &&
+              !effectViewProjection)
           ) {
             violations.push(
               Object.freeze({
@@ -4738,6 +4823,99 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
                 function: fn.id,
                 region: region.id,
                 detail: 'run propagation does not preserve canonical outcome contracts',
+              }),
+            )
+        }
+        if (operation._tag === 'RunEffectValue') {
+          const effect = fn.localTypes.at(operation.effect.ordinal)
+          const outcome = fn.localTypes.at(operation.outcome.ordinal)
+          const destination = fn.localTypes.at(operation.destination.ordinal)
+          const runner = self.functions.find((candidate) =>
+            matchesInstance(candidate, operation.runner, operation.runnerTypeArguments),
+          )
+          const suspensionRegion = fn.suspension?.regions.find(
+            (candidate) =>
+              candidate.operation._tag === 'RunEffectValue' &&
+              (candidate._tag === 'RunSuspendableEffectRegion'
+                ? candidate.runner.declaration?.module === operation.runner.module &&
+                  candidate.runner.declaration.name === operation.runner.name
+                : candidate.deferred.declaration?.module === operation.runner.module &&
+                  candidate.deferred.declaration.name === operation.runner.name),
+          )
+          const suspensionRunner =
+            suspensionRegion?._tag === 'RunSuspendableEffectRegion'
+              ? suspensionRegion.runner
+              : suspensionRegion?.deferred
+          const mappingsValid =
+            operation.propagationType === undefined
+              ? operation.tagMappings.length === 0
+              : operation.tagMappings.length === operation.outcomeType.type.failures.length &&
+                operation.tagMappings.every((mapping) => {
+                  const source = operation.outcomeType.type.failures.at(mapping.source - 1)
+                  const targetFailure = operation.propagationType?.type.failures.at(
+                    mapping.target - 1,
+                  )
+                  return (
+                    source !== undefined &&
+                    targetFailure !== undefined &&
+                    SilkType.equals(source, targetFailure)
+                  )
+                })
+          const effectValue = effect?._tag === 'EffectValue' ? effect : undefined
+          const stored = effectValue?.storage
+          const storedContractValid =
+            stored === undefined ||
+            (effectValue !== undefined &&
+              SilkType.equals(effectValue.type, stored.realization.contract) &&
+              effectValue.type.access === stored.realization.access &&
+              effectValue.type.failures.length === stored.realization.rows.failures.length &&
+              effectValue.type.failures.every((failure, ordinal) => {
+                const expected = stored.realization.rows.failures.at(ordinal)
+                return expected !== undefined && SilkType.equals(failure, expected)
+              }) &&
+              effectValue.type.requirements.length ===
+                stored.realization.rows.requirements.length &&
+              effectValue.type.requirements.every((requirement, ordinal) => {
+                const expected = stored.realization.rows.requirements.at(ordinal)
+                return (
+                  expected !== undefined &&
+                  requirement.access === expected.access &&
+                  requirement.role === expected.role &&
+                  SilkType.equals(requirement.capability, expected.capability)
+                )
+              }))
+          const directStoredRunner =
+            stored === undefined ||
+            operation.arguments.length > 0 ||
+            (operation.runner.module === stored.realization.runner.module &&
+              operation.runner.name === stored.realization.runner.name &&
+              operation.runnerTypeArguments.length === stored.realization.runnerArguments.length &&
+              operation.runnerTypeArguments.every((argument, ordinal) => {
+                const expected = stored.realization.runnerArguments.at(ordinal)
+                return expected !== undefined && SilkType.equalsGenericArgument(argument, expected)
+              }))
+          const valid =
+            effectValue !== undefined &&
+            outcome?._tag === 'EffectOutcome' &&
+            destination !== undefined &&
+            SilkType.equals(effectValue.type, operation.outcomeType.type) &&
+            SilkType.equals(outcome.type, operation.outcomeType.type) &&
+            SilkType.equals(semanticType(destination), semanticType(operation.type)) &&
+            ((runner?.result._tag === 'EffectOutcome' &&
+              SilkType.equals(runner.result.type, operation.outcomeType.type)) ||
+              (suspensionRunner !== undefined &&
+                SilkType.equals(suspensionRunner.outcome, operation.outcomeType.type))) &&
+            storedContractValid &&
+            directStoredRunner &&
+            mappingsValid
+          if (stored !== undefined && !valid)
+            violations.push(
+              Object.freeze({
+                _tag: 'Violation',
+                rule: 'InvalidEffectOperation',
+                function: fn.id,
+                region: region.id,
+                detail: `stored Effect run disagrees with its static runner, exact rows, access, outcome, or propagation contract (target=${targetText(operation.runner)}, effect=${effectValue !== undefined}, runner=${runner !== undefined}, suspension-runner=${suspensionRunner !== undefined}, stored-contract=${storedContractValid}, static-runner=${directStoredRunner}, mappings=${mappingsValid})`,
               }),
             )
         }
@@ -5086,7 +5264,7 @@ const operationText = (operation: Operation): string => {
     case 'CloseEffectEntry':
       return `${localText(operation.destination)} = close-effect-entry ${targetText(operation.target)} effect=${localText(operation.effect)} runner=${targetText(operation.runner)} outcome=${localText(operation.outcome)} failures=${operation.failures.map((failure) => `${failure.tag}:${SilkType.encode(failure.type)}->${localText(failure.payload)}:${failure.cleanup._tag}`).join(',') || 'none'} : i32 ${provenanceText(operation.provenance)}`
     case 'Construct':
-      return `${localText(operation.destination)} = construct ${typeText(operation.type)} { ${operation.fields.map(({ field, value, stored }) => `#${field.ordinal}: ${localText(value)}${stored === undefined ? '' : ` stored=${storedCallableTargetText(stored.realization.target)}`}`).join(', ')} } ${provenanceText(operation.provenance)}`
+      return `${localText(operation.destination)} = construct ${typeText(operation.type)} { ${operation.fields.map(({ field, value, stored }) => `#${field.ordinal}: ${localText(value)}${stored === undefined ? '' : ` stored=${storedExecutableText(stored)}`}`).join(', ')} } ${provenanceText(operation.provenance)}`
     case 'ConstructArray':
       return `${localText(operation.destination)} = construct-array ${typeText(operation.type)} [${operation.elements.map(localText).join(', ')}] ${provenanceText(operation.provenance)}`
     case 'Project':

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -178,6 +178,12 @@ export type CleanupPlan =
       readonly contract: Type.Callable
     }
   | {
+      /** The complete stored Effect environment is selected only after instance layout. */
+      readonly _tag: 'RepresentedEffectCleanup'
+      readonly type: Type.Represented
+      readonly contract: Type.Effect
+    }
+  | {
       readonly _tag: 'EffectCleanup'
       readonly type: Type.Effect
       readonly site: Hir.EffectSiteId
@@ -892,11 +898,7 @@ const checkExpression = (
       if (stored !== undefined) state.diagnostics.push(stored)
       const storedContract = storedEffectContract(expression.subject)
       const rootSite = placeSite(expression.subject)
-      if (
-        storedContract?.access === 'Take' &&
-        stored === undefined &&
-        rootSite !== undefined
-      ) {
+      if (storedContract?.access === 'Take' && stored === undefined && rootSite !== undefined) {
         // A stored consuming Effect owns its environment through the aggregate. Running it moves
         // the complete root in one use, including through nested field projections; the Effect
         // field is never extracted as an independently owned value.
@@ -1833,10 +1835,10 @@ const analyzeLoans = (fn: Elaboration.FunctionFact): LoanAnalysis => {
             'Read',
             initializerType._tag === 'Available' && Type.isEffect(initializerType.type)
               ? (runEnds.get(statement.binding.id.ordinal) ??
-                callableEnds.get(statement.binding.id.ordinal) ?? {
-                  region: statement.region,
-                  span: fn.declaration.syntax.span,
-                })
+                  callableEnds.get(statement.binding.id.ordinal) ?? {
+                    region: statement.region,
+                    span: fn.declaration.syntax.span,
+                  })
               : // A binding that stores an executable holds its captured borrows for as long as it
                 // holds that environment, whether it is the binding's own value or sits in a field
                 // of the aggregate it names.
@@ -1993,12 +1995,14 @@ export const cleanupPlan = (
     })
   }
   if (Type.isCallable(type)) return Object.freeze({ _tag: 'NoCleanup', type })
-  // A stored callable representation owes its enclosing aggregate an exactly-once release of every
-  // owned capture lane. A stored Effect representation is issue #190's obligation, not this one.
+  // A stored executable representation owes its enclosing aggregate an exactly-once release of
+  // every owned environment lane. Concrete specialization resolves the shared realization.
   if (Type.isRepresented(type))
     return Type.isCallable(type.contract)
       ? Object.freeze({ _tag: 'RepresentedCallableCleanup', type, contract: type.contract })
-      : Object.freeze({ _tag: 'NoCleanup', type })
+      : Type.isEffect(type.contract)
+        ? Object.freeze({ _tag: 'RepresentedEffectCleanup', type, contract: type.contract })
+        : Object.freeze({ _tag: 'NoCleanup', type })
   const key = Type.key(type)
   if (seen.has(key)) return Object.freeze({ _tag: 'NoCleanup', type })
   const declaration = DeclarationIndex.byCanonical(index, {
@@ -2213,6 +2217,14 @@ export const specializeCleanup = (
             type,
             contract: type.contract,
           })
+        : resolved
+    }
+    case 'RepresentedEffectCleanup': {
+      if (!Type.isRepresented(type) || !Type.isEffect(type.contract))
+        return Object.freeze({ _tag: 'NoCleanup', type })
+      const resolved = resolveConcrete?.(type)
+      return resolved === undefined
+        ? Object.freeze({ _tag: 'RepresentedEffectCleanup', type, contract: type.contract })
         : resolved
     }
   }
@@ -2869,6 +2881,9 @@ const cleanupText = (cleanup: CleanupPlan): string => {
   }
   if (cleanup._tag === 'RepresentedCallableCleanup') {
     return `represented-callable:${Type.encode(cleanup.contract)}`
+  }
+  if (cleanup._tag === 'RepresentedEffectCleanup') {
+    return `represented-effect:${Type.encode(cleanup.contract)}`
   }
   if (cleanup._tag === 'HookCleanup') {
     return `hook:${Type.encode(cleanup.type)} target=${cleanup.hook.module}.${cleanup.hook.name}${

--- a/packages/compiler/src/Ownership.ts
+++ b/packages/compiler/src/Ownership.ts
@@ -401,9 +401,9 @@ const placeSite = (expression: Hir.Expression): BindingSite | undefined => {
 
 /**
  * Names the dedicated extraction rejection when a place resolves to a field holding a concrete
- * callable representation. Extracting one would leave the aggregate owning a partially released
- * environment, so its captures could be cleaned twice; consuming invocation takes the whole
- * aggregate instead. Every other partial move keeps the general struct-field rejection.
+ * executable representation. Extracting one would leave the aggregate owning a partially released
+ * environment, so its captures could be cleaned twice; consuming invocation or execution takes the
+ * whole aggregate instead. Every other partial move keeps the general struct-field rejection.
  */
 const representationFieldExtraction = (
   place: Hir.Expression,
@@ -411,7 +411,11 @@ const representationFieldExtraction = (
 ): Diagnostic.Diagnostic | undefined => {
   if (place._tag !== 'Project') return undefined
   const type = place.type
-  if (!Type.isRepresented(type) || !Type.isCallable(type.contract)) return undefined
+  if (
+    !Type.isRepresented(type) ||
+    (!Type.isCallable(type.contract) && !Type.isEffect(type.contract))
+  )
+    return undefined
   return Diagnostic.representationFieldExtraction(
     Type.encode(place.nominal),
     `#${place.field.ordinal}`,
@@ -886,6 +890,20 @@ const checkExpression = (
     case 'Run': {
       const stored = storedEffectRunAccess(state, expression.subject, expression.span)
       if (stored !== undefined) state.diagnostics.push(stored)
+      const storedContract = storedEffectContract(expression.subject)
+      const rootSite = placeSite(expression.subject)
+      if (
+        storedContract?.access === 'Take' &&
+        stored === undefined &&
+        rootSite !== undefined
+      ) {
+        // A stored consuming Effect owns its environment through the aggregate. Running it moves
+        // the complete root in one use, including through nested field projections; the Effect
+        // field is never extracted as an independently owned value.
+        checkPlaceInterior(state, live, expression.subject, guard, escaping)
+        checkUse(state, live, rootSite, placeRoot(expression.subject).span, true)
+        return
+      }
       const site = useSite(expression.subject)
       if (
         site !== undefined &&
@@ -1327,42 +1345,45 @@ const analyzeLoans = (fn: Elaboration.FunctionFact): LoanAnalysis => {
   }
   scanStatementRunEnds(fn.statements)
 
-  const movedCallableBindings = (expression: Elaboration.ExpressionFact): ReadonlyArray<number> => {
-    if (expression._tag === 'Grouped') return movedCallableBindings(expression.expression)
+  const movedExecutableBindings = (
+    expression: Elaboration.ExpressionFact,
+  ): ReadonlyArray<number> => {
+    if (expression._tag === 'Grouped') return movedExecutableBindings(expression.expression)
     if (expression._tag === 'Move') {
       const site = directSite(expression.subject)?.site
       return site?._tag === 'Let' &&
         expression.subject.type._tag === 'Available' &&
-        Type.containsCallableRepresentation(expression.subject.type.type)
+        (Type.isEffect(expression.subject.type.type) ||
+          Type.containsExecutableRepresentation(expression.subject.type.type))
         ? Object.freeze([site.binding.ordinal])
-        : movedCallableBindings(expression.subject)
+        : movedExecutableBindings(expression.subject)
     }
     if (expression._tag === 'StructLiteral')
       return Object.freeze(
         expression.initializers.flatMap((initializer) =>
-          movedCallableBindings(initializer.expression),
+          movedExecutableBindings(initializer.expression),
         ),
       )
     if (expression._tag === 'ArrayLiteral')
       return Object.freeze(
-        expression.elements.flatMap((element) => movedCallableBindings(element.expression)),
+        expression.elements.flatMap((element) => movedExecutableBindings(element.expression)),
       )
     return Object.freeze([])
   }
-  const callableAliases = new Map<number, number>()
+  const executableAliases = new Map<number, number>()
   for (const binding of fn.bindings) {
-    for (const source of movedCallableBindings(binding.initializer)) {
-      callableAliases.set(source, binding.id.ordinal)
+    for (const source of movedExecutableBindings(binding.initializer)) {
+      executableAliases.set(source, binding.id.ordinal)
     }
   }
-  let propagatedCallableEnd = true
-  while (propagatedCallableEnd) {
-    propagatedCallableEnd = false
-    for (const [source, destination] of callableAliases) {
+  let propagatedExecutableEnd = true
+  while (propagatedExecutableEnd) {
+    propagatedExecutableEnd = false
+    for (const [source, destination] of executableAliases) {
       const ending = callableEnds.get(destination)
       if (ending === undefined || callableEnds.get(source) === ending) continue
       callableEnds.set(source, ending)
-      propagatedCallableEnd = true
+      propagatedExecutableEnd = true
     }
   }
 
@@ -1811,16 +1832,17 @@ const analyzeLoans = (fn: Elaboration.FunctionFact): LoanAnalysis => {
             [],
             'Read',
             initializerType._tag === 'Available' && Type.isEffect(initializerType.type)
-              ? (runEnds.get(statement.binding.id.ordinal) ?? {
+              ? (runEnds.get(statement.binding.id.ordinal) ??
+                callableEnds.get(statement.binding.id.ordinal) ?? {
                   region: statement.region,
                   span: fn.declaration.syntax.span,
                 })
-              : // A binding that stores a callable holds its captured borrows for as long as it
-                // holds the callable, whether the callable is the binding's own value or sits in a
-                // field of the aggregate it names.
+              : // A binding that stores an executable holds its captured borrows for as long as it
+                // holds that environment, whether it is the binding's own value or sits in a field
+                // of the aggregate it names.
                 initializerType._tag === 'Available' &&
                   (Type.isCallable(initializerType.type) ||
-                    Type.containsCallableRepresentation(initializerType.type))
+                    Type.containsExecutableRepresentation(initializerType.type))
                 ? (callableEnds.get(statement.binding.id.ordinal) ?? {
                     region: statement.region,
                     span: fn.declaration.syntax.span,

--- a/packages/compiler/src/ProvisionalMir.ts
+++ b/packages/compiler/src/ProvisionalMir.ts
@@ -303,6 +303,17 @@ const storedEffectRealizationOf = (
   expression: Hir.Expression,
   context: BuildContext,
 ): CallableFieldRealization.EffectRealization | undefined => {
+  if (expression._tag === 'BindingReference') {
+    const initializer = context.bindings.get(expression.binding.ordinal)
+    return initializer === undefined ? undefined : storedEffectRealizationOf(initializer, context)
+  }
+  if (expression._tag === 'Move') return storedEffectRealizationOf(expression.subject, context)
+  if (expression._tag === 'UnionConvert')
+    return storedEffectRealizationOf(expression.source, context)
+  if (expression._tag === 'EffectBindRequirement')
+    return storedEffectRealizationOf(expression.protected, context)
+  if (expression._tag === 'EffectResult')
+    return storedEffectRealizationOf(expression.protected, context)
   if (expression._tag !== 'Project') return undefined
   const represented = Type.substitute(expression.type, context.instance.substitution)
   const planned = Layout.entry(context.layout, represented)?.representation
@@ -645,6 +656,8 @@ const controlsOf = (
           expression.subject._tag === 'EffectResult'
             ? expression.subject.protected
             : expression.subject
+        const storedSuspendable =
+          storedEffectRealizationOf(protected_, context)?.suspendable === true
         const runner = runnerOf(protected_, context)
         // The concrete fixed point proves that no call or run in this execution can transfer.
         // Stored Effects add their realization's suspendability dependency after the ordinary
@@ -652,7 +665,7 @@ const controlsOf = (
         if (
           executionClassification === 'Synchronous' &&
           !maySpecializeProviders &&
-          runner.classification === 'Synchronous'
+          !storedSuspendable
         ) {
           for (const child of Hir.expressionChildren(expression)) visit(child)
           return

--- a/packages/compiler/src/ProvisionalMir.ts
+++ b/packages/compiler/src/ProvisionalMir.ts
@@ -1,3 +1,4 @@
+import type * as CallableFieldRealization from './CallableFieldRealization.js'
 import * as DeclarationIndex from './DeclarationIndex.js'
 import * as Hir from './Hir.js'
 import * as Instances from './Instances.js'
@@ -298,6 +299,17 @@ interface BuildContext {
   readonly bindings: ReadonlyMap<number, Hir.Expression>
 }
 
+const storedEffectRealizationOf = (
+  expression: Hir.Expression,
+  context: BuildContext,
+): CallableFieldRealization.EffectRealization | undefined => {
+  if (expression._tag !== 'Project') return undefined
+  const represented = Type.substitute(expression.type, context.instance.substitution)
+  const planned = Layout.entry(context.layout, represented)?.representation
+  if (planned?._tag === 'StoredEffectEnvironment') return planned.realization
+  return undefined
+}
+
 const effectIdentityOf = (
   expression: Hir.Expression,
   context: BuildContext,
@@ -311,6 +323,18 @@ const effectIdentityOf = (
   if (expression._tag === 'EffectBindRequirement')
     return effectIdentityOf(expression.protected, context)
   if (expression._tag === 'EffectResult') return effectIdentityOf(expression.protected, context)
+  if (expression._tag === 'Project') {
+    const realization = storedEffectRealizationOf(expression, context)
+    const represented = Type.substitute(expression.type, context.instance.substitution)
+    const retainedIdentity =
+      Type.isRepresented(represented) &&
+      Type.isEffect(represented.contract) &&
+      Type.isExactRepresentationArgument(represented.representation.argument) &&
+      Type.isEffectIdentityArgument(represented.representation.argument.identity)
+        ? represented.representation.argument.identity.identity
+        : undefined
+    return realization?.runnerIdentity ?? retainedIdentity
+  }
   if (expression._tag === 'EffectBlock')
     return Instances.effectIdentity(context.instance.key, expression.site)
   if (expression._tag === 'ParameterReference')
@@ -365,6 +389,7 @@ const providersOf = (
 }
 
 const runnerOf = (expression: Hir.Expression, context: BuildContext): Runner => {
+  const stored = storedEffectRealizationOf(expression, context)
   const identity = effectIdentityOf(expression, context)
   const environment = context.layout.effectEnvironments.find(
     (candidate) =>
@@ -376,7 +401,9 @@ const runnerOf = (expression: Hir.Expression, context: BuildContext): Runner => 
     'type' in expression
       ? Type.substitute(expression.type, context.instance.substitution)
       : Type.effect('never', [])
-  const effect = Type.isEffect(expressionType) ? expressionType : Type.effect(expressionType, [])
+  const effect =
+    stored?.contract ??
+    (Type.isEffect(expressionType) ? expressionType : Type.effect(expressionType, []))
   const providers = providersOf(expression, context)
   if (environment?._tag !== 'EffectEnvironment' || identity === undefined) {
     return Object.freeze({
@@ -393,10 +420,11 @@ const runnerOf = (expression: Hir.Expression, context: BuildContext): Runner => 
   }
   const baseExecution: ExecutionKey = Object.freeze({
     _tag: 'EffectRunnerExecution',
-    owner: environment.instance,
-    site: environment.site,
+    owner: stored?.runnerInstance ?? environment.instance,
+    site: stored?.site ?? environment.site,
     identity,
-    runner: Hir.effectRunnerId(environment.instance.declaration, environment.site),
+    runner:
+      stored?.runner ?? Hir.effectRunnerId(environment.instance.declaration, environment.site),
   })
   const providedIdentity =
     providers.length === 0
@@ -414,7 +442,12 @@ const runnerOf = (expression: Hir.Expression, context: BuildContext): Runner => 
           runner: baseExecution.runner,
           providers,
         })
-  const baseClassification = classificationOfEffect(context.discovery, identity)
+  const baseClassification =
+    stored === undefined
+      ? classificationOfEffect(context.discovery, identity)
+      : stored.suspendable
+        ? 'Suspendable'
+        : 'Synchronous'
   const providedClassification = (): Classification => {
     if (providedIdentity === undefined || baseClassification === 'Suspendable')
       return baseClassification
@@ -462,11 +495,11 @@ const runnerOf = (expression: Hir.Expression, context: BuildContext): Runner => 
     execution,
     classification: providedClassification(),
     declaration: execution.runner,
-    instance: environment.instance,
+    instance: stored?.runnerInstance ?? environment.instance,
     effectIdentity: identity,
     ...(providedIdentity === undefined ? {} : { providedIdentity }),
-    typeArguments: environment.instance.typeArguments,
-    outcome: environment.effect,
+    typeArguments: stored?.runnerArguments ?? environment.instance.typeArguments,
+    outcome: stored?.contract ?? environment.effect,
     captures: Object.freeze(
       environment.fields.map((field, ordinal) =>
         Object.freeze({
@@ -608,17 +641,22 @@ const controlsOf = (
           )
         }
       } else {
-        // The concrete fixed point proves that no call or run in this execution can transfer.
-        // Unknown local origin recovery must not manufacture suspension control in that case.
-        if (executionClassification === 'Synchronous' && !maySpecializeProviders) {
-          for (const child of Hir.expressionChildren(expression)) visit(child)
-          return
-        }
         const protected_ =
           expression.subject._tag === 'EffectResult'
             ? expression.subject.protected
             : expression.subject
         const runner = runnerOf(protected_, context)
+        // The concrete fixed point proves that no call or run in this execution can transfer.
+        // Stored Effects add their realization's suspendability dependency after the ordinary
+        // execution fixed point, so that exact runner may still require relay control here.
+        if (
+          executionClassification === 'Synchronous' &&
+          !maySpecializeProviders &&
+          runner.classification === 'Synchronous'
+        ) {
+          for (const child of Hir.expressionChildren(expression)) visit(child)
+          return
+        }
         if (runner.classification !== 'Synchronous') {
           const policy =
             expression.subject._tag === 'EffectResult'
@@ -672,6 +710,16 @@ const controlsOf = (
   return Object.freeze(regions)
 }
 
+const classificationWithRegions = (
+  base: Classification,
+  regions: ReadonlyArray<Region>,
+): Classification =>
+  regions.reduce<Classification>((classification, region) => {
+    if (region.outcome._tag !== 'RunSuspendableEffect') return classification
+    if (region.outcome.runner.classification === 'Suspendable') return 'Suspendable'
+    return classification === 'Synchronous' ? 'Unknown' : classification
+  }, base)
+
 /** Builds deterministic provisional control without producing executable final MIR. */
 export const build = (
   discovery: Instances.Discovery,
@@ -699,17 +747,18 @@ export const build = (
     )
       ? 'Suspendable'
       : 'Synchronous'
+    const instanceRegions = controlsOf(
+      instance.function.statements,
+      instanceKey,
+      instanceClassification,
+      context,
+    )
     executions.push(
       Object.freeze({
         _tag: 'ProvisionalExecution',
         key: instanceKey,
-        classification: instanceClassification,
-        regions: controlsOf(
-          instance.function.statements,
-          instanceKey,
-          instanceClassification,
-          context,
-        ),
+        classification: classificationWithRegions(instanceClassification, instanceRegions),
+        regions: instanceRegions,
       }),
     )
     for (const expression of instance.function.statements
@@ -730,11 +779,7 @@ export const build = (
         bindings: new Map([...context.bindings, ...bindingsOfStatements(expression.statements)]),
       }
       const regions = controlsOf(expression.statements, key, runnerClassification, runnerContext)
-      const specializedClassification = regions.reduce<Classification>((classification, region) => {
-        if (region.outcome._tag !== 'RunSuspendableEffect') return classification
-        if (region.outcome.runner.classification === 'Suspendable') return 'Suspendable'
-        return classification === 'Synchronous' ? 'Unknown' : classification
-      }, runnerClassification)
+      const specializedClassification = classificationWithRegions(runnerClassification, regions)
       executions.push(
         Object.freeze({
           _tag: 'ProvisionalExecution',

--- a/packages/compiler/src/Type.ts
+++ b/packages/compiler/src/Type.ts
@@ -1833,6 +1833,24 @@ export const containsCallableRepresentation = (self: Type): boolean => {
   return false
 }
 
+/** Tests whether a value stores one statically known Effect environment anywhere inside it. */
+export const containsEffectRepresentation = (self: Type): boolean => {
+  if (isRepresented(self)) return isEffect(self.contract)
+  if (isNominal(self))
+    return self.arguments.some(
+      (argument) =>
+        (isExactRepresentationArgument(argument) && isEffectIdentityArgument(argument.identity)) ||
+        (isTypeArgument(argument) && containsEffectRepresentation(argument)),
+    )
+  if (isFixedArray(self)) return containsEffectRepresentation(self.element)
+  if (isUnion(self)) return self.members.some(containsEffectRepresentation)
+  return false
+}
+
+/** Tests for either concrete executable environment carried through an enclosing value. */
+export const containsExecutableRepresentation = (self: Type): boolean =>
+  containsCallableRepresentation(self) || containsEffectRepresentation(self)
+
 /** Tests for explicit borrow wrappers forbidden inside ordinary type positions. */
 export const containsPositionRestrictedBorrow = (self: Type): boolean => {
   if (isString(self)) return false

--- a/packages/compiler/test/StoredCallableCleanup.test.ts
+++ b/packages/compiler/test/StoredCallableCleanup.test.ts
@@ -394,7 +394,7 @@ pub fn main() -> i32 {
   }),
 )
 
-it.effect('leaves a stored Effect representation without a callable obligation', () =>
+it.effect('records a distinct symbolic cleanup obligation for a stored Effect', () =>
   Effect.gen(function* () {
     const module = 'stored-callable-cleanup/effect'
     const snapshot = yield* realized(
@@ -407,7 +407,6 @@ pub fn main() -> i32 {
     )
     const stored = fieldCleanup(bindingCleanup(snapshot, module, 'deferred'), 0)
 
-    // Stored Effect storage is a separate change's obligation and stays exactly as it was.
-    assert.strictEqual(stored._tag, 'NoCleanup')
+    assert.strictEqual(stored._tag, 'RepresentedEffectCleanup')
   }),
 )

--- a/packages/compiler/test/StoredCallableMir.test.ts
+++ b/packages/compiler/test/StoredCallableMir.test.ts
@@ -61,9 +61,11 @@ pub fn main() -> i32 {
           : undefined
 
       assert.strictEqual(construction?._tag, 'Construct')
+      const constructionStorage =
+        construction?._tag === 'Construct' ? construction.fields.at(0)?.stored : undefined
       assert.strictEqual(
-        construction?._tag === 'Construct'
-          ? construction.fields.at(0)?.stored?.realization.target._tag
+        constructionStorage?._tag === 'StoredCallableField'
+          ? constructionStorage.realization.target._tag
           : undefined,
         'Declaration',
       )

--- a/packages/compiler/test/StoredEffectCleanupVerification.test.ts
+++ b/packages/compiler/test/StoredEffectCleanupVerification.test.ts
@@ -1,0 +1,203 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Layout from '../src/Layout.js'
+import * as Lower from '../src/Lower.js'
+import * as Mir from '../src/Mir.js'
+import * as OpaqueRealization from '../src/OpaqueRealization.js'
+import type * as Ownership from '../src/Ownership.js'
+import * as Target from '../src/Target.js'
+import { unreachable } from './support/raise.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const lowerStored = Effect.fnUntraced(function* (name: string, source: string) {
+  const snapshot = yield* Analysis.ofSourceRealized(
+    name,
+    ascii(source),
+    Target.wasm32UnknownUnknown.id,
+  )
+  const catalog = Layout.catalog(Target.wasm32UnknownUnknown, snapshot.index, snapshot.instances)
+  const layout = Layout.plan(catalog, snapshot.instances)
+  const ownership = Analysis.ownershipOf(snapshot, name) ?? unreachable('expected module ownership')
+  return Lower.lowerProgram(
+    snapshot.instances,
+    new Map<string, Ownership.ModuleOwnership>([[name, ownership]]),
+    layout,
+    snapshot.index,
+    OpaqueRealization.catalogOf(snapshot),
+  )
+})
+
+const replaceDrop = (
+  module: Mir.Module,
+  target: Extract<Mir.Operation, { readonly _tag: 'Drop' }>,
+  replacement: Extract<Mir.Operation, { readonly _tag: 'Drop' }>,
+): Mir.Module =>
+  Object.freeze({
+    ...module,
+    functions: Object.freeze(
+      module.functions.map((fn) =>
+        Object.freeze({
+          ...fn,
+          regions: Object.freeze(
+            fn.regions.map((region) =>
+              region._tag === 'OperationRegion'
+                ? Object.freeze({
+                    ...region,
+                    operations: Object.freeze(
+                      region.operations.map((operation) =>
+                        operation === target ? replacement : operation,
+                      ),
+                    ),
+                  })
+                : region._tag === 'CleanupRegion'
+                  ? Object.freeze({
+                      ...region,
+                      releases: Object.freeze(
+                        region.releases.map((operation) =>
+                          operation === target ? replacement : operation,
+                        ),
+                      ),
+                    })
+                  : region,
+            ),
+          ),
+        }),
+      ),
+    ),
+  })
+
+it.effect('rejects incomplete cleanup inside nested Effect and callable captures', () =>
+  Effect.gen(function* () {
+    const module = yield* lowerStored(
+      'stored-effect-cleanup-verification/nested-executables',
+      `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(value: i32, token: Token) -> i32 { return value + token.value }
+pub fn main() -> i32 {
+  let effectToken = Token { value: 1 }
+  let nested = effect { return consume(1, move effectToken) }
+  let callableToken = Token { value: 2 }
+  let transform = consume(move callableToken)
+  let deferred = Deferred { operation: effect {
+    let value = run move nested
+    let ownedTransform = move transform
+    return ownedTransform(value)
+  } }
+  return 0
+}`,
+    )
+    assert.deepEqual(Mir.verify(module), [])
+    const construct = module.functions
+      .flatMap(Mir.operations)
+      .find(
+        (operation) =>
+          operation._tag === 'Construct' &&
+          operation.fields.some((field) => field.stored?._tag === 'StoredEffectField'),
+      )
+    const stored =
+      construct?._tag === 'Construct'
+        ? construct.fields.find((field) => field.stored?._tag === 'StoredEffectField')?.stored
+        : undefined
+    assert.strictEqual(stored?._tag, 'StoredEffectField')
+    if (stored?._tag !== 'StoredEffectField') return
+    assert.deepEqual(
+      stored.realization.environment.map((field) => ({
+        access: field.access,
+        effect: field.effectIdentity !== undefined,
+        callable: field.callableIdentity !== undefined,
+      })),
+      [
+        { access: 'Take', effect: true, callable: false },
+        { access: 'Take', effect: false, callable: true },
+      ],
+    )
+
+    const drop = module.functions
+      .flatMap(Mir.operations)
+      .find(
+        (operation): operation is Extract<Mir.Operation, { readonly _tag: 'Drop' }> =>
+          operation._tag === 'Drop' &&
+          operation.cleanup._tag === 'StructCleanup' &&
+          operation.cleanup.fields.some((field) => field.cleanup._tag === 'EffectCleanup'),
+      )
+    assert.isDefined(drop)
+    if (drop === undefined || drop.cleanup._tag !== 'StructCleanup') return
+    const structCleanup = drop.cleanup
+    const outerField = structCleanup.fields.find((field) => field.cleanup._tag === 'EffectCleanup')
+    assert.strictEqual(outerField?.cleanup._tag, 'EffectCleanup')
+    if (outerField?.cleanup._tag !== 'EffectCleanup') return
+    const outer = outerField.cleanup
+    assert.deepEqual(
+      outer.slots.map((slot) => slot.cleanup._tag),
+      ['CallableCleanup', 'EffectCleanup'],
+    )
+    const effectSlot = outer.slots.find((slot) => slot.cleanup._tag === 'EffectCleanup')
+    const callableSlot = outer.slots.find((slot) => slot.cleanup._tag === 'CallableCleanup')
+    assert.strictEqual(effectSlot?.cleanup._tag, 'EffectCleanup')
+    assert.strictEqual(callableSlot?.cleanup._tag, 'CallableCleanup')
+    if (
+      effectSlot?.cleanup._tag !== 'EffectCleanup' ||
+      callableSlot?.cleanup._tag !== 'CallableCleanup'
+    )
+      return
+
+    const replaceOuter = (
+      cleanup: Ownership.CleanupPlan,
+      selected: Ownership.CleanupPlan,
+    ): Extract<Mir.Operation, { readonly _tag: 'Drop' }> =>
+      Object.freeze({
+        ...drop,
+        cleanup: Object.freeze({
+          ...structCleanup,
+          fields: Object.freeze(
+            structCleanup.fields.map((field) =>
+              field === outerField
+                ? Object.freeze({
+                    ...field,
+                    cleanup: Object.freeze({
+                      ...outer,
+                      slots: Object.freeze(
+                        outer.slots.map((slot) =>
+                          slot.cleanup === selected ? Object.freeze({ ...slot, cleanup }) : slot,
+                        ),
+                      ),
+                    }),
+                  })
+                : field,
+            ),
+          ),
+        }),
+      })
+
+    const nestedEffectSlot =
+      effectSlot.cleanup.slots.at(0) ?? unreachable('expected nested Effect cleanup slot')
+    const malformed: ReadonlyArray<readonly [Ownership.CleanupPlan, Ownership.CleanupPlan]> = [
+      [Object.freeze({ _tag: 'NoCleanup', type: effectSlot.cleanup.type }), effectSlot.cleanup],
+      [
+        Object.freeze({
+          ...effectSlot.cleanup,
+          slots: Object.freeze([
+            Object.freeze({
+              ...nestedEffectSlot,
+              laneOffset: nestedEffectSlot.laneOffset + 1,
+            }),
+          ]),
+        }),
+        effectSlot.cleanup,
+      ],
+      [Object.freeze({ _tag: 'NoCleanup', type: callableSlot.cleanup.type }), callableSlot.cleanup],
+      [Object.freeze({ ...callableSlot.cleanup, slots: Object.freeze([]) }), callableSlot.cleanup],
+    ]
+    for (const [cleanup, selected] of malformed) {
+      assert.include(
+        Mir.verify(replaceDrop(module, drop, replaceOuter(cleanup, selected))).map(
+          (violation) => violation.rule,
+        ),
+        'InvalidAggregateOperation',
+      )
+    }
+  }),
+)

--- a/packages/compiler/test/StoredEffectCleanupVerification.test.ts
+++ b/packages/compiler/test/StoredEffectCleanupVerification.test.ts
@@ -21,13 +21,14 @@ const lowerStored = Effect.fnUntraced(function* (name: string, source: string) {
   const catalog = Layout.catalog(Target.wasm32UnknownUnknown, snapshot.index, snapshot.instances)
   const layout = Layout.plan(catalog, snapshot.instances)
   const ownership = Analysis.ownershipOf(snapshot, name) ?? unreachable('expected module ownership')
-  return Lower.lowerProgram(
+  const module = Lower.lowerProgram(
     snapshot.instances,
     new Map<string, Ownership.ModuleOwnership>([[name, ownership]]),
     layout,
     snapshot.index,
     OpaqueRealization.catalogOf(snapshot),
   )
+  return Object.freeze({ catalog, module })
 })
 
 const replaceDrop = (
@@ -71,7 +72,7 @@ const replaceDrop = (
 
 it.effect('rejects incomplete cleanup inside nested Effect and callable captures', () =>
   Effect.gen(function* () {
-    const module = yield* lowerStored(
+    const { catalog, module } = yield* lowerStored(
       'stored-effect-cleanup-verification/nested-executables',
       `struct Token<F: once fn(i32) -> i32> { value: i32 marker: F }
 struct Deferred<F: once Effect<i32>> { operation: F }
@@ -182,6 +183,38 @@ pub fn main() -> i32 {
       effectSlot.cleanup.slots.at(0) ?? unreachable('expected nested Effect cleanup slot')
     assert.strictEqual(nestedEffectSlot.cleanup._tag, 'HookCleanup')
     if (nestedEffectSlot.cleanup._tag !== 'HookCleanup') return
+    const hookedEntry = module.layout.entries.find(
+      (entry): entry is Layout.Entry =>
+        entry._tag === 'LayoutEntry' &&
+        entry.representation._tag === 'Aggregate' &&
+        entry.representation.cleanupHook !== undefined &&
+        Layout.catalogEntry(catalog, entry.type)?._tag === 'LayoutEntry',
+    )
+    assert.isDefined(hookedEntry)
+    if (hookedEntry === undefined || hookedEntry.representation._tag !== 'Aggregate') return
+    const hookedRepresentation = hookedEntry.representation
+    assert.include(Layout.encode(module.layout), 'cleanup-hook=')
+    const forgedLayout: Layout.Plan = Object.freeze({
+      ...module.layout,
+      entries: Object.freeze(
+        module.layout.entries.map((entry) =>
+          entry === hookedEntry
+            ? Object.freeze({
+                ...entry,
+                representation: Object.freeze({
+                  _tag: 'Aggregate' as const,
+                  fields: hookedRepresentation.fields,
+                  tailPadding: hookedRepresentation.tailPadding,
+                }),
+              })
+            : entry,
+        ),
+      ),
+    })
+    assert.include(
+      Layout.verifyAgainstCatalog(forgedLayout, catalog).map((violation) => violation.rule),
+      'CatalogMismatch',
+    )
     const strippedHook: Ownership.CleanupPlan = Object.freeze({
       ...effectSlot.cleanup,
       slots: Object.freeze([

--- a/packages/compiler/test/StoredEffectCleanupVerification.test.ts
+++ b/packages/compiler/test/StoredEffectCleanupVerification.test.ts
@@ -73,13 +73,19 @@ it.effect('rejects incomplete cleanup inside nested Effect and callable captures
   Effect.gen(function* () {
     const module = yield* lowerStored(
       'stored-effect-cleanup-verification/nested-executables',
-      `struct Token { value: i32 }
+      `struct Token<F: once fn(i32) -> i32> { value: i32 marker: F }
 struct Deferred<F: once Effect<i32>> { operation: F }
-fn consume(value: i32, token: Token) -> i32 { return value + token.value }
+fn marker(value: i32) -> i32 { return value }
+fn consume<F: once fn(i32) -> i32>(value: i32, token: Token<F>) -> i32 {
+  return value + token.value
+}
+impl<F: once fn(i32) -> i32> Drop for Token<F> {
+  fn drop(self: &mut Token<F>) -> () { return () }
+}
 pub fn main() -> i32 {
-  let effectToken = Token { value: 1 }
+  let effectToken = Token { value: 1, marker: marker }
   let nested = effect { return consume(1, move effectToken) }
-  let callableToken = Token { value: 2 }
+  let callableToken = Token { value: 2, marker: marker }
   let transform = consume(move callableToken)
   let deferred = Deferred { operation: effect {
     let value = run move nested
@@ -174,8 +180,17 @@ pub fn main() -> i32 {
 
     const nestedEffectSlot =
       effectSlot.cleanup.slots.at(0) ?? unreachable('expected nested Effect cleanup slot')
+    assert.strictEqual(nestedEffectSlot.cleanup._tag, 'HookCleanup')
+    if (nestedEffectSlot.cleanup._tag !== 'HookCleanup') return
+    const strippedHook: Ownership.CleanupPlan = Object.freeze({
+      ...effectSlot.cleanup,
+      slots: Object.freeze([
+        Object.freeze({ ...nestedEffectSlot, cleanup: nestedEffectSlot.cleanup.inner }),
+      ]),
+    })
     const malformed: ReadonlyArray<readonly [Ownership.CleanupPlan, Ownership.CleanupPlan]> = [
       [Object.freeze({ _tag: 'NoCleanup', type: effectSlot.cleanup.type }), effectSlot.cleanup],
+      [strippedHook, effectSlot.cleanup],
       [
         Object.freeze({
           ...effectSlot.cleanup,

--- a/packages/compiler/test/StoredEffectLayout.test.ts
+++ b/packages/compiler/test/StoredEffectLayout.test.ts
@@ -1,0 +1,140 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Layout from '../src/Layout.js'
+import * as Target from '../src/Target.js'
+import * as Type from '../src/Type.js'
+import { unreachable } from './support/raise.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const storedLayout = Effect.fnUntraced(function* (
+  name: string,
+  source: string,
+  target: Target.Target,
+) {
+  const snapshot = yield* Analysis.ofSourceRealized(name, ascii(source), target.id)
+  const catalog = Layout.catalog(target, snapshot.index, snapshot.instances)
+  const plan = Layout.plan(catalog, snapshot.instances)
+  return Object.freeze({ snapshot, catalog, plan })
+})
+
+const representedEntry = (plan: Layout.Plan): Layout.Entry =>
+  plan.entries.find(
+    (entry) =>
+      Type.isRepresented(entry.type) && entry.representation._tag === 'StoredEffectEnvironment',
+  ) ?? unreachable('expected one represented Effect layout')
+
+it.effect('places an owned stored Effect environment inline in its enclosing nominal ABI', () =>
+  Effect.gen(function* () {
+    const source = `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+pub fn main() -> i32 {
+  let token = Token { value: 7 }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  return 0
+}`
+    for (const target of [Target.wasm32UnknownUnknown, Target.aarch64AppleDarwin]) {
+      const { snapshot, catalog, plan } = yield* storedLayout(
+        'stored-effect-layout/owned',
+        source,
+        target,
+      )
+      const represented = representedEntry(plan)
+      const deferred =
+        plan.entries.find(
+          (entry) => Type.isNominal(entry.type) && entry.type.name === 'Deferred',
+        ) ?? unreachable('expected Deferred layout')
+
+      assert.include(
+        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+        'SEM0107',
+      )
+      assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+      assert.strictEqual(represented.representation._tag, 'StoredEffectEnvironment')
+      if (represented.representation._tag !== 'StoredEffectEnvironment') continue
+      assert.deepEqual(
+        represented.representation.fields.map((field) => ({
+          capture: field.capture,
+          access: field.access,
+          representation: field.representation,
+          offset: field.offset,
+          size: field.size,
+        })),
+        [{ capture: 0, access: 'Take', representation: 'Value', offset: 0, size: 4 }],
+      )
+      assert.strictEqual(represented.size, 4)
+      assert.strictEqual(represented.alignment, 4)
+      assert.strictEqual(deferred.representation._tag, 'Aggregate')
+      assert.deepEqual(Layout.verifyCatalog(catalog), [])
+      assert.deepEqual(Layout.verify(plan), [])
+    }
+  }),
+)
+
+it.effect('keeps exact rows compile-time-only and suspendability in the layout dependency', () =>
+  Effect.gen(function* () {
+    const { plan } = yield* storedLayout(
+      'stored-effect-layout/suspending',
+      `struct Deferred<F: Effect<i32>> { operation: F }
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+effect fn delayed() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  let provided = Effect.suspend(effect { return 42 }) |> Effect.provideMut(&mut allocator)
+  return run Effect.catch(move provided, recover)
+}
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return run delayed() } }
+  return 0
+}`,
+      Target.wasm32UnknownUnknown,
+    )
+    const represented = representedEntry(plan)
+
+    assert.strictEqual(represented.representation._tag, 'StoredEffectEnvironment')
+    if (represented.representation._tag !== 'StoredEffectEnvironment') return
+    assert.strictEqual(represented.representation.realization.suspendable, true)
+    assert.deepEqual(
+      represented.representation.realization.rows.failures.map(Type.encode),
+      represented.representation.realization.contract.failures.map(Type.encode),
+    )
+    assert.deepEqual(
+      represented.representation.realization.rows.requirements,
+      represented.representation.realization.contract.requirements,
+    )
+    const shape =
+      plan.callingShapes.find((candidate) => Type.equals(candidate.type, represented.type)) ??
+      unreachable('expected represented Effect calling shape')
+    assert.strictEqual(shape.tree._tag, 'EffectEnvironmentShape')
+    assert.strictEqual(shape.laneCount, represented.representation.fields.length)
+    assert.include(Layout.encode(plan), 'suspendable=yes')
+  }),
+)
+
+it.effect('keeps nested owners deterministic without assigning structural Effect an ABI', () =>
+  Effect.gen(function* () {
+    const source = `struct Deferred<F: Effect<i32>> { operation: F }
+struct Boxed<F: Effect<i32>> { inner: Deferred<F> }
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return 42 } }
+  let boxed = Boxed { inner: move deferred }
+  return 0
+}`
+    const first = yield* storedLayout(
+      'stored-effect-layout/nested',
+      source,
+      Target.wasm32UnknownUnknown,
+    )
+    const second = yield* storedLayout(
+      'stored-effect-layout/nested',
+      source,
+      Target.wasm32UnknownUnknown,
+    )
+
+    assert.strictEqual(Layout.encode(first.plan), Layout.encode(second.plan))
+    assert.deepEqual(Layout.verify(first.plan), [])
+    assert.isFalse(first.plan.entries.some((entry) => Type.isEffect(entry.type)))
+  }),
+)

--- a/packages/compiler/test/StoredEffectLayout.test.ts
+++ b/packages/compiler/test/StoredEffectLayout.test.ts
@@ -178,3 +178,36 @@ pub fn main() -> i32 {
     assert.deepEqual(Layout.verify(plan), [])
   }),
 )
+
+it.effect('preserves local executable identities through recursively nested Effects', () =>
+  Effect.gen(function* () {
+    const { plan } = yield* storedLayout(
+      'stored-effect-layout/deep-nested-executables',
+      `struct Deferred<F: once Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let deepest = effect { return 1 }
+  let transform = i32.add(1)
+  let middle = effect {
+    let base = run move deepest
+    return transform(base)
+  }
+  let deferred = Deferred { operation: effect { return run move middle } }
+  return 0
+}`,
+      Target.wasm32UnknownUnknown,
+    )
+    const represented = representedEntry(plan)
+    const shape = Layout.callingShape(plan, represented.type)
+
+    assert.strictEqual(shape?.tree._tag, 'EffectEnvironmentShape')
+    if (shape?.tree._tag !== 'EffectEnvironmentShape') return
+    const middle = shape.tree.fields.at(0)?.shape
+    assert.strictEqual(middle?._tag, 'EffectEnvironmentShape')
+    if (middle?._tag !== 'EffectEnvironmentShape') return
+    assert.deepEqual(
+      middle.fields.map((field) => field.shape._tag),
+      ['EffectEnvironmentShape', 'CallableEnvironmentShape'],
+    )
+    assert.deepEqual(Layout.verify(plan), [])
+  }),
+)

--- a/packages/compiler/test/StoredEffectLayout.test.ts
+++ b/packages/compiler/test/StoredEffectLayout.test.ts
@@ -138,3 +138,43 @@ pub fn main() -> i32 {
     assert.isFalse(first.plan.entries.some((entry) => Type.isEffect(entry.type)))
   }),
 )
+
+it.effect('shapes nested Effect and callable captures from their concrete environments', () =>
+  Effect.gen(function* () {
+    const { plan } = yield* storedLayout(
+      'stored-effect-layout/nested-executables',
+      `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let token = Token { value: 1 }
+  let nested = effect { return token.value }
+  let transform = i32.add(1)
+  let deferred = Deferred { operation: effect {
+    let base = run move nested
+    return transform(base)
+  } }
+  return 0
+}`,
+      Target.wasm32UnknownUnknown,
+    )
+    const represented = representedEntry(plan)
+    const shape = Layout.callingShape(plan, represented.type)
+
+    assert.strictEqual(represented.representation._tag, 'StoredEffectEnvironment')
+    assert.strictEqual(shape?.tree._tag, 'EffectEnvironmentShape')
+    if (
+      represented.representation._tag !== 'StoredEffectEnvironment' ||
+      shape?.tree._tag !== 'EffectEnvironmentShape'
+    )
+      return
+    assert.deepEqual(
+      shape.tree.fields.map((field) => field.shape._tag),
+      ['EffectEnvironmentShape', 'CallableEnvironmentShape'],
+    )
+    assert.strictEqual(
+      shape.laneCount,
+      shape.tree.fields.reduce((total, field) => total + field.shape.laneCount, 0),
+    )
+    assert.deepEqual(Layout.verify(plan), [])
+  }),
+)

--- a/packages/compiler/test/StoredEffectMir.test.ts
+++ b/packages/compiler/test/StoredEffectMir.test.ts
@@ -54,6 +54,75 @@ const finalizeSuspension = (
   )
 }
 
+const replaceDrop = (
+  module: Mir.Module,
+  target: Extract<Mir.Operation, { readonly _tag: 'Drop' }>,
+  replacement: Extract<Mir.Operation, { readonly _tag: 'Drop' }>,
+): Mir.Module =>
+  Object.freeze({
+    ...module,
+    functions: Object.freeze(
+      module.functions.map((fn) =>
+        Object.freeze({
+          ...fn,
+          regions: Object.freeze(
+            fn.regions.map((region) =>
+              region._tag === 'OperationRegion'
+                ? Object.freeze({
+                    ...region,
+                    operations: Object.freeze(
+                      region.operations.map((operation) =>
+                        operation === target ? replacement : operation,
+                      ),
+                    ),
+                  })
+                : region._tag === 'CleanupRegion'
+                  ? Object.freeze({
+                      ...region,
+                      releases: Object.freeze(
+                        region.releases.map((operation) =>
+                          operation === target ? replacement : operation,
+                        ),
+                      ),
+                    })
+                  : region,
+            ),
+          ),
+        }),
+      ),
+    ),
+  })
+
+const replaceOperation = (
+  module: Mir.Module,
+  target: Mir.Operation,
+  replacement: Mir.Operation,
+): Mir.Module =>
+  Object.freeze({
+    ...module,
+    functions: Object.freeze(
+      module.functions.map((fn) =>
+        Object.freeze({
+          ...fn,
+          regions: Object.freeze(
+            fn.regions.map((region) =>
+              region._tag === 'OperationRegion'
+                ? Object.freeze({
+                    ...region,
+                    operations: Object.freeze(
+                      region.operations.map((operation) =>
+                        operation === target ? replacement : operation,
+                      ),
+                    ),
+                  })
+                : region,
+            ),
+          ),
+        }),
+      ),
+    ),
+  })
+
 it.effect('carries lazy construction and exact stored Effect execution through MIR', () =>
   Effect.gen(function* () {
     const name = 'stored-effect-mir/lifecycle'
@@ -61,6 +130,8 @@ it.effect('carries lazy construction and exact stored Effect execution through M
       name,
       `struct Deferred<F: Effect<i32>> { operation: F }
 pub fn main() -> i32 {
+  let other = effect { return 0 }
+  let ignored = run other
   let deferred = Deferred { operation: effect { return 42 } }
   return run deferred.operation
 }`,
@@ -68,7 +139,13 @@ pub fn main() -> i32 {
     const operations = module.functions.flatMap(Mir.operations)
     const make = operations.find((operation) => operation._tag === 'MakeEffect')
     const construct = operations.find((operation) => operation._tag === 'Construct')
-    const run = operations.find((operation) => operation._tag === 'RunEffectValue')
+    const run = module.functions
+      .flatMap((fn) => Mir.operations(fn).map((operation) => Object.freeze({ fn, operation })))
+      .find(({ fn, operation }) => {
+        if (operation._tag !== 'RunEffectValue') return false
+        const type = fn.localTypes.at(operation.effect.ordinal)
+        return type?._tag === 'EffectValue' && type.storage !== undefined
+      })?.operation
     const stored = construct?._tag === 'Construct' ? construct.fields.at(0)?.stored : undefined
     const projected = module.functions
       .flatMap((fn) => fn.localTypes)
@@ -92,6 +169,21 @@ pub fn main() -> i32 {
     assert.deepEqual(run.outcomeType.type.failures, stored.realization.rows.failures)
     assert.deepEqual(run.outcomeType.type.requirements, stored.realization.rows.requirements)
     assert.deepEqual(Mir.verify(module), [])
+    const alternate = operations.find(
+      (operation) => operation._tag === 'RunEffectValue' && operation !== run,
+    )
+    assert.strictEqual(alternate?._tag, 'RunEffectValue')
+    if (alternate?._tag !== 'RunEffectValue') return
+    const forged = Object.freeze({
+      ...run,
+      runner: alternate.runner,
+      runnerTypeArguments: alternate.runnerTypeArguments,
+      arguments: Object.freeze([run.effect]),
+    })
+    assert.include(
+      Mir.verify(replaceOperation(module, run, forged)).map((violation) => violation.rule),
+      'InvalidEffectOperation',
+    )
   }),
 )
 
@@ -125,6 +217,66 @@ pub fn main() -> i32 {
       'EffectCleanup',
     )
     assert.deepEqual(Mir.verify(module), [])
+
+    const drop = module.functions
+      .flatMap(Mir.operations)
+      .find(
+        (operation): operation is Extract<Mir.Operation, { readonly _tag: 'Drop' }> =>
+          operation._tag === 'Drop' &&
+          operation.cleanup._tag === 'StructCleanup' &&
+          operation.cleanup.fields.some((field) => field.cleanup._tag === 'EffectCleanup'),
+      )
+    assert.isDefined(drop)
+    if (drop === undefined || drop.cleanup._tag !== 'StructCleanup') return
+    const structCleanup = drop.cleanup
+    const field = structCleanup.fields.find(
+      (candidate) => candidate.cleanup._tag === 'EffectCleanup',
+    )
+    assert.strictEqual(field?.cleanup._tag, 'EffectCleanup')
+    if (field?.cleanup._tag !== 'EffectCleanup') return
+    const slot = field.cleanup.slots.at(0) ?? unreachable('expected owned stored Effect slot')
+    const withEffectCleanup = (
+      cleanup: Extract<Ownership.CleanupPlan, { readonly _tag: 'EffectCleanup' }>,
+    ): Extract<Mir.Operation, { readonly _tag: 'Drop' }> =>
+      Object.freeze({
+        ...drop,
+        cleanup: Object.freeze({
+          ...structCleanup,
+          fields: Object.freeze(
+            structCleanup.fields.map((candidate) =>
+              candidate === field ? Object.freeze({ ...candidate, cleanup }) : candidate,
+            ),
+          ),
+        }),
+      })
+    const malformed = [
+      Object.freeze({ ...field.cleanup, slots: Object.freeze([]) }),
+      Object.freeze({
+        ...field.cleanup,
+        slots: Object.freeze([Object.freeze({ ...slot, laneOffset: slot.laneOffset + 1 })]),
+      }),
+      Object.freeze({
+        ...field.cleanup,
+        slots: Object.freeze([Object.freeze({ ...slot, laneCount: slot.laneCount + 1 })]),
+      }),
+      Object.freeze({
+        ...field.cleanup,
+        slots: Object.freeze([
+          Object.freeze({
+            ...slot,
+            cleanup: Object.freeze({ _tag: 'NoCleanup' as const, type: slot.cleanup.type }),
+          }),
+        ]),
+      }),
+    ]
+    for (const cleanup of malformed) {
+      assert.include(
+        Mir.verify(replaceDrop(module, drop, withEffectCleanup(cleanup))).map(
+          (violation) => violation.rule,
+        ),
+        'InvalidAggregateOperation',
+      )
+    }
   }),
 )
 

--- a/packages/compiler/test/StoredEffectMir.test.ts
+++ b/packages/compiler/test/StoredEffectMir.test.ts
@@ -187,6 +187,72 @@ pub fn main() -> i32 {
   }),
 )
 
+it.effect('binds provider-specialized runs to their exact generated runner and witness', () =>
+  Effect.gen(function* () {
+    const { module } = yield* lowerStored(
+      'stored-effect-mir/provided-runner',
+      `service Counter { effect fn get() -> i32 ? &Counter }
+service Meter { effect fn read() -> i32 ? &Meter }
+struct Fixed { value: i32 }
+effect fn get(self: &Fixed) -> i32 { return self.value }
+effect fn read(self: &Fixed) -> i32 { return self.value }
+impl Counter for Fixed { get: Fixed.get }
+impl Meter for Fixed { read: Fixed.read }
+effect fn count() -> i32 ? &Counter { return run Counter.get() }
+effect fn measure() -> i32 ? &Meter { return run Meter.read() }
+pub fn main() -> i32 {
+  let fixed = Fixed { value: 42 }
+  let ignored = run (count() |> Effect.provide(&fixed))
+  let alsoIgnored = run (measure() |> Effect.provide(&fixed))
+  return run (count() |> Effect.provide(&fixed))
+}`,
+    )
+    const providedRuns = module.functions.flatMap((fn) =>
+      Mir.operations(fn).flatMap((operation) => {
+        if (operation._tag !== 'RunEffectValue' || operation.providers.length !== 1) return []
+        return [operation]
+      }),
+    )
+    const counter = providedRuns.find(
+      (operation) => operation.providers.at(0)?.capability.name === 'Counter',
+    )
+    const meter = providedRuns.find(
+      (operation) => operation.providers.at(0)?.capability.name === 'Meter',
+    )
+
+    assert.strictEqual(counter?._tag, 'RunEffectValue')
+    assert.strictEqual(meter?._tag, 'RunEffectValue')
+    assert.deepEqual(Mir.verify(module), [])
+    if (counter?._tag !== 'RunEffectValue' || meter?._tag !== 'RunEffectValue') return
+    const wrongWrapper = Object.freeze({
+      ...counter,
+      runner: meter.runner,
+      runnerTypeArguments: meter.runnerTypeArguments,
+    })
+    assert.include(
+      Mir.verify(replaceOperation(module, counter, wrongWrapper)).map(
+        (violation) => violation.rule,
+      ),
+      'InvalidEffectOperation',
+    )
+    const counterProvider = counter.providers.at(0)
+    const meterProvider = meter.providers.at(0)
+    if (counterProvider === undefined || meterProvider === undefined) return
+    const wrongWitness = Object.freeze({
+      ...counter,
+      providers: Object.freeze([
+        Object.freeze({ ...counterProvider, witness: meterProvider.witness }),
+      ]),
+    })
+    assert.include(
+      Mir.verify(replaceOperation(module, counter, wrongWitness)).map(
+        (violation) => violation.rule,
+      ),
+      'InvalidEffectOperation',
+    )
+  }),
+)
+
 it.effect('resolves unrun stored Effect cleanup before MIR', () =>
   Effect.gen(function* () {
     const { module } = yield* lowerStored(

--- a/packages/compiler/test/StoredEffectMir.test.ts
+++ b/packages/compiler/test/StoredEffectMir.test.ts
@@ -1,0 +1,220 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as ContinuationLayout from '../src/ContinuationLayout.js'
+import * as Layout from '../src/Layout.js'
+import * as Lower from '../src/Lower.js'
+import * as Mir from '../src/Mir.js'
+import * as MirNormalization from '../src/MirNormalization.js'
+import * as OpaqueRealization from '../src/OpaqueRealization.js'
+import type * as Ownership from '../src/Ownership.js'
+import * as ProvisionalMir from '../src/ProvisionalMir.js'
+import * as SuspensionMir from '../src/SuspensionMir.js'
+import * as SuspensionOwnership from '../src/SuspensionOwnership.js'
+import * as Target from '../src/Target.js'
+import * as Type from '../src/Type.js'
+import { unreachable } from './support/raise.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const lowerStored = Effect.fnUntraced(function* (name: string, source: string) {
+  const snapshot = yield* Analysis.ofSourceRealized(
+    name,
+    ascii(source),
+    Target.wasm32UnknownUnknown.id,
+  )
+  const catalog = Layout.catalog(Target.wasm32UnknownUnknown, snapshot.index, snapshot.instances)
+  const layout = Layout.plan(catalog, snapshot.instances)
+  const ownership = Analysis.ownershipOf(snapshot, name) ?? unreachable('expected module ownership')
+  const module = Lower.lowerProgram(
+    snapshot.instances,
+    new Map<string, Ownership.ModuleOwnership>([[name, ownership]]),
+    layout,
+    snapshot.index,
+    OpaqueRealization.catalogOf(snapshot),
+  )
+  return Object.freeze({ snapshot, layout, module })
+})
+
+const finalizeSuspension = (
+  snapshot: Analysis.Snapshot,
+  module: Mir.Module,
+  layout: Layout.Plan,
+): Mir.Module => {
+  const provisional = ProvisionalMir.build(snapshot.instances, layout, snapshot.index)
+  const normalized = MirNormalization.normalize(module, provisional)
+  return ContinuationLayout.apply(
+    SuspensionMir.finalize(
+      normalized,
+      provisional,
+      SuspensionOwnership.plan(normalized, provisional, snapshot.index),
+      snapshot.index,
+    ),
+  )
+}
+
+it.effect('carries lazy construction and exact stored Effect execution through MIR', () =>
+  Effect.gen(function* () {
+    const name = 'stored-effect-mir/lifecycle'
+    const { snapshot, module } = yield* lowerStored(
+      name,
+      `struct Deferred<F: Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return 42 } }
+  return run deferred.operation
+}`,
+    )
+    const operations = module.functions.flatMap(Mir.operations)
+    const make = operations.find((operation) => operation._tag === 'MakeEffect')
+    const construct = operations.find((operation) => operation._tag === 'Construct')
+    const run = operations.find((operation) => operation._tag === 'RunEffectValue')
+    const stored = construct?._tag === 'Construct' ? construct.fields.at(0)?.stored : undefined
+    const projected = module.functions
+      .flatMap((fn) => fn.localTypes)
+      .find((type) => type._tag === 'EffectValue' && type.storage !== undefined)
+
+    assert.include(
+      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+      'SEM0107',
+    )
+    assert.strictEqual(make?._tag, 'MakeEffect')
+    assert.strictEqual(stored?._tag, 'StoredEffectField')
+    assert.strictEqual(projected?._tag, 'EffectValue')
+    assert.strictEqual(
+      projected?._tag === 'EffectValue' ? projected.storage?._tag : undefined,
+      'StoredEffectField',
+    )
+    assert.strictEqual(run?._tag, 'RunEffectValue')
+    if (run?._tag !== 'RunEffectValue' || stored?._tag !== 'StoredEffectField') return
+    assert.deepEqual(run.runner, stored.realization.runner)
+    assert.deepEqual(run.runnerTypeArguments, stored.realization.runnerArguments)
+    assert.deepEqual(run.outcomeType.type.failures, stored.realization.rows.failures)
+    assert.deepEqual(run.outcomeType.type.requirements, stored.realization.rows.requirements)
+    assert.deepEqual(Mir.verify(module), [])
+  }),
+)
+
+it.effect('resolves unrun stored Effect cleanup before MIR', () =>
+  Effect.gen(function* () {
+    const { module } = yield* lowerStored(
+      'stored-effect-mir/unrun-cleanup',
+      `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+pub fn main() -> i32 {
+  let token = Token { value: 1 }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  return 0
+}`,
+    )
+    const cleanups = module.functions
+      .flatMap(Mir.operations)
+      .flatMap((operation) => (operation._tag === 'Drop' ? [operation.cleanup] : []))
+
+    assert.notInclude(
+      cleanups.map((cleanup) => cleanup._tag),
+      'RepresentedEffectCleanup',
+    )
+    assert.include(
+      cleanups.flatMap((cleanup) =>
+        cleanup._tag === 'StructCleanup'
+          ? cleanup.fields.map((field) => field.cleanup._tag)
+          : [cleanup._tag],
+      ),
+      'EffectCleanup',
+    )
+    assert.deepEqual(Mir.verify(module), [])
+  }),
+)
+
+it.effect('retains stored runners across suspension and resume planning', () =>
+  Effect.gen(function* () {
+    const lowered = yield* lowerStored(
+      'stored-effect-mir/suspending',
+      `struct Deferred<F: Effect<i32>> { operation: F }
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+effect fn delayed() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  let provided = Effect.suspend(effect { return 42 }) |> Effect.provideMut(&mut allocator)
+  return run Effect.catch(move provided, recover)
+}
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return run delayed() } }
+  return run deferred.operation
+}`,
+    )
+    const module = finalizeSuspension(lowered.snapshot, lowered.module, lowered.layout)
+    const run = module.functions
+      .flatMap(Mir.operations)
+      .find((operation) => operation._tag === 'RunEffectValue')
+    const suspension = module.functions.flatMap((fn) => fn.suspension?.regions ?? [])
+
+    assert.strictEqual(run?._tag, 'RunEffectValue')
+    assert.include(
+      suspension.map((region) => region._tag),
+      'SuspendEffectRegion',
+    )
+    assert.include(
+      suspension.map((region) => region._tag),
+      'RunSuspendableEffectRegion',
+    )
+    const violations = Mir.verify(module)
+    assert.notInclude(
+      violations.map((violation) => violation.rule),
+      'InvalidEffectOperation',
+    )
+    assert.notInclude(
+      violations.map((violation) => violation.rule),
+      'InvalidSuspension',
+    )
+    assert.deepEqual(
+      violations.map((violation) => violation.rule),
+      ['OrphanSuspensionMachinery'],
+    )
+    assert.include(Mir.encode(module), 'stored-effect-mir/suspending.main$effect$0')
+  }),
+)
+
+it.effect('keeps typed-failure releases on stored Effect propagation paths', () =>
+  Effect.gen(function* () {
+    const { module } = yield* lowerStored(
+      'stored-effect-mir/failure-cleanup',
+      `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+effect fn build() -> i32 ! OutOfMemory {
+  let token = Token { value: 1 }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  let mut allocator = SystemAllocator.make()
+  let allocation = run Allocator.allocate(Layout.of<[i32; 2]>()) |> Effect.provideMut(&mut allocator)
+  return 42
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`,
+    )
+    const propagating = module.functions
+      .flatMap(Mir.operations)
+      .flatMap((operation) =>
+        (operation._tag === 'RunEffect' || operation._tag === 'RunEffectValue') &&
+        operation.releases !== undefined
+          ? [operation]
+          : [],
+      )
+    const cleanupTags = propagating.flatMap((operation) =>
+      (operation.releases ?? []).flatMap((release) =>
+        release.cleanup._tag === 'StructCleanup'
+          ? release.cleanup.fields.map((field) => field.cleanup._tag)
+          : [release.cleanup._tag],
+      ),
+    )
+
+    assert.include(cleanupTags, 'EffectCleanup')
+    assert.deepEqual(Mir.verify(module), [])
+    assert.isFalse(
+      module.layout.entries.some(
+        (entry) => Type.isEffect(entry.type) && entry.representation._tag !== 'Aggregate',
+      ),
+    )
+  }),
+)

--- a/packages/compiler/test/StoredEffectOwnership.test.ts
+++ b/packages/compiler/test/StoredEffectOwnership.test.ts
@@ -122,3 +122,90 @@ pub fn main() -> i32 { return 0 }`,
     assert.notInclude(codesOf(snapshot), 'OWN0015')
   }),
 )
+
+it.effect('consumes the whole aggregate when its take-once Effect runs', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/whole-owner-move',
+      `${declarations}fn runTwice<F: once Effect<i32>>(value: Once<F>) -> i32 {
+  let first = run value.operation
+  return first + run value.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.include(codesOf(snapshot), 'OWN0001')
+    const facts =
+      snapshot.ownership.get('stored-effect-ownership/whole-owner-move') ??
+      unreachable('expected ownership facts')
+    const runTwice = facts.functions.at(0) ?? unreachable('expected runTwice ownership')
+    const owner =
+      runTwice.bindings.find((binding) => binding.name === 'value') ??
+      unreachable('expected value binding')
+    assert.notStrictEqual(owner.movedAt, undefined)
+  }),
+)
+
+it.effect('consumes the outer owner through a nested stored Effect projection', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/nested-owner-move',
+      `${declarations}struct Boxed<F: once Effect<i32>> { inner: Once<F> }
+fn runTwice<F: once Effect<i32>>(value: Boxed<F>) -> i32 {
+  let first = run value.inner.operation
+  return first + run value.inner.operation
+}
+pub fn main() -> i32 { return 0 }`,
+    )
+
+    assert.include(codesOf(snapshot), 'OWN0001')
+    assert.notInclude(codesOf(snapshot), 'OWN0013')
+  }),
+)
+
+it.effect('rejects extracting a represented Effect field directly', () =>
+  Effect.gen(function* () {
+    const snapshot = yield* realized(
+      'stored-effect-ownership/extraction',
+      `${declarations}pub fn main() -> i32 {
+  let deferred = Once { operation: effect { return 42 } }
+  let operation = move deferred.operation
+  return 0
+}`,
+    )
+    const diagnostic = Analysis.diagnostics(snapshot).find(
+      (candidate) => candidate.code === 'OWN0013',
+    )
+
+    assert.strictEqual(diagnostic?.reason._tag, 'RepresentationFieldExtraction')
+    assert.include(diagnostic?.message ?? '', 'executable representation')
+    assert.notInclude(codesOf(snapshot), 'OWN0002')
+  }),
+)
+
+it.effect('retains a stored Effect loan until the enclosing aggregate is consumed', () =>
+  Effect.gen(function* () {
+    const module = 'stored-effect-ownership/retained-loan'
+    const source = `struct Deferred<F: Effect<i32>> { operation: F }
+effect fn inspect(values: &[i32]) -> i32 { return values[0] }
+pub fn main() -> i32 {
+  let mut values = [1]
+  let recipe = inspect(&values)
+  let deferred = Deferred { operation: move recipe }
+  values[0] = 2
+  drop deferred
+  return values[0]
+}`
+    const snapshot = yield* realized(module, source)
+    const facts = snapshot.ownership.get(module) ?? unreachable('expected ownership facts')
+    const loan = facts.functions.flatMap((fn) => [...fn.loans]).at(0)
+
+    assert.notStrictEqual(loan, undefined)
+    assert.strictEqual(loan?.origin, 'FixedArrayBorrow')
+    assert.include(codesOf(snapshot), 'OWN0011')
+    assert.strictEqual(
+      loan === undefined ? undefined : source.slice(loan.endSpan.start, loan.endSpan.end).trim(),
+      'drop deferred',
+    )
+  }),
+)

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -193,7 +193,7 @@ There are 151 codes in total.
 | `OWN0010` |  | `<requested> slice loan conflicts with an active <toLowerCase> loan` |
 | `OWN0011` |  | `<toLowerCase> access to <spelling> conflicts with an active slice loan` |
 | `OWN0012` |  | `A non-Copy value cannot be moved out through a borrowed slice place` |
-| `OWN0013` | Stable code for extracting one owned representation-bearing field out of its aggregate. | `Cannot move field <field> out of <aggregate>: it stores the callable representation <contract>, whose captures are cleaned with the whole aggregate` |
+| `OWN0013` | Stable code for extracting one owned representation-bearing field out of its aggregate. | `Cannot move field <field> out of <aggregate>: it stores the executable representation <contract>, whose captures are cleaned with the whole aggregate` |
 | `OWN0014` | Stable code for invoking a stored callable through too weak an aggregate receiver access. | `Cannot invoke field <field> of <aggregate> through <toLowerCase> aggregate access: <contract> requires <toLowerCase> access to the whole aggregate` |
 | `OWN0015` | Stable code for running a stored Effect through too weak an aggregate receiver access. | `Cannot run field <field> of <aggregate> through <toLowerCase> aggregate access: <contract> requires <toLowerCase> access to the whole aggregate` |
 


### PR DESCRIPTION
## Summary

- preserve exact stored Effect ownership, access, moves, nesting, and direct-field extraction rejection
- plan inline concrete Effect environments and suspendability dependencies in nominal ABI layout
- carry lazy construction, runs, typed failure, suspension/resume facts, and cleanup through HIR and MIR
- retain SEM0107 and SEM0103 until downstream engine parity/fence retirement

Part of #190. This is PR3 only; it does not sync/archive the OpenSpec change or implement PR4 engine admission.

## OpenSpec tasks

- [x] 3.1 ownership
- [x] 3.2 layout
- [x] 3.3 HIR/MIR
- [ ] PR4 engine parity and fence retirement
- [ ] PR5 final validation/archive

## Validation

- repository typecheck: 20/20 tasks passed
- Biome: passed (one pre-existing informational literal-key suggestion)
- focused stored Effect/callable, opaque realization, cleanup, suspension, and normalization suites: passed
- exact-head pnpm check: 1,825/1,826 compiler tests passed; sole failure is the pre-existing host-stack stress assertion in WasmShadowStackHeapCollision
- exact-head three-axis read-only review: no downstream or merge blockers

## Pressure debt

- connect the known provided named-Effect OrphanSuspensionMachinery seam before PR4 engine admission and SEM0107 retirement
- add stronger recursive cleanup mutation coverage and direct stored provider-specialization coverage
- add direct wrapper-path suspendability and unreachable stored-layout orphan regressions
- retain the pre-existing WasmShadowStackHeapCollision host-stack stress failure as host-pressure evidence
