### PR TITLE
#190 PR4a — Stored Effect evaluator parity

### DIFF
--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -18,7 +18,7 @@
 
 ## 4. Engine Parity and Invalidation
 
-- [ ] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
+- [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
 - [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
 - [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
 - [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.

--- a/packages/compiler/src/CallableFieldRealization.ts
+++ b/packages/compiler/src/CallableFieldRealization.ts
@@ -325,7 +325,21 @@ const sameArguments = (
   left.length === right.length &&
   left.every((argument, ordinal) => {
     const candidate = right.at(ordinal)
-    return candidate !== undefined && Type.equalsGenericArgument(argument, candidate)
+    if (candidate === undefined) return false
+    if (Type.equalsGenericArgument(argument, candidate)) return true
+    if (!Type.isEffectIdentityArgument(argument) || !Type.isEffectIdentityArgument(candidate))
+      return false
+    const retained = argument.owner === undefined ? candidate : argument
+    const discovered = argument.owner === undefined ? argument : candidate
+    const owner = retained.owner
+    if (owner === undefined || !retained.identity.startsWith('effect:')) return false
+    const ownerPrefix = `${owner.declaration.module}\u0000${owner.declaration.name}\u0000${owner.typeArguments
+      .map(Type.genericArgumentKey)
+      .join('\u0000')}\u0002`
+    return (
+      discovered.identity.startsWith(ownerPrefix) &&
+      discovered.identity.endsWith(`\u0004${retained.identity.slice('effect:'.length)}`)
+    )
   })
 
 export const matchesIdentity = (

--- a/packages/compiler/src/Elaboration.ts
+++ b/packages/compiler/src/Elaboration.ts
@@ -2708,13 +2708,128 @@ const exactCallableRepresentation = (
   )
 }
 
+const exactEffectDeclarationRepresentation = (
+  declaration: DeclarationFact,
+  contract: Type.Effect,
+  typeArguments: ReadonlyArray<Type.GenericArgument>,
+): Type.ExactRepresentationArgument | undefined => {
+  if (declaration.functionKind !== 'Effect' || declaration.canonical._tag !== 'Canonical')
+    return undefined
+  const owner = Object.freeze({
+    declaration: Object.freeze({
+      module: declaration.canonical.id.module,
+      name: declaration.canonical.id.name,
+    }),
+    typeArguments,
+  })
+  const site: Hir.EffectSiteId = Object.freeze({
+    _tag: 'EffectSiteId',
+    function: declaration.id,
+    owner: declaration.canonical.id,
+    ordinal: -1,
+    span: declaration.syntax.span,
+  })
+  return Type.exactRepresentationArgument(
+    Type.effectIdentityArgument(Hir.effectRepresentationIdentity(site), owner),
+    contract,
+  )
+}
+
+const exactEffectIdentityOfExpression = (
+  expression: ExpressionFact,
+): Type.EffectIdentityArgument | undefined => {
+  const representation = representationOfExpression(expression)
+  return representation?._tag === 'ExactRepresentationArgument' &&
+    Type.isEffectIdentityArgument(representation.identity)
+    ? representation.identity
+    : undefined
+}
+
+const hiddenEffectArguments = (
+  declaration: DeclarationFact,
+  substitution: Type.Substitution,
+  argumentAt: (ordinal: number) => ExpressionFact | undefined,
+): ReadonlyArray<Type.EffectIdentityArgument> =>
+  Object.freeze(
+    declaration.parameters.flatMap((parameter, ordinal) => {
+      const declared = parameter.declaredType
+      if (declared._tag !== 'Resolved') return []
+      const specialized = Type.substitute(declared.type, substitution)
+      const contract = Type.isRepresented(specialized) ? specialized.contract : specialized
+      if (!Type.isEffect(contract)) return []
+      const argument = argumentAt(ordinal)
+      const identity =
+        argument === undefined ? undefined : exactEffectIdentityOfExpression(argument)
+      return identity === undefined ? [] : [identity]
+    }),
+  )
+
+const exactEffectApplicationContract = (
+  declaration: DeclarationFact,
+  substitution: Type.Substitution,
+  contract: Type.Effect,
+): Type.Effect => {
+  const accesses = declaration.parameters.flatMap((parameter) => {
+    const declared = parameter.declaredType
+    if (declared._tag !== 'Resolved') return []
+    const specialized = Type.substitute(declared.type, substitution)
+    const captured = Type.isRepresented(specialized) ? specialized.contract : specialized
+    if (Type.isEffect(captured)) return [captured.access]
+    if (Type.isCallable(captured)) return [captured.mode]
+    return []
+  })
+  const access = accesses.includes('Take')
+    ? 'Take'
+    : accesses.includes('Exclusive')
+      ? 'Exclusive'
+      : contract.access
+  return Type.effect(
+    contract.success,
+    contract.failures,
+    access,
+    contract.requirements,
+    contract.failureParameters,
+    contract.requirementParameters,
+  )
+}
+
+const effectCallableApplicationRepresentation = (
+  expression: CallableApplyExpressionFact,
+  contract: Type.Effect,
+): Type.ExactRepresentationArgument | undefined => {
+  const callee = expression.callee
+  if (callee._tag !== 'CallableSection' || callee.reference._tag !== 'Resolved') return undefined
+  const substitution = new Map(callee.substitution)
+  for (const [parameter, argument] of expression.substitution) substitution.set(parameter, argument)
+  const declaredArguments = Object.freeze(
+    callee.reference.declaration.typeParameters.map(
+      (parameter) =>
+        substitution.get(Type.key(parameter.type)) ??
+        Type.substituteGenericArgument(parameter.type, substitution),
+    ),
+  )
+  const applicationArgument = (ordinal: number): ExpressionFact | undefined => {
+    const captured = callee.captures.find((capture) => capture.parameterOrdinal === ordinal)
+    if (captured !== undefined) return captured.expression
+    return ordinal === callee.omittedParameter ? expression.arguments.at(0)?.expression : undefined
+  }
+  return exactEffectDeclarationRepresentation(
+    callee.reference.declaration,
+    exactEffectApplicationContract(callee.reference.declaration, substitution, contract),
+    Object.freeze([
+      ...declaredArguments,
+      ...hiddenEffectArguments(callee.reference.declaration, substitution, applicationArgument),
+    ]),
+  )
+}
+
 /**
  * Recovers a compile-time representation from semantic expression structure. This is deliberately
  * frontend-owned: later phases consume the retained argument and never reconstruct it from syntax.
  */
-export const representationOfExpression = (
+export function representationOfExpression(
   expression: ExpressionFact,
-): Type.RepresentationArgument | undefined => {
+): Type.RepresentationArgument | undefined {
   if (expression.type._tag === 'Available' && Type.isRepresented(expression.type.type))
     return expression.type.type.representation.argument
   if (expression._tag === 'FunctionItem' && expression.type._tag === 'Available') {
@@ -2749,6 +2864,33 @@ export const representationOfExpression = (
       ),
       contract,
     )
+  }
+  if (
+    expression._tag === 'Call' &&
+    expression.reference._tag === 'Resolved' &&
+    expression.contract._tag === 'Compatible' &&
+    expression.type._tag === 'Available' &&
+    Type.isEffect(expression.type.type)
+  ) {
+    return exactEffectDeclarationRepresentation(
+      expression.reference.declaration,
+      expression.type.type,
+      Object.freeze([
+        ...expression.contract.typeArguments,
+        ...hiddenEffectArguments(
+          expression.reference.declaration,
+          expression.contract.substitution,
+          (ordinal) => expression.arguments.at(ordinal)?.expression,
+        ),
+      ]),
+    )
+  }
+  if (
+    expression._tag === 'CallableApply' &&
+    expression.type._tag === 'Available' &&
+    Type.isEffect(expression.type.type)
+  ) {
+    return effectCallableApplicationRepresentation(expression, expression.type.type)
   }
   if (expression._tag === 'Identifier' && expression.reference._tag === 'ResolvedBinding')
     return representationOfExpression(expression.reference.binding.initializer)

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -1223,7 +1223,11 @@ const effectParameterOrdinals = (
 ): ReadonlyArray<number> =>
   fn.contract._tag === 'Contract'
     ? fn.contract.parameters.flatMap((parameter, ordinal) =>
-        Type.isEffect(Type.substitute(parameter, substitution)) ? [ordinal] : [],
+        (() => {
+          const specialized = Type.substitute(parameter, substitution)
+          const contract = Type.isRepresented(specialized) ? specialized.contract : specialized
+          return Type.isEffect(contract) ? [ordinal] : []
+        })(),
       )
     : Object.freeze([])
 
@@ -1407,6 +1411,7 @@ interface EffectOriginContext {
   readonly results: ReadonlyMap<string, Elaboration.Result>
   readonly index: DeclarationIndex.Index
   readonly resolving: ReadonlySet<string>
+  readonly resolveEffectIdentity?: (identity: Type.EffectIdentityArgument) => string | undefined
 }
 
 const returnedExpression = (fn: Hir.HirFunction): Hir.Expression | undefined => {
@@ -1486,6 +1491,52 @@ const effectOriginOf = (
   expression: Hir.Expression,
   context: EffectOriginContext,
 ): string | undefined => {
+  const exactIdentity = (type: Type.Type): string | undefined => {
+    const specialized = Type.substitute(type, context.substitution)
+    return Type.isRepresented(specialized) &&
+      Type.isEffect(specialized.contract) &&
+      Type.isExactRepresentationArgument(specialized.representation.argument) &&
+      Type.isEffectIdentityArgument(specialized.representation.argument.identity)
+      ? (context.resolveEffectIdentity?.(specialized.representation.argument.identity) ??
+          specialized.representation.argument.identity.identity)
+      : undefined
+  }
+  if (expression._tag !== 'Unavailable') {
+    const identity = exactIdentity(expression.type)
+    if (identity !== undefined) return identity
+  }
+  if (expression._tag === 'Project') {
+    const declaration = DeclarationIndex.byCanonical(context.index, {
+      _tag: 'CanonicalDeclarationId',
+      module: expression.nominal.module,
+      name: expression.nominal.name,
+    })
+    const field =
+      declaration?._tag === 'StructDeclaration'
+        ? declaration.fields.find((candidate) => candidate.id.ordinal === expression.field.ordinal)
+        : undefined
+    const substitution =
+      declaration?._tag === 'StructDeclaration'
+        ? Type.substitution(
+            declaration.typeParameters.map((parameter) => parameter.type),
+            expression.nominal.arguments,
+          )
+        : undefined
+    if (field?.declaredType._tag === 'RepresentationParameter' && substitution !== undefined) {
+      const argument = substitution.get(Type.key(field.declaredType.parameter))
+      if (
+        argument !== undefined &&
+        Type.isExactRepresentationArgument(argument) &&
+        Type.isEffectIdentityArgument(argument.identity)
+      )
+        return context.resolveEffectIdentity?.(argument.identity) ?? argument.identity.identity
+    }
+    if (field?.declaredType._tag === 'Resolved' && substitution !== undefined) {
+      const projected = Type.substitute(field.declaredType.type, substitution)
+      const identity = exactIdentity(projected)
+      if (identity !== undefined) return identity
+    }
+  }
   if (expression._tag === 'EffectBlock') return effectIdentity(context.owner, expression.site)
   if (
     (expression._tag === 'BoundOperationCall' || expression._tag === 'BuiltinCall') &&
@@ -1995,6 +2046,29 @@ const suspensionGraph = (
   const roots = new Set<string>()
   const dependencies = new Map<string, Set<string>>()
   const effectIdentities = new Set<string>()
+  const resolveEffectIdentity = (identity: Type.EffectIdentityArgument): string | undefined => {
+    const candidates = instances.flatMap((instance) => {
+      const owner = identity.owner
+      if (
+        owner !== undefined &&
+        (instance.key.declaration.module !== owner.declaration.module ||
+          instance.key.declaration.name !== owner.declaration.name ||
+          instance.key.typeArguments.length !== owner.typeArguments.length ||
+          !instance.key.typeArguments.every((argument, ordinal) => {
+            const expected = owner.typeArguments.at(ordinal)
+            return expected !== undefined && Type.equalsGenericArgument(argument, expected)
+          }))
+      )
+        return []
+      return callableExpressions(instance.function).flatMap((expression) =>
+        expression._tag === 'EffectBlock' &&
+        Hir.effectRepresentationIdentity(expression.site) === identity.identity
+          ? [effectIdentity(instance.key, expression.site)]
+          : [],
+      )
+    })
+    return candidates.length === 1 ? candidates.at(0) : undefined
+  }
   const addDependency = (owner: string, target: string): void => {
     const targets = dependencies.get(owner) ?? new Set<string>()
     targets.add(target)
@@ -2009,6 +2083,7 @@ const suspensionGraph = (
       results,
       index,
       resolving: new Set(),
+      resolveEffectIdentity,
     }
     const bindings = callableBindings(instance.function)
 

--- a/packages/compiler/src/Layout.ts
+++ b/packages/compiler/src/Layout.ts
@@ -3141,7 +3141,23 @@ const verifyEntry = (
           slot.source !== field.source ||
           slot.sourceOrdinal !== field.ordinal ||
           slot.access !== field.access ||
-          !Type.equals(slot.type, field.type) ||
+          !(
+            Type.equals(slot.type, field.type) ||
+            (field.effectIdentity !== undefined &&
+              Type.isEffect(slot.type) &&
+              Type.isEffect(field.type) &&
+              Type.equals(
+                Type.effect(
+                  slot.type.success,
+                  slot.type.failures,
+                  field.type.access,
+                  slot.type.requirements,
+                  slot.type.failureParameters,
+                  slot.type.requirementParameters,
+                ),
+                field.type,
+              ))
+          ) ||
           slot.effectIdentity !== field.effectIdentity ||
           (slot.callableIdentity === undefined && field.callableIdentity !== undefined) ||
           (slot.callableIdentity !== undefined &&

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -2258,10 +2258,7 @@ const storedExecutableText = (
 const borrowKey = (borrow: Hir.BorrowId): string =>
   `${borrow.function.sourceId}:${borrow.function.ordinal}:${borrow.callSpan.start}:${borrow.callSpan.end}:${borrow.ordinal}`
 
-const instanceText = (self: Instances.InstanceKey): string =>
-  `${self.declaration.module}\u0000${self.declaration.name}\u0000${self.typeArguments
-    .map(SilkType.genericArgumentKey)
-    .join('\u0000')}\u0000${self.contractRow.join('\u0000')}`
+const instanceText = Instances.keyText
 
 const callArgumentCompatible = (actual: Type, expected: Type): boolean => {
   if (

--- a/packages/compiler/src/Mir.ts
+++ b/packages/compiler/src/Mir.ts
@@ -2263,6 +2263,28 @@ const instanceText = (self: Instances.InstanceKey): string =>
     .map(SilkType.genericArgumentKey)
     .join('\u0000')}\u0000${self.contractRow.join('\u0000')}`
 
+const callArgumentCompatible = (actual: Type, expected: Type): boolean => {
+  if (
+    TypeCompatibility.isCompatible(
+      TypeCompatibility.check(semanticType(actual), semanticType(expected)),
+    )
+  )
+    return true
+  if (
+    actual._tag !== 'EffectValue' ||
+    expected._tag !== 'EffectValue' ||
+    actual.storage !== undefined ||
+    expected.storage?._tag !== 'StoredEffectField'
+  )
+    return false
+  const realization = expected.storage.realization
+  return (
+    SilkType.equals(actual.type, realization.contract) &&
+    Hir.sameExecutableSite(actual.site, realization.site) &&
+    instanceText(actual.environment.instance) === instanceText(realization.runnerInstance)
+  )
+}
+
 const cleanupTypes = (cleanup: Ownership.CleanupPlan): ReadonlyArray<SilkType.Type> => {
   switch (cleanup._tag) {
     case 'NoCleanup':
@@ -4933,9 +4955,7 @@ export const verify = (self: Module): ReadonlyArray<Violation> => {
               return (
                 actual !== undefined &&
                 expected !== undefined &&
-                TypeCompatibility.isCompatible(
-                  TypeCompatibility.check(semanticType(actual), semanticType(expected)),
-                )
+                callArgumentCompatible(actual, expected)
               )
             }) &&
             SilkType.equals(semanticType(operation.type), semanticType(target.result))

--- a/packages/compiler/test/StoredEffectRuntime.test.ts
+++ b/packages/compiler/test/StoredEffectRuntime.test.ts
@@ -60,12 +60,22 @@ const completedValue = (outcome: BootstrapEvaluation.Outcome): number => {
   return outcome.result.value
 }
 
-const storedRun = (module: Mir.Module, label = 'stored Effect') => {
-  const realizations = module.layout.entries.flatMap((entry) =>
+const storedRealizations = (module: Mir.Module) =>
+  module.layout.entries.flatMap((entry) =>
     entry.representation._tag === 'StoredEffectEnvironment'
       ? [entry.representation.realization]
       : [],
   )
+
+const storedRealization = (module: Mir.Module, label = 'stored Effect') => {
+  const realizations = storedRealizations(module)
+  return realizations.length === 1
+    ? (realizations.at(0) ?? unreachable(`expected one ${label} realization`))
+    : unreachable(`expected one ${label} realization (${realizations.length} found)`)
+}
+
+const storedRun = (module: Mir.Module, label = 'stored Effect') => {
+  const realizations = storedRealizations(module)
   for (const realization of realizations) {
     for (const operation of module.functions.flatMap(Mir.operations)) {
       if (operation._tag !== 'RunEffectValue') continue
@@ -159,6 +169,21 @@ const assertOwnershipFacts = (
   )
   assert.isAbove(realization.cleanup.unrunLanes.length, 0, name)
   assert.isTrue(realization.cleanup.consumedByRun, name)
+}
+
+const assertTicketsReleasedExactlyOnce = (
+  acquired: ReadonlyArray<number>,
+  released: ReadonlyArray<number>,
+  label: string,
+): void => {
+  assert.isAbove(acquired.length, 0, `${label} acquired`)
+  assert.strictEqual(new Set(acquired).size, acquired.length, `${label} duplicate acquire`)
+  assert.strictEqual(new Set(released).size, released.length, `${label} duplicate release`)
+  assert.deepEqual(
+    [...released].sort((left, right) => left - right),
+    [...acquired].sort((left, right) => left - right),
+    `${label} ticket balance`,
+  )
 }
 
 const shared = `struct Deferred<F: Effect<i32>> { operation: F }
@@ -267,7 +292,7 @@ effect fn failing(guard: Guard) -> i32 ! Problem {
 effect fn build() -> i32 ! Problem | OutOfMemory {
   let mut allocator = SystemAllocator.make()
   let storage = run Allocator.allocate(Layout.of<i32>()) |> Effect.provideMut(&mut allocator)
-  let guard = Guard { tag: 42, storage: move storage }
+  let guard = Guard { tag: 7, storage: move storage }
   let deferred = defer(failing(move guard))
   ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
 }
@@ -282,8 +307,16 @@ it.effect('cleans unrun and failing stored Effect environments exactly once', ()
         cleanupProgram(exit),
       )
       assert.deepEqual(Mir.verify(module), [], exit)
+      const realization = storedRealization(module, exit)
       const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
       assert.strictEqual(completedValue(outcome), 42, exit)
+      const runnerCalls = outcome.trace.filter(
+        (event) =>
+          event._tag === 'Call' &&
+          event.target.module === realization.runner.module &&
+          event.target.name === realization.runner.name,
+      )
+      assert.lengthOf(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
       assert.strictEqual(
         outcome.trace.filter(
           (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl'),
@@ -301,7 +334,21 @@ it.effect('cleans unrun and failing stored Effect environments exactly once', ()
         1,
         `${exit} allocation release`,
       )
-      if (exit === 'failure') assertRunnerAndRows(module, outcome)
+      if (exit === 'failure') {
+        assert.isAbove(
+          outcome.trace.filter((event) => event._tag === 'EffectFailure').length,
+          0,
+          'typed failure trace',
+        )
+        assert.lengthOf(
+          outcome.trace.filter(
+            (event) => event._tag === 'Call' && event.target.name.startsWith('recover$effect$'),
+          ),
+          1,
+          'recovery runner calls',
+        )
+        assertRunnerAndRows(module, outcome)
+      }
     }
   }),
 )
@@ -344,9 +391,24 @@ it.effect('resumes a suspending stored Effect and cleans its environment exactly
       1,
     )
     assert.isAbove(outcome.trace.filter((event) => event._tag === 'SuspensionOrigin').length, 0)
-    assert.strictEqual(
-      outcome.trace.filter((event) => event._tag === 'ContinuationAcquire').length,
-      outcome.trace.filter((event) => event._tag === 'ContinuationRelease').length,
+    const allocationAcquires = outcome.trace.flatMap((event) =>
+      event._tag === 'AllocationAcquire' ? [event.ticket] : [],
     )
+    const allocationReleases = outcome.trace.flatMap((event) =>
+      event._tag === 'AllocationRelease' ? [event.ticket] : [],
+    )
+    assert.isAbove(allocationAcquires.length, 1, 'guard plus continuation allocations')
+    assertTicketsReleasedExactlyOnce(
+      allocationAcquires,
+      allocationReleases,
+      'suspending allocation',
+    )
+    const continuationAcquires = outcome.trace.flatMap((event) =>
+      event._tag === 'ContinuationAcquire' && event.ticket !== undefined ? [event.ticket] : [],
+    )
+    const continuationReleases = outcome.trace.flatMap((event) =>
+      event._tag === 'ContinuationRelease' && event.ticket !== undefined ? [event.ticket] : [],
+    )
+    assertTicketsReleasedExactlyOnce(continuationAcquires, continuationReleases, 'continuation')
   }),
 )

--- a/packages/compiler/test/StoredEffectRuntime.test.ts
+++ b/packages/compiler/test/StoredEffectRuntime.test.ts
@@ -3,7 +3,6 @@ import * as Effect from 'effect/Effect'
 import * as Analysis from '../src/Analysis.js'
 import * as BootstrapEvaluation from '../src/BootstrapEvaluation.js'
 import * as ContinuationLayout from '../src/ContinuationLayout.js'
-import * as Hir from '../src/Hir.js'
 import * as Layout from '../src/Layout.js'
 import * as Lower from '../src/Lower.js'
 import * as Mir from '../src/Mir.js'
@@ -61,7 +60,7 @@ const completedValue = (outcome: BootstrapEvaluation.Outcome): number => {
   return outcome.result.value
 }
 
-const storedRun = (module: Mir.Module, label = 'stored Effect', runnerName?: string) => {
+const storedRun = (module: Mir.Module, label = 'stored Effect') => {
   const realizations = module.layout.entries.flatMap((entry) =>
     entry.representation._tag === 'StoredEffectEnvironment'
       ? [entry.representation.realization]
@@ -71,38 +70,8 @@ const storedRun = (module: Mir.Module, label = 'stored Effect', runnerName?: str
     for (const operation of module.functions.flatMap(Mir.operations)) {
       if (operation._tag !== 'RunEffectValue') continue
       const runner = operation.runnerBase?.declaration ?? operation.runner
-      if (
-        runner.module === realization.runner.module &&
-        runner.name === realization.runner.name &&
-        (runnerName === undefined || runner.name === runnerName)
-      )
+      if (runner.module === realization.runner.module && runner.name === realization.runner.name)
         return Object.freeze({ operation, realization })
-    }
-  }
-  for (const fn of module.functions) {
-    for (const operation of Mir.operations(fn)) {
-      if (operation._tag !== 'RunEffectValue') continue
-      const runner = operation.runnerBase?.declaration ?? operation.runner
-      if (runnerName === undefined || runner.name !== runnerName) continue
-      const effect = fn.localTypes.at(operation.effect.ordinal)
-      if (effect?._tag !== 'EffectValue') continue
-      const exactRunner = Hir.effectRunnerId(
-        effect.environment.instance.declaration,
-        effect.environment.site,
-      )
-      if (runner.module !== exactRunner.module || runner.name !== exactRunner.name) continue
-      return Object.freeze({
-        operation,
-        realization: Object.freeze({
-          runner: exactRunner,
-          runnerArguments: effect.environment.instance.typeArguments,
-          rows: Object.freeze({
-            failures: effect.type.failures,
-            requirements: effect.type.requirements,
-          }),
-          access: effect.type.access,
-        }),
-      })
     }
   }
   const expected = realizations.map((realization) => realization.runner.name).join(', ')
@@ -117,12 +86,8 @@ const storedRun = (module: Mir.Module, label = 'stored Effect', runnerName?: str
   return unreachable(`expected one ${label} run (${expected || 'none'}; saw ${actual || 'none'})`)
 }
 
-const assertRunnerAndRows = (
-  module: Mir.Module,
-  outcome: BootstrapEvaluation.Outcome,
-  runnerName?: string,
-): void => {
-  const { operation, realization } = storedRun(module, 'stored Effect', runnerName)
+const assertRunnerAndRows = (module: Mir.Module, outcome: BootstrapEvaluation.Outcome): void => {
+  const { operation, realization } = storedRun(module)
   assert.deepEqual(operation.runnerBase?.declaration ?? operation.runner, realization.runner)
   assert.deepEqual(
     operation.runnerBase?.typeArguments ?? operation.runnerTypeArguments,
@@ -171,9 +136,35 @@ const assertProvidedSpecialization = (
   )
 }
 
+const assertOwnershipFacts = (
+  realization: ReturnType<typeof storedRun>['realization'],
+  name: (typeof runtimeMatrix)[number]['name'],
+): void => {
+  assert.isTrue('environment' in realization && 'cleanup' in realization, name)
+  if (!('environment' in realization) || !('cleanup' in realization)) return
+  if (name === 'shared' || name === 'exclusive') {
+    assert.isTrue(
+      name === 'shared'
+        ? realization.environment.every((slot) => !slot.owned)
+        : realization.environment.some((slot) => slot.borrowed),
+      name,
+    )
+    assert.lengthOf(realization.cleanup.unrunLanes, 0, name)
+    assert.isFalse(realization.cleanup.consumedByRun, name)
+    return
+  }
+  assert.isTrue(
+    realization.environment.some((slot) => slot.owned),
+    name,
+  )
+  assert.isAbove(realization.cleanup.unrunLanes.length, 0, name)
+  assert.isTrue(realization.cleanup.consumedByRun, name)
+}
+
 const shared = `struct Deferred<F: Effect<i32>> { operation: F }
 pub fn main() -> i32 {
-  let deferred = Deferred { operation: effect { return 21 } }
+  let base = 21
+  let deferred = Deferred { operation: effect { return base } }
   return (run deferred.operation) + (run deferred.operation)
 }`
 
@@ -187,13 +178,20 @@ pub fn main() -> i32 {
   return (run deferred.operation) + (run deferred.operation)
 }`
 
-const consuming = `struct Token { value: i32 }
+const consuming = `struct Token { value: i32 storage: Allocation }
+impl Drop for Token { fn drop(self: &mut Token) -> () { return () } }
 struct Deferred<F: once Effect<i32>> { operation: F }
 fn consume(token: Token) -> i32 { return token.value }
-pub fn main() -> i32 {
-  let token = Token { value: 42 }
+effect fn build() -> i32 ! OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let token = Token { value: 42, storage: move storage }
   let deferred = Deferred { operation: effect { return consume(move token) } }
   return run deferred.operation
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
 }`
 
 const provided = `service Counter { effect fn get() -> i32 ? &Counter }
@@ -223,12 +221,28 @@ it.effect('executes stored Effects with exact runner, rows, access, and ownershi
         testCase.source,
       )
       assert.deepEqual(Mir.verify(module), [], testCase.name)
-      const runnerName = testCase.name === 'provided' ? 'bindRequirement$effect$-1' : undefined
-      const { realization } = storedRun(module, testCase.name, runnerName)
+      const { realization } = storedRun(module, testCase.name)
       assert.strictEqual(realization.access, testCase.access, testCase.name)
+      assertOwnershipFacts(realization, testCase.name)
       const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
       assert.strictEqual(completedValue(outcome), testCase.result, testCase.name)
-      assertRunnerAndRows(module, outcome, runnerName)
+      assertRunnerAndRows(module, outcome)
+      if (testCase.name === 'consuming') {
+        assert.strictEqual(
+          outcome._tag === 'Completed'
+            ? outcome.trace.filter(
+                (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl'),
+              ).length
+            : 0,
+          1,
+        )
+        assert.strictEqual(
+          outcome._tag === 'Completed'
+            ? outcome.trace.filter((event) => event._tag === 'AllocationRelease').length
+            : 0,
+          1,
+        )
+      }
       if (testCase.name === 'provided') assertProvidedSpecialization(module, outcome)
     }
   }),

--- a/packages/compiler/test/StoredEffectRuntime.test.ts
+++ b/packages/compiler/test/StoredEffectRuntime.test.ts
@@ -1,0 +1,338 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as BootstrapEvaluation from '../src/BootstrapEvaluation.js'
+import * as ContinuationLayout from '../src/ContinuationLayout.js'
+import * as Hir from '../src/Hir.js'
+import * as Layout from '../src/Layout.js'
+import * as Lower from '../src/Lower.js'
+import * as Mir from '../src/Mir.js'
+import * as MirNormalization from '../src/MirNormalization.js'
+import * as OpaqueRealization from '../src/OpaqueRealization.js'
+import type * as Ownership from '../src/Ownership.js'
+import * as ProvisionalMir from '../src/ProvisionalMir.js'
+import * as SuspensionMir from '../src/SuspensionMir.js'
+import * as SuspensionOwnership from '../src/SuspensionOwnership.js'
+import * as Target from '../src/Target.js'
+import { unreachable } from './support/raise.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const lowerStored = Effect.fnUntraced(function* (name: string, source: string) {
+  const snapshot = yield* Analysis.ofSourceRealized(
+    name,
+    ascii(source),
+    Target.wasm32UnknownUnknown.id,
+  )
+  const diagnostics = Analysis.diagnostics(snapshot)
+  assert.isTrue(diagnostics.length > 0)
+  assert.isTrue(
+    diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
+    JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
+  )
+  const catalog = Layout.catalog(Target.wasm32UnknownUnknown, snapshot.index, snapshot.instances)
+  const layout = Layout.plan(catalog, snapshot.instances)
+  const ownership =
+    Analysis.ownershipOf(snapshot, name) ?? unreachable('expected module ownership facts')
+  const lowered = Lower.lowerProgram(
+    snapshot.instances,
+    new Map<string, Ownership.ModuleOwnership>([[name, ownership]]),
+    layout,
+    snapshot.index,
+    OpaqueRealization.catalogOf(snapshot),
+  )
+  const provisional = ProvisionalMir.build(snapshot.instances, layout, snapshot.index)
+  const normalized = MirNormalization.normalize(lowered, provisional)
+  const module = ContinuationLayout.apply(
+    SuspensionMir.finalize(
+      normalized,
+      provisional,
+      SuspensionOwnership.plan(normalized, provisional, snapshot.index),
+      snapshot.index,
+    ),
+  )
+  return Object.freeze({ snapshot, module })
+})
+
+const completedValue = (outcome: BootstrapEvaluation.Outcome): number => {
+  assert.strictEqual(outcome._tag, 'Completed', outcome._tag)
+  if (outcome._tag !== 'Completed') return unreachable('expected completed evaluation')
+  return outcome.result.value
+}
+
+const storedRun = (module: Mir.Module, label = 'stored Effect', runnerName?: string) => {
+  const realizations = module.layout.entries.flatMap((entry) =>
+    entry.representation._tag === 'StoredEffectEnvironment'
+      ? [entry.representation.realization]
+      : [],
+  )
+  for (const realization of realizations) {
+    for (const operation of module.functions.flatMap(Mir.operations)) {
+      if (operation._tag !== 'RunEffectValue') continue
+      const runner = operation.runnerBase?.declaration ?? operation.runner
+      if (
+        runner.module === realization.runner.module &&
+        runner.name === realization.runner.name &&
+        (runnerName === undefined || runner.name === runnerName)
+      )
+        return Object.freeze({ operation, realization })
+    }
+  }
+  for (const fn of module.functions) {
+    for (const operation of Mir.operations(fn)) {
+      if (operation._tag !== 'RunEffectValue') continue
+      const runner = operation.runnerBase?.declaration ?? operation.runner
+      if (runnerName === undefined || runner.name !== runnerName) continue
+      const effect = fn.localTypes.at(operation.effect.ordinal)
+      if (effect?._tag !== 'EffectValue') continue
+      const exactRunner = Hir.effectRunnerId(
+        effect.environment.instance.declaration,
+        effect.environment.site,
+      )
+      if (runner.module !== exactRunner.module || runner.name !== exactRunner.name) continue
+      return Object.freeze({
+        operation,
+        realization: Object.freeze({
+          runner: exactRunner,
+          runnerArguments: effect.environment.instance.typeArguments,
+          rows: Object.freeze({
+            failures: effect.type.failures,
+            requirements: effect.type.requirements,
+          }),
+          access: effect.type.access,
+        }),
+      })
+    }
+  }
+  const expected = realizations.map((realization) => realization.runner.name).join(', ')
+  const actual = module.functions
+    .flatMap(Mir.operations)
+    .flatMap((operation) =>
+      operation._tag === 'RunEffectValue'
+        ? [operation.runnerBase?.declaration.name ?? operation.runner.name]
+        : [],
+    )
+    .join(', ')
+  return unreachable(`expected one ${label} run (${expected || 'none'}; saw ${actual || 'none'})`)
+}
+
+const assertRunnerAndRows = (
+  module: Mir.Module,
+  outcome: BootstrapEvaluation.Outcome,
+  runnerName?: string,
+): void => {
+  const { operation, realization } = storedRun(module, 'stored Effect', runnerName)
+  assert.deepEqual(operation.runnerBase?.declaration ?? operation.runner, realization.runner)
+  assert.deepEqual(
+    operation.runnerBase?.typeArguments ?? operation.runnerTypeArguments,
+    realization.runnerArguments,
+  )
+  assert.deepEqual(operation.outcomeType.type.failures, realization.rows.failures)
+  assert.deepEqual(operation.outcomeType.type.requirements, realization.rows.requirements)
+  assert.strictEqual(outcome._tag, 'Completed')
+  if (outcome._tag !== 'Completed') return
+  assert.isTrue(
+    outcome.trace.some(
+      (event) =>
+        event._tag === 'Call' &&
+        event.target.module === operation.runner.module &&
+        event.target.name === operation.runner.name,
+    ),
+  )
+}
+
+const assertProvidedSpecialization = (
+  module: Mir.Module,
+  outcome: BootstrapEvaluation.Outcome,
+): void => {
+  const operation = module.functions
+    .flatMap(Mir.operations)
+    .find(
+      (candidate) =>
+        candidate._tag === 'RunEffectValue' &&
+        candidate.runnerBase?.declaration.name === 'count$effect$-1',
+    )
+  assert.isDefined(operation)
+  if (operation?._tag !== 'RunEffectValue') return
+  assert.match(operation.runner.name, /^count\$effect\$-1\$provided\$/)
+  assert.lengthOf(operation.providers, 1)
+  assert.deepEqual(operation.outcomeType.type.failures, [])
+  assert.lengthOf(operation.outcomeType.type.requirements, 1)
+  assert.strictEqual(outcome._tag, 'Completed')
+  if (outcome._tag !== 'Completed') return
+  assert.isTrue(
+    outcome.trace.some(
+      (event) =>
+        event._tag === 'Call' &&
+        event.target.module === operation.runner.module &&
+        event.target.name === operation.runner.name,
+    ),
+  )
+}
+
+const shared = `struct Deferred<F: Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let deferred = Deferred { operation: effect { return 21 } }
+  return (run deferred.operation) + (run deferred.operation)
+}`
+
+const exclusive = `struct Deferred<F: mut Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let mut counter = 20
+  let mut deferred = Deferred { operation: effect {
+    counter = counter + 1
+    return counter
+  } }
+  return (run deferred.operation) + (run deferred.operation)
+}`
+
+const consuming = `struct Token { value: i32 }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+pub fn main() -> i32 {
+  let token = Token { value: 42 }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  return run deferred.operation
+}`
+
+const provided = `service Counter { effect fn get() -> i32 ? &Counter }
+struct Fixed { value: i32 }
+effect fn get(self: &Fixed) -> i32 { return self.value }
+impl Counter for Fixed { get: Fixed.get }
+effect fn count() -> i32 ? &Counter { return run Counter.get() }
+struct Deferred<F: once Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let fixed = Fixed { value: 42 }
+  let deferred = Deferred { operation: count() |> Effect.provide(&fixed) }
+  return run deferred.operation
+}`
+
+const runtimeMatrix = [
+  { name: 'shared', source: shared, result: 42, access: 'Shared' },
+  { name: 'exclusive', source: exclusive, result: 43, access: 'Exclusive' },
+  { name: 'consuming', source: consuming, result: 42, access: 'Take' },
+  { name: 'provided', source: provided, result: 42, access: 'Take' },
+] as const
+
+it.effect('executes stored Effects with exact runner, rows, access, and ownership transport', () =>
+  Effect.gen(function* () {
+    for (const testCase of runtimeMatrix) {
+      const { snapshot, module } = yield* lowerStored(
+        `stored-effect-runtime/${testCase.name}`,
+        testCase.source,
+      )
+      assert.deepEqual(Mir.verify(module), [], testCase.name)
+      const runnerName = testCase.name === 'provided' ? 'bindRequirement$effect$-1' : undefined
+      const { realization } = storedRun(module, testCase.name, runnerName)
+      assert.strictEqual(realization.access, testCase.access, testCase.name)
+      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+      assert.strictEqual(completedValue(outcome), testCase.result, testCase.name)
+      assertRunnerAndRows(module, outcome, runnerName)
+      if (testCase.name === 'provided') assertProvidedSpecialization(module, outcome)
+    }
+  }),
+)
+
+type CleanupExit = 'unrun' | 'failure'
+
+const cleanupProgram = (exit: CleanupExit): string => `struct Problem { code: i32 }
+struct Guard { tag: i32 storage: Allocation }
+impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
+fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
+  operation: F
+) -> Deferred<A, E, R, F> {
+  return Deferred<A, E, R> { operation: move operation }
+}
+effect fn failing(guard: Guard) -> i32 ! Problem {
+  let result = guard.tag
+  if result == 0 { return 0 }
+  fail Problem { code: result }
+}
+effect fn build() -> i32 ! Problem | OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let storage = run Allocator.allocate(Layout.of<i32>()) |> Effect.provideMut(&mut allocator)
+  let guard = Guard { tag: 42, storage: move storage }
+  let deferred = defer(failing(move guard))
+  ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
+}
+effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect('cleans unrun and failing stored Effect environments exactly once', () =>
+  Effect.gen(function* () {
+    for (const exit of ['unrun', 'failure'] as const) {
+      const { snapshot, module } = yield* lowerStored(
+        `stored-effect-runtime/cleanup-${exit}`,
+        cleanupProgram(exit),
+      )
+      assert.deepEqual(Mir.verify(module), [], exit)
+      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+      assert.strictEqual(completedValue(outcome), 42, exit)
+      assert.strictEqual(
+        outcome.trace.filter(
+          (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl'),
+        ).length,
+        1,
+        `${exit} Drop hook`,
+      )
+      assert.strictEqual(
+        outcome.trace.filter((event) => event._tag === 'AllocationAcquire').length,
+        1,
+        `${exit} allocation acquire`,
+      )
+      assert.strictEqual(
+        outcome.trace.filter((event) => event._tag === 'AllocationRelease').length,
+        1,
+        `${exit} allocation release`,
+      )
+      if (exit === 'failure') assertRunnerAndRows(module, outcome)
+    }
+  }),
+)
+
+const suspending = `struct Guard { tag: i32 storage: Allocation }
+impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
+fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
+  operation: F
+) -> Deferred<A, E, R, F> {
+  return Deferred<A, E, R> { operation: move operation }
+}
+effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
+  let base = run Effect.suspend(effect { return 40 })
+  return base + guard.tag
+}
+effect fn build() -> i32 ! OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let guard = Guard { tag: 2, storage: move storage }
+  let deferred = defer(delayed(move guard))
+  return run deferred.operation
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
+}`
+
+it.effect('resumes a suspending stored Effect and cleans its environment exactly once', () =>
+  Effect.gen(function* () {
+    const { snapshot, module } = yield* lowerStored('stored-effect-runtime/suspending', suspending)
+    assert.deepEqual(Mir.verify(module), [])
+    const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+    assert.strictEqual(completedValue(outcome), 42)
+    assertRunnerAndRows(module, outcome)
+    assert.strictEqual(
+      outcome.trace.filter(
+        (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl'),
+      ).length,
+      1,
+    )
+    assert.isAbove(outcome.trace.filter((event) => event._tag === 'SuspensionOrigin').length, 0)
+    assert.strictEqual(
+      outcome.trace.filter((event) => event._tag === 'ContinuationAcquire').length,
+      outcome.trace.filter((event) => event._tag === 'ContinuationRelease').length,
+    )
+  }),
+)


### PR DESCRIPTION
## Scope

- Completes only OpenSpec store-effects-in-nominals task 4.1.
- Executes shared, exclusive, consuming, unrun, failing, provided, and suspending stored Effects in the evaluator.
- Preserves exact runner identity, rows, access, ownership/loan transport, and exactly-once cleanup traces.
- Keeps SEM0107 globally active and uses a narrow internal evaluator acceptance path.

## Evidence

- Post-rebase focused suite: 15 files, 137 tests passed, including the 9 evaluator/storage files and #192 witness/static-runner tests.
- Compiler typecheck and targeted Biome passed.
- pnpm release:candidate passed: 12 package builds and 7 validations.
- Coordinated local pnpm check: 35/36 Turbo tasks passed; compiler 1,843/1,844 tests passed. The sole WasmShadowStackHeapCollision host-stack probe failure reproduces identically on clean base 7070e7d and is pre-existing.
- Exact-head CI at cc895fedf42fb3d61398f04eb3b4ba48a26ee98c passed: validate and webcontainer-browser.
- Three read-only candidate reviews and three delta reviews report no merge or downstream blockers.

## Deferred

OpenSpec tasks 4.2, 4.3, and 4.4 remain unchecked: no native LLVM/direct Wasm parity, invalidation fixtures, or SEM0107 retirement is included.