### PR TITLE
#190 PR4b — Stored Effect native and Wasm parity

### DIFF
--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -19,10 +19,7 @@
 ## 4. Engine Parity and Invalidation
 
 - [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
-- [x] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
-  - Direct Wasm executes each shape end to end; native parity is proven at emitted LLVM IR because
-    `SEM0107` still fences these programs out of `Analysis.realize`, so `Driver.compile` cannot
-    reach a native executable until task 4.4 narrows the fence.
+- [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
 - [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
 - [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
 

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -19,7 +19,7 @@
 ## 4. Engine Parity and Invalidation
 
 - [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
-- [x] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
+- [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
 - [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
 - [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
 

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -19,7 +19,10 @@
 ## 4. Engine Parity and Invalidation
 
 - [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
-- [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
+- [x] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
+  - Direct Wasm executes each shape end to end; native parity is proven at emitted LLVM IR because
+    `SEM0107` still fences these programs out of `Analysis.realize`, so `Driver.compile` cannot
+    reach a native executable until task 4.4 narrows the fence.
 - [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
 - [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
 

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -19,7 +19,7 @@
 ## 4. Engine Parity and Invalidation
 
 - [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
-- [ ] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
+- [x] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
 - [ ] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
 - [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
 

--- a/packages/compiler/src/Backend.ts
+++ b/packages/compiler/src/Backend.ts
@@ -983,6 +983,12 @@ const emitProgram = (program: Mir.Module, request: CodegenRequest) =>
             }),
           }),
         ])
+      if (type._tag === 'EffectValue' && type.storage !== undefined) {
+        const shape = Layout.callingShape(program.layout, type.storage.type)
+        if (shape === undefined)
+          throw new RangeError('LLVM backend lost a stored Effect calling shape')
+        return shape.lanes
+      }
       if (type._tag === 'EffectValue')
         return Layout.effectEnvironmentLanes(program.layout, type.environment)
       if (type._tag === 'CallableValue' && type.storage !== undefined) {

--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -115,6 +115,41 @@ const i64 = ValType.i64
 const f32 = ValType.f32
 const f64 = ValType.f64
 
+/**
+ * The lanes one MIR type occupies, for locals, signatures, and suspension transfer slots alike.
+ *
+ * A stored executable must resolve through its storage type's calling shape: that is the only
+ * producer that prefixes each lane path with the owning `EffectCaptureSelector` or
+ * `CallableCaptureSelector`. `effectEnvironmentLanes`/`callableEnvironmentLanes` emit the same
+ * lane count and value types but prefix-less paths, so a caller that reads `lane.path` — such as
+ * place-read realization — cannot match them against a destination lane. Every lane computation
+ * shares this function so the two can never disagree.
+ */
+const laneKindsOf = (
+  plan: LayoutPlan.Plan,
+  type: Mir.Type,
+): ReadonlyArray<LayoutPlan.CallingLane> => {
+  if (type._tag === 'EffectValue' && type.storage !== undefined) {
+    const shape = LayoutPlan.callingShape(plan, type.storage.type)
+    if (shape === undefined) throw new RangeError('Wasm backend lost a stored Effect calling shape')
+    return shape.lanes
+  }
+  if (type._tag === 'EffectValue') return LayoutPlan.effectEnvironmentLanes(plan, type.environment)
+  if (type._tag === 'CallableValue' && type.storage !== undefined) {
+    const shape = LayoutPlan.callingShape(plan, type.storage.type)
+    if (shape === undefined)
+      throw new RangeError('Wasm backend lost a stored callable calling shape')
+    return shape.lanes
+  }
+  if (type._tag === 'CallableValue')
+    return type.environment === undefined
+      ? Object.freeze([])
+      : LayoutPlan.callableEnvironmentLanes(plan, type.environment)
+  const shape = LayoutPlan.callingShape(plan, Mir.semanticType(type))
+  if (shape === undefined) throw new RangeError('Wasm backend lost a calling shape')
+  return shape.lanes
+}
+
 const laneValueType = (plan: LayoutPlan.Plan, lane: LayoutPlan.CallingLane): ValType.ValType => {
   if (typeof lane.type !== 'string') return i32
   const scalar = Scalar.find(lane.type)
@@ -1284,25 +1319,7 @@ const layoutOf = (
       if (shape === undefined) throw new RangeError('Wasm backend lost a borrowed calling shape')
       return shape.lanes
     }
-    if (type._tag === 'EffectValue' && type.storage !== undefined) {
-      const shape = LayoutPlan.callingShape(plan, type.storage.type)
-      if (shape === undefined) throw new RangeError('Wasm backend lost a stored Effect shape')
-      return shape.lanes
-    }
-    if (type._tag === 'EffectValue')
-      return LayoutPlan.effectEnvironmentLanes(plan, type.environment)
-    if (type._tag === 'CallableValue' && type.storage !== undefined) {
-      const shape = LayoutPlan.callingShape(plan, type.storage.type)
-      if (shape === undefined) throw new RangeError('Wasm backend lost a stored callable shape')
-      return shape.lanes
-    }
-    if (type._tag === 'CallableValue')
-      return type.environment === undefined
-        ? Object.freeze([])
-        : LayoutPlan.callableEnvironmentLanes(plan, type.environment)
-    const shape = LayoutPlan.callingShape(plan, Mir.semanticType(type))
-    if (shape === undefined) throw new RangeError('Wasm backend lost a logical calling shape')
-    return shape.lanes
+    return laneKindsOf(plan, type)
   }
   const lanes = fn.localTypes.map(logicalLanes)
   const signatureLaneCount = (type: Mir.Type): number =>
@@ -4773,13 +4790,7 @@ const emitBody = (
       const shape = LayoutPlan.callingShape(plan, fn.result.type)
       return shape?.lanes ?? Object.freeze([])
     }
-    if (fn.result._tag === 'EffectValue')
-      return LayoutPlan.effectEnvironmentLanes(plan, fn.result.environment)
-    if (fn.result._tag === 'CallableValue')
-      return fn.result.environment === undefined
-        ? Object.freeze([])
-        : LayoutPlan.callableEnvironmentLanes(plan, fn.result.environment)
-    return LayoutPlan.callingShape(plan, Mir.semanticType(fn.result))?.lanes ?? Object.freeze([])
+    return laneKindsOf(plan, fn.result)
   })()
   const zeroOf = (type: ValType.ValType): Instr.Instr =>
     type === i64
@@ -5316,15 +5327,7 @@ const emitProgram = (program: Mir.Module, request: Backend.CodegenRequest) =>
             }),
           }),
         ])
-      if (type._tag === 'EffectValue')
-        return LayoutPlan.effectEnvironmentLanes(program.layout, type.environment)
-      if (type._tag === 'CallableValue')
-        return type.environment === undefined
-          ? Object.freeze([])
-          : LayoutPlan.callableEnvironmentLanes(program.layout, type.environment)
-      const shape = LayoutPlan.callingShape(program.layout, Mir.semanticType(type))
-      if (shape === undefined) throw new RangeError('Wasm declaration lost a calling shape')
-      return shape.lanes
+      return laneKindsOf(program.layout, type)
     }
     const originRecords = program.functions
       .flatMap((fn) =>

--- a/packages/compiler/src/WasmBackend.ts
+++ b/packages/compiler/src/WasmBackend.ts
@@ -1284,6 +1284,11 @@ const layoutOf = (
       if (shape === undefined) throw new RangeError('Wasm backend lost a borrowed calling shape')
       return shape.lanes
     }
+    if (type._tag === 'EffectValue' && type.storage !== undefined) {
+      const shape = LayoutPlan.callingShape(plan, type.storage.type)
+      if (shape === undefined) throw new RangeError('Wasm backend lost a stored Effect shape')
+      return shape.lanes
+    }
     if (type._tag === 'EffectValue')
       return LayoutPlan.effectEnvironmentLanes(plan, type.environment)
     if (type._tag === 'CallableValue' && type.storage !== undefined) {

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -1,5 +1,5 @@
 import { NodeServices } from '@effect/platform-node'
-import { assert, it } from '@effect/vitest'
+import { assert, layer } from '@effect/vitest'
 import * as Config from 'effect/Config'
 import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
@@ -26,6 +26,8 @@ import { unreachable } from './support/raise.js'
 
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 const clangPath = Effect.fnUntraced(function* () {
   const configured = yield* Config.string('SILK_TEST_CLANG').pipe(Config.withDefault(''))
@@ -74,6 +76,14 @@ const runNative = Effect.fnUntraced(function* (
   )
   if (linked._tag !== 'Executable') return unreachable('expected a native executable')
   return yield* Process.run(linked.path, [])
+})
+
+const makeToolchain = Effect.fnUntraced(function* () {
+  return Object.freeze({
+    _tag: 'Toolchain' as const,
+    clang: yield* clangPath(),
+    shimCache: NativeToolchain.makeShimCache(),
+  })
 })
 
 const lowerSource = Effect.fnUntraced(function* (
@@ -225,9 +235,6 @@ const emittedFunction = (module: Mir.Module, runner: { module: string; name: str
   )
 }
 
-const emittedSymbol = (module: Mir.Module, runner: { module: string; name: string }): string =>
-  Backend.symbolFor(emittedFunction(module, runner), Mir.machineEntry(module))
-
 /** The exact debug-WAT call target for one runner, including the suspend-step suffix when needed. */
 const emittedWasmCallTarget = (
   module: Mir.Module,
@@ -249,6 +256,26 @@ const assertDirectWasmRunner = (
   const target = emittedWasmCallTarget(module, runner)
   assert.include(wat, `call $${target}`, `${label} direct call $${target}`)
   assert.notInclude(wat, 'call_indirect', label)
+}
+
+/**
+ * Pins the LLVM call instruction, not merely that the runner symbol is defined.
+ *
+ * A `define ... @symbol` line would satisfy a substring check; `call ... @symbol(` is the
+ * static dispatch the stored run must emit, including `$suspend_step` when the runner suspends.
+ */
+const assertDirectLlvmRunner = (
+  ir: string,
+  module: Mir.Module,
+  runner: { module: string; name: string },
+  label: string,
+): void => {
+  const target = emittedWasmCallTarget(module, runner)
+  assert.match(
+    ir,
+    new RegExp(`\\bcall\\b[^\\n]*@${escapeRegExp(target)}\\(`),
+    `${label} LLVM call @${target}`,
+  )
 }
 
 const dropCalls = (outcome: BootstrapEvaluation.Outcome): number =>
@@ -316,111 +343,111 @@ const runtimeMatrix = [
   { name: 'provided', source: provided, result: 42, access: 'Take' },
 ] as const
 
-it.effect(
-  'executes stored Effects with identical results and runner identity in every engine',
-  () =>
-    Effect.gen(function* () {
-      const host = yield* Target.host()
-      const toolchain = Object.freeze({
-        _tag: 'Toolchain' as const,
-        clang: yield* clangPath(),
-        shimCache: NativeToolchain.makeShimCache(),
-      })
-      for (const testCase of runtimeMatrix) {
-        // One module name for both targets: the runner identity must not depend on the target.
-        const moduleName = `stored-effect-parity/${testCase.name}`
-        const wasmLowering = yield* lowerStored(
-          moduleName,
-          testCase.source,
-          Target.wasm32UnknownUnknown,
-        )
-        const { realization } = storedRunner(wasmLowering.module, testCase.name)
-        assert.strictEqual(realization.access, testCase.access, testCase.name)
-        assertExactRows(wasmLowering.module, testCase.name)
+layer(NodeServices.layer)('stored Effect engine parity', (it) => {
+  it.effect(
+    'executes stored Effects with identical results and runner identity in every engine',
+    () =>
+      Effect.gen(function* () {
+        const host = yield* Target.host()
+        const toolchain = yield* makeToolchain()
+        for (const testCase of runtimeMatrix) {
+          // One module name for both targets: the runner identity must not depend on the target.
+          const moduleName = `stored-effect-parity/${testCase.name}`
+          const wasmLowering = yield* lowerStored(
+            moduleName,
+            testCase.source,
+            Target.wasm32UnknownUnknown,
+          )
+          const { realization } = storedRunner(wasmLowering.module, testCase.name)
+          assert.strictEqual(realization.access, testCase.access, testCase.name)
+          assertExactRows(wasmLowering.module, testCase.name)
 
-        const evaluated = BootstrapEvaluation.evaluate(
-          wasmLowering.snapshot.instances,
-          wasmLowering.module,
-        )
-        assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
+          const evaluated = BootstrapEvaluation.evaluate(
+            wasmLowering.snapshot.instances,
+            wasmLowering.module,
+          )
+          assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
 
-        // Debug WAT names the exact call target; release would only give a numeric index.
-        const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
-          mode: 'debug',
-        })
-        assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
-        if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-        assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
-        assertDirectWasmRunner(wasm.wat, wasmLowering.module, realization.runner, testCase.name)
+          // Debug WAT names the exact call target; release would only give a numeric index.
+          const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
+            mode: 'debug',
+          })
+          assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+          if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+          assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
+          assertDirectWasmRunner(wasm.wat, wasmLowering.module, realization.runner, testCase.name)
 
-        const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
-        const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
-        // The native lowering carries the same exact rows the Wasm lowering and evaluator proved.
-        assertExactRows(nativeLowering.module, testCase.name)
-        const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
-          mode: 'release',
-        })
-        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
-        if (llvm._tag !== 'LlvmBitcodeArtifact') return
-        assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
-        // The same static runner the evaluator called is the one LLVM emitted.
-        assert.include(
-          llvm.ir,
-          emittedSymbol(nativeLowering.module, nativeRunner.realization.runner),
-          testCase.name,
-        )
-        assert.deepEqual(
-          nativeRunner.realization.runner,
-          realization.runner,
-          `${testCase.name} runner identity across targets`,
-        )
-        const nativeRun = yield* runNative(toolchain, llvm, host)
-        assert.strictEqual(
-          Number(nativeRun.exitCode),
-          testCase.result,
-          `${testCase.name} native: ${nativeRun.stderr}`,
-        )
-        if (testCase.name === 'provided') {
-          // Service provision resolves statically: the specialized runner reaches the backend, and
-          // the provider travels in the environment rather than a runtime dictionary.
-          const specialized = nativeLowering.module.functions
-            .flatMap(Mir.operations)
-            .find(
-              (candidate) =>
-                candidate._tag === 'RunEffectValue' &&
-                candidate.runnerBase?.declaration.name === 'count$effect$-1',
-            )
-          assert.isDefined(specialized, testCase.name)
-          if (specialized?._tag !== 'RunEffectValue') return
-          assert.match(specialized.runner.name, /^count\$effect\$-1\$provided\$/)
-          assert.lengthOf(specialized.providers, 1, testCase.name)
-          assert.include(
+          const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
+          const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
+          // The native lowering carries the same exact rows the Wasm lowering and evaluator proved.
+          assertExactRows(nativeLowering.module, testCase.name)
+          const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
+            mode: 'release',
+          })
+          assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
+          if (llvm._tag !== 'LlvmBitcodeArtifact') return
+          assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
+          assertDirectLlvmRunner(
             llvm.ir,
-            emittedSymbol(nativeLowering.module, specialized.runner),
+            nativeLowering.module,
+            nativeRunner.realization.runner,
             testCase.name,
           )
-          assertDirectWasmRunner(
-            wasm.wat,
-            wasmLowering.module,
-            specialized.runner,
-            `${testCase.name} specialized`,
+          assert.deepEqual(
+            nativeRunner.realization.runner,
+            realization.runner,
+            `${testCase.name} runner identity across targets`,
           )
+          const nativeRun = yield* runNative(toolchain, llvm, host)
+          assert.strictEqual(
+            Number(nativeRun.exitCode),
+            testCase.result,
+            `${testCase.name} native: ${nativeRun.stderr}`,
+          )
+          if (testCase.name === 'provided') {
+            // Service provision resolves statically: the specialized runner reaches the backend, and
+            // the provider travels in the environment rather than a runtime dictionary.
+            const specialized = nativeLowering.module.functions
+              .flatMap(Mir.operations)
+              .find(
+                (candidate) =>
+                  candidate._tag === 'RunEffectValue' &&
+                  candidate.runnerBase?.declaration.name === 'count$effect$-1',
+              )
+            assert.isDefined(specialized, testCase.name)
+            if (specialized?._tag !== 'RunEffectValue') return
+            assert.match(specialized.runner.name, /^count\$effect\$-1\$provided\$/)
+            assert.lengthOf(specialized.providers, 1, testCase.name)
+            assertDirectLlvmRunner(
+              llvm.ir,
+              nativeLowering.module,
+              specialized.runner,
+              `${testCase.name} specialized`,
+            )
+            assertDirectWasmRunner(
+              wasm.wat,
+              wasmLowering.module,
+              specialized.runner,
+              `${testCase.name} specialized`,
+            )
+          }
         }
-      }
-    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  180_000,
-)
+      }).pipe(Effect.scoped),
+    180_000,
+  )
 
-type CleanupExit = 'unrun' | 'failure'
+  type CleanupExit = 'unrun' | 'failure'
 
-/**
- * Shared stored-Effect cleanup surface.
- *
- * Guard.drop poisons `tag` on the first call and traps on the second, so a double cleanup cannot
- * return 42. A missed cleanup is a leak: the cycle programs compare heap pages as the iteration
- * count grows. Together those two observations fail unless each live capture is cleaned once.
- */
-const cleanupSurface = `struct Problem { code: i32 }
+  /**
+   * Shared stored-Effect cleanup surface.
+   *
+   * Guard.drop poisons `tag` on the first call and traps on the second, so a double cleanup cannot
+   * return 42. A missed cleanup leaves the capture's `i32` block off Wasm free-list class 0
+   * (`heapTableBase` 65536). A mut-borrow ticket cannot be read after the stored Effect is dropped
+   * (OWN0011 / InvalidLoan), so the free-list head is the 0-vs-1 signal both backends can share
+   * with poison for 2.
+   */
+  const cleanupSurface = `struct Problem { code: i32 }
 struct Guard { tag: i32 storage: Allocation }
 impl Drop for Guard {
   fn drop(self: &mut Guard) -> () {
@@ -444,14 +471,14 @@ effect fn failing(guard: Guard) -> i32 ! Problem {
   fail Problem { code: result }
 }`
 
-/**
- * Repeats one stored-Effect construct-and-clean cycle `count` times.
- *
- * Failure recovers inside each iteration so the loop can actually repeat. Each capture is 2KiB
- * (`[i64; 256]`) so 80 leaked cycles must grow the Wasm heap past a 64KiB page; an `i32` leak
- * would stay inside the first page and the comparison would pass. A double Drop traps.
- */
-const cleanupCycles = (exit: CleanupExit, count: number): string => `${cleanupSurface}
+  /**
+   * Repeats one stored-Effect construct-and-clean cycle `count` times.
+   *
+   * Failure recovers inside each iteration so the loop can actually repeat. Each capture is 2KiB
+   * (`[i64; 256]`) so 80 leaked cycles must grow the Wasm heap past a 64KiB page; an `i32` leak
+   * would stay inside the first page and the comparison would pass. A double Drop traps.
+   */
+  const cleanupCycles = (exit: CleanupExit, count: number): string => `${cleanupSurface}
 effect fn cycle() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
   let storage = run Allocator.allocate(Layout.of<[i64; 256]>())
   let guard = Guard { tag: 7, storage: move storage }
@@ -475,26 +502,29 @@ pub fn main() -> i32 {
   return 1
 }`
 
-const pagesOf = (instance: WebAssembly.Instance): number => {
-  const memory = instance.exports[StandardStreams.wasmMemoryExport]
-  assert.instanceOf(memory, WebAssembly.Memory)
-  return memory instanceof WebAssembly.Memory
-    ? memory.buffer.byteLength / 65536
-    : Number.POSITIVE_INFINITY
-}
+  const pagesOf = (instance: WebAssembly.Instance): number => {
+    const memory = instance.exports[StandardStreams.wasmMemoryExport]
+    assert.instanceOf(memory, WebAssembly.Memory)
+    return memory instanceof WebAssembly.Memory
+      ? memory.buffer.byteLength / 65536
+      : Number.POSITIVE_INFINITY
+  }
 
-/** Runs a Wasm artifact and reports both its result and the heap it needed. */
-const runWasmMeasured = Effect.fnUntraced(function* (bytes: Uint8Array) {
-  return yield* Effect.try(() => {
-    const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
-    const main = instance.exports.silk_main
-    if (typeof main !== 'function') return unreachable('expected Wasm main')
-    const value = main()
-    return Object.freeze({ value, pages: pagesOf(instance) })
+  /** Runs a Wasm artifact and reports both its result and the heap it needed. */
+  const runWasmMeasured = Effect.fnUntraced(function* (bytes: Uint8Array) {
+    return yield* Effect.try(() => {
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
+      const main = instance.exports.silk_main
+      if (typeof main !== 'function') return unreachable('expected Wasm main')
+      const value = main()
+      const memory = instance.exports[StandardStreams.wasmMemoryExport]
+      const class0 =
+        memory instanceof WebAssembly.Memory ? new DataView(memory.buffer).getInt32(65536, true) : 0
+      return Object.freeze({ value, pages: pagesOf(instance), class0 })
+    })
   })
-})
 
-const cleanupProgram = (exit: CleanupExit): string => `${cleanupSurface}
+  const cleanupProgram = (exit: CleanupExit): string => `${cleanupSurface}
 effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
 effect fn build() -> i32 ! Problem | OutOfMemory {
   let mut allocator = SystemAllocator.make()
@@ -505,81 +535,93 @@ effect fn build() -> i32 ! Problem | OutOfMemory {
 }
 pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
 
-it.effect(
-  'cleans unrun and failing stored Effect environments exactly once in every engine',
-  () =>
-    Effect.gen(function* () {
-      const host = yield* Target.host()
-      const toolchain = Object.freeze({
-        _tag: 'Toolchain' as const,
-        clang: yield* clangPath(),
-        shimCache: NativeToolchain.makeShimCache(),
-      })
-      for (const exit of ['unrun', 'failure'] as const) {
-        const moduleName = `stored-effect-parity/cleanup-${exit}`
-        const { snapshot, module } = yield* lowerStored(
-          moduleName,
-          cleanupProgram(exit),
-          Target.wasm32UnknownUnknown,
-        )
-        const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
-        assert.strictEqual(completedValue(outcome), 42, exit)
-        // The evaluator's cleanup trace is the contract the backends must match.
-        assert.strictEqual(dropCalls(outcome), 1, `${exit} Drop hook`)
-        assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
-        assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
-
-        const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
-        assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
-        if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-        // 42 means the poisoned Drop did not run twice. A missed cleanup is a leak, proven by cycles.
-        assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
-        assert.notInclude(wasm.wat, 'call_indirect', exit)
-        if (exit === 'failure') {
-          assertDirectWasmRunner(
-            wasm.wat,
-            module,
-            storedRunner(module, exit).realization.runner,
-            exit,
+  it.effect(
+    'cleans unrun and failing stored Effect environments exactly once in every engine',
+    () =>
+      Effect.gen(function* () {
+        const host = yield* Target.host()
+        const toolchain = yield* makeToolchain()
+        for (const exit of ['unrun', 'failure'] as const) {
+          const moduleName = `stored-effect-parity/cleanup-${exit}`
+          const { snapshot, module } = yield* lowerStored(
+            moduleName,
+            cleanupProgram(exit),
+            Target.wasm32UnknownUnknown,
           )
+          const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+          assert.strictEqual(completedValue(outcome), 42, exit)
+          // The evaluator's cleanup trace is the contract the backends must match.
+          assert.strictEqual(dropCalls(outcome), 1, `${exit} Drop hook`)
+          assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
+          assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
+
+          const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
+          assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
+          if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+          const wasmRun = yield* runWasmMeasured(wasm.bytes)
+          // 42 is not enough: poison rejects 2, a non-zero class-0 free-list head rejects 0.
+          assert.strictEqual(wasmRun.value, 42, `${exit} Wasm`)
+          assert.notStrictEqual(wasmRun.class0, 0, `${exit} Wasm capture returned to class 0`)
+          assert.notInclude(wasm.wat, 'call_indirect', exit)
+          if (exit === 'failure') {
+            assertDirectWasmRunner(
+              wasm.wat,
+              module,
+              storedRunner(module, exit).realization.runner,
+              exit,
+            )
+          }
+
+          const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
+          const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+          assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
+          if (llvm._tag !== 'LlvmBitcodeArtifact') return
+          // The Drop hook that cleans the stored environment survives into native code.
+          const dropFn =
+            native.module.functions.find((candidate) =>
+              candidate.id.name.startsWith('drop@impl'),
+            ) ?? unreachable(`expected an emitted Drop hook for ${exit}`)
+          const dropSymbol = Backend.symbolFor(dropFn, Mir.machineEntry(native.module))
+          assert.match(
+            llvm.ir,
+            new RegExp(`\\bcall\\b[^\\n]*@${escapeRegExp(dropSymbol)}\\(`),
+            `${exit} LLVM Drop call`,
+          )
+          if (exit === 'failure') {
+            assertDirectLlvmRunner(
+              llvm.ir,
+              native.module,
+              storedRunner(native.module, exit).realization.runner,
+              `${exit} native`,
+            )
+          }
+          const nativeRun = yield* runNative(toolchain, llvm, host)
+          assert.strictEqual(Number(nativeRun.exitCode), 42, `${exit} native: ${nativeRun.stderr}`)
+
+          // `unrun` never reaches a run operation, so the realization is the only runner fact.
+          const runner = storedRealization(module, exit).runner
+          const runnerCalls =
+            outcome._tag === 'Completed'
+              ? outcome.trace.filter(
+                  (event) =>
+                    event._tag === 'Call' &&
+                    event.target.module === runner.module &&
+                    event.target.name === runner.name,
+                ).length
+              : -1
+          assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
+          if (exit === 'failure') {
+            assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
+            // A typed failure keeps its exact failure rows through both lowerings.
+            assertExactRows(module, exit)
+            assertExactRows(native.module, `${exit} native`)
+          }
         }
+      }).pipe(Effect.scoped),
+    180_000,
+  )
 
-        const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
-        const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
-        if (llvm._tag !== 'LlvmBitcodeArtifact') return
-        // The Drop hook that cleans the stored environment survives into native code.
-        const dropFn =
-          native.module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
-          unreachable(`expected an emitted Drop hook for ${exit}`)
-        assert.include(llvm.ir, Backend.symbolFor(dropFn, Mir.machineEntry(native.module)), exit)
-        const nativeRun = yield* runNative(toolchain, llvm, host)
-        assert.strictEqual(Number(nativeRun.exitCode), 42, `${exit} native: ${nativeRun.stderr}`)
-
-        // `unrun` never reaches a run operation, so the realization is the only runner fact.
-        const runner = storedRealization(module, exit).runner
-        const runnerCalls =
-          outcome._tag === 'Completed'
-            ? outcome.trace.filter(
-                (event) =>
-                  event._tag === 'Call' &&
-                  event.target.module === runner.module &&
-                  event.target.name === runner.name,
-              ).length
-            : -1
-        assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
-        if (exit === 'failure') {
-          assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
-          // A typed failure keeps its exact failure rows through both lowerings.
-          assertExactRows(module, exit)
-          assertExactRows(native.module, `${exit} native`)
-        }
-      }
-    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  180_000,
-)
-
-const suspending = `${cleanupSurface}
+  const suspending = `${cleanupSurface}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag
@@ -596,63 +638,62 @@ pub fn main() -> i32 {
   return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
 }`
 
-it.effect(
-  'resumes a suspending stored Effect with matching cleanup in every engine',
-  () =>
-    Effect.gen(function* () {
-      const host = yield* Target.host()
-      const toolchain = Object.freeze({
-        _tag: 'Toolchain' as const,
-        clang: yield* clangPath(),
-        shimCache: NativeToolchain.makeShimCache(),
-      })
-      const moduleName = 'stored-effect-parity/suspending'
-      const { snapshot, module } = yield* lowerStored(
-        moduleName,
-        suspending,
-        Target.wasm32UnknownUnknown,
-      )
-      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
-      assert.strictEqual(completedValue(outcome), 42)
-      assert.strictEqual(dropCalls(outcome), 1)
-      assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
-      assertExactRows(module, 'suspending')
+  it.effect(
+    'resumes a suspending stored Effect with matching cleanup in every engine',
+    () =>
+      Effect.gen(function* () {
+        const host = yield* Target.host()
+        const toolchain = yield* makeToolchain()
+        const moduleName = 'stored-effect-parity/suspending'
+        const { snapshot, module } = yield* lowerStored(
+          moduleName,
+          suspending,
+          Target.wasm32UnknownUnknown,
+        )
+        const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+        assert.strictEqual(completedValue(outcome), 42)
+        assert.strictEqual(dropCalls(outcome), 1)
+        assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
+        assertExactRows(module, 'suspending')
 
-      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
-      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
-      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-      // 42 means resume succeeded and the poisoned Drop did not run twice.
-      assert.strictEqual(yield* runWasm(wasm.bytes), 42)
-      assertDirectWasmRunner(
-        wasm.wat,
-        module,
-        storedRunner(module, 'suspending').realization.runner,
-        'suspending',
-      )
+        const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
+        assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
+        if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+        const wasmRun = yield* runWasmMeasured(wasm.bytes)
+        assert.strictEqual(wasmRun.value, 42)
+        assert.notStrictEqual(wasmRun.class0, 0, 'suspending Wasm capture returned to class 0')
+        assertDirectWasmRunner(
+          wasm.wat,
+          module,
+          storedRunner(module, 'suspending').realization.runner,
+          'suspending',
+        )
 
-      const native = yield* lowerStored(moduleName, suspending, host)
-      const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
-      if (llvm._tag !== 'LlvmBitcodeArtifact') return
-      assert.include(llvm.ir, 'define i32 @silk_main')
-      assert.include(
-        llvm.ir,
-        emittedSymbol(native.module, storedRunner(native.module, 'suspending').realization.runner),
-      )
-      const nativeRun = yield* runNative(toolchain, llvm, host)
-      assert.strictEqual(Number(nativeRun.exitCode), 42, `suspending native: ${nativeRun.stderr}`)
-    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
-  180_000,
-)
+        const native = yield* lowerStored(moduleName, suspending, host)
+        const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
+        if (llvm._tag !== 'LlvmBitcodeArtifact') return
+        assert.include(llvm.ir, 'define i32 @silk_main')
+        assertDirectLlvmRunner(
+          llvm.ir,
+          native.module,
+          storedRunner(native.module, 'suspending').realization.runner,
+          'suspending',
+        )
+        const nativeRun = yield* runNative(toolchain, llvm, host)
+        assert.strictEqual(Number(nativeRun.exitCode), 42, `suspending native: ${nativeRun.stderr}`)
+      }).pipe(Effect.scoped),
+    180_000,
+  )
 
-/**
- * Keeps `count` 2KiB allocations live until `main` returns. Wasm does not shrink pages on free, so
- * this is the missing-cleanup control: 80 holds must use more pages than 8, or the flat-heap
- * comparison below cannot see a leaked capture.
- */
-const leakHolds = (
-  count: number,
-): string => `effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+  /**
+   * Keeps `count` 2KiB allocations live until `main` returns. Wasm does not shrink pages on free, so
+   * this is the missing-cleanup control: 80 holds must use more pages than 8, or the flat-heap
+   * comparison below cannot see a leaked capture.
+   */
+  const leakHolds = (
+    count: number,
+  ): string => `effect fn recover(error: OutOfMemory) -> i32 { return 0 }
 effect fn drive() -> i32 ! OutOfMemory ? &mut Allocator {
   ${Array.from({ length: count }, (_, index) => `let hold${index} = run Allocator.allocate(Layout.of<[i64; 256]>())`).join('\n  ')}
   return 42
@@ -662,7 +703,7 @@ pub fn main() -> i32 {
   return run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
 }`
 
-const suspendCycles = (count: number): string => `${cleanupSurface}
+  const suspendCycles = (count: number): string => `${cleanupSurface}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag
@@ -685,83 +726,84 @@ pub fn main() -> i32 {
   return 1
 }`
 
-it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
-  Effect.gen(function* () {
-    const leakShort = yield* lowerSource(
-      'stored-effect-parity/cycles-leak-short',
-      leakHolds(8),
-      Target.wasm32UnknownUnknown,
-      'open',
-    )
-    const leakLong = yield* lowerSource(
-      'stored-effect-parity/cycles-leak-long',
-      leakHolds(80),
-      Target.wasm32UnknownUnknown,
-      'open',
-    )
-    const leakShortWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakShort.module, {
-      mode: 'release',
-    })
-    const leakLongWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakLong.module, {
-      mode: 'release',
-    })
-    assert.strictEqual(leakShortWasm._tag, 'WebAssemblyModuleArtifact', 'leak short')
-    assert.strictEqual(leakLongWasm._tag, 'WebAssemblyModuleArtifact', 'leak long')
-    if (leakShortWasm._tag !== 'WebAssemblyModuleArtifact') return
-    if (leakLongWasm._tag !== 'WebAssemblyModuleArtifact') return
-    const leakShortRun = yield* runWasmMeasured(leakShortWasm.bytes)
-    const leakLongRun = yield* runWasmMeasured(leakLongWasm.bytes)
-    assert.strictEqual(leakShortRun.value, 42, 'leak short')
-    assert.strictEqual(leakLongRun.value, 42, 'leak long')
-    // Sensitivity: 80 live 2KiB holds must grow past the 8-hold heap, or a missed Drop is invisible.
-    assert.isAbove(leakLongRun.pages, leakShortRun.pages, 'leak control must grow Wasm pages')
+  it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
+    Effect.gen(function* () {
+      const leakShort = yield* lowerSource(
+        'stored-effect-parity/cycles-leak-short',
+        leakHolds(8),
+        Target.wasm32UnknownUnknown,
+        'open',
+      )
+      const leakLong = yield* lowerSource(
+        'stored-effect-parity/cycles-leak-long',
+        leakHolds(80),
+        Target.wasm32UnknownUnknown,
+        'open',
+      )
+      const leakShortWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakShort.module, {
+        mode: 'release',
+      })
+      const leakLongWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakLong.module, {
+        mode: 'release',
+      })
+      assert.strictEqual(leakShortWasm._tag, 'WebAssemblyModuleArtifact', 'leak short')
+      assert.strictEqual(leakLongWasm._tag, 'WebAssemblyModuleArtifact', 'leak long')
+      if (leakShortWasm._tag !== 'WebAssemblyModuleArtifact') return
+      if (leakLongWasm._tag !== 'WebAssemblyModuleArtifact') return
+      const leakShortRun = yield* runWasmMeasured(leakShortWasm.bytes)
+      const leakLongRun = yield* runWasmMeasured(leakLongWasm.bytes)
+      assert.strictEqual(leakShortRun.value, 42, 'leak short')
+      assert.strictEqual(leakLongRun.value, 42, 'leak long')
+      // Sensitivity: 80 live 2KiB holds must grow past the 8-hold heap, or a missed Drop is invisible.
+      assert.isAbove(leakLongRun.pages, leakShortRun.pages, 'leak control must grow Wasm pages')
 
-    const programs = [
-      {
-        name: 'unrun',
-        short: 8,
-        long: 80,
-        source: (count: number) => cleanupCycles('unrun', count),
-      },
-      {
-        name: 'failure',
-        short: 8,
-        long: 80,
-        source: (count: number) => cleanupCycles('failure', count),
-      },
-      { name: 'suspending', short: 8, long: 80, source: suspendCycles },
-    ] as const
-    for (const testCase of programs) {
-      const short = yield* lowerStored(
-        `stored-effect-parity/cycles-${testCase.name}-short`,
-        testCase.source(testCase.short),
-        Target.wasm32UnknownUnknown,
-      )
-      const long = yield* lowerStored(
-        `stored-effect-parity/cycles-${testCase.name}-long`,
-        testCase.source(testCase.long),
-        Target.wasm32UnknownUnknown,
-      )
-      const shortWasm = yield* Backend.emit(WasmBackend.WasmBackend, short.module, {
-        mode: 'release',
-      })
-      const longWasm = yield* Backend.emit(WasmBackend.WasmBackend, long.module, {
-        mode: 'release',
-      })
-      assert.strictEqual(shortWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
-      assert.strictEqual(longWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
-      if (shortWasm._tag !== 'WebAssemblyModuleArtifact') return
-      if (longWasm._tag !== 'WebAssemblyModuleArtifact') return
-      const shortRun = yield* runWasmMeasured(shortWasm.bytes)
-      const longRun = yield* runWasmMeasured(longWasm.bytes)
-      assert.strictEqual(shortRun.value, 42, `${testCase.name} short cycles`)
-      assert.strictEqual(longRun.value, 42, `${testCase.name} long cycles`)
-      // Same counts as the leak control: cleanup must reuse, so pages stay flat.
-      assert.strictEqual(
-        longRun.pages,
-        shortRun.pages,
-        `${testCase.name} heap growth across cycles`,
-      )
-    }
-  }),
-)
+      const programs = [
+        {
+          name: 'unrun',
+          short: 8,
+          long: 80,
+          source: (count: number) => cleanupCycles('unrun', count),
+        },
+        {
+          name: 'failure',
+          short: 8,
+          long: 80,
+          source: (count: number) => cleanupCycles('failure', count),
+        },
+        { name: 'suspending', short: 8, long: 80, source: suspendCycles },
+      ] as const
+      for (const testCase of programs) {
+        const short = yield* lowerStored(
+          `stored-effect-parity/cycles-${testCase.name}-short`,
+          testCase.source(testCase.short),
+          Target.wasm32UnknownUnknown,
+        )
+        const long = yield* lowerStored(
+          `stored-effect-parity/cycles-${testCase.name}-long`,
+          testCase.source(testCase.long),
+          Target.wasm32UnknownUnknown,
+        )
+        const shortWasm = yield* Backend.emit(WasmBackend.WasmBackend, short.module, {
+          mode: 'release',
+        })
+        const longWasm = yield* Backend.emit(WasmBackend.WasmBackend, long.module, {
+          mode: 'release',
+        })
+        assert.strictEqual(shortWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+        assert.strictEqual(longWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+        if (shortWasm._tag !== 'WebAssemblyModuleArtifact') return
+        if (longWasm._tag !== 'WebAssemblyModuleArtifact') return
+        const shortRun = yield* runWasmMeasured(shortWasm.bytes)
+        const longRun = yield* runWasmMeasured(longWasm.bytes)
+        assert.strictEqual(shortRun.value, 42, `${testCase.name} short cycles`)
+        assert.strictEqual(longRun.value, 42, `${testCase.name} long cycles`)
+        // Same counts as the leak control: cleanup must reuse, so pages stay flat.
+        assert.strictEqual(
+          longRun.pages,
+          shortRun.pages,
+          `${testCase.name} heap growth across cycles`,
+        )
+      }
+    }),
+  )
+})

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -1,9 +1,12 @@
 import { NodeServices } from '@effect/platform-node'
 import { assert, layer } from '@effect/vitest'
+import * as Cause from 'effect/Cause'
 import * as Config from 'effect/Config'
 import * as Effect from 'effect/Effect'
 import * as FileSystem from 'effect/FileSystem'
+import * as Option from 'effect/Option'
 import * as Path from 'effect/Path'
+import * as PlatformError from 'effect/PlatformError'
 import * as Analysis from '../src/Analysis.js'
 import * as Backend from '../src/Backend.js'
 import * as BootstrapEvaluation from '../src/BootstrapEvaluation.js'
@@ -166,10 +169,7 @@ const assertLlvmDropCall = (ir: string, module: Mir.Module, label: string): void
   )
 }
 
-/**
- * A Drop that divides by zero on first entry. Completing with 42 means the hook never ran; a trap
- * or any other exit is the ≥1 signal. Pair with the poison program (exit 42) to pin exactly once.
- */
+/** Requires the explicit LLVM trap signal emitted by the witness Drop hook. */
 const assertNativeWitnessTraps = Effect.fnUntraced(function* (
   toolchain: NativeToolchain.Toolchain,
   module: Mir.Module,
@@ -177,10 +177,31 @@ const assertNativeWitnessTraps = Effect.fnUntraced(function* (
   label: string,
 ) {
   const llvm = yield* emitLlvm(module, `${label} witness`)
+  assertLlvmDropCall(llvm.ir, module, `${label} witness`)
   const outcome = yield* Effect.exit(runNative(toolchain, llvm, host))
-  assert.isFalse(
-    outcome._tag === 'Success' && Number(outcome.value.exitCode) === 42,
-    `${label} native witness must trap rather than return 42`,
+  assert.strictEqual(
+    outcome._tag,
+    'Failure',
+    `${label} native witness returned ${outcome._tag === 'Success' ? Number(outcome.value.exitCode) : 'a failure'}`,
+  )
+  if (outcome._tag !== 'Failure') return unreachable(`${label} native witness must trap`)
+
+  const failure = Cause.findErrorOption(outcome.cause)
+  assert.isTrue(Option.isSome(failure), Cause.pretty(outcome.cause))
+  if (Option.isNone(failure)) return unreachable(`${label} native witness must report a signal`)
+  assert.instanceOf(failure.value, PlatformError.PlatformError, Cause.pretty(outcome.cause))
+  if (!(failure.value instanceof PlatformError.PlatformError))
+    return unreachable(`${label} native witness must fail at the process boundary`)
+
+  assert.strictEqual(failure.value.reason.module, 'ChildProcess')
+  assert.strictEqual(failure.value.reason.method, 'exitCode')
+  const signal = 'cause' in failure.value.reason ? failure.value.reason.cause : undefined
+  assert.instanceOf(signal, Error, Cause.pretty(outcome.cause))
+  if (!(signal instanceof Error)) return unreachable(`${label} native witness signal is missing`)
+  assert.match(
+    signal.message,
+    /Process interrupted due to receipt of signal: 'SIG(?:ILL|TRAP)'/,
+    `${label} native witness must reach the LLVM trap instruction`,
   )
 })
 
@@ -485,7 +506,8 @@ layer(NodeServices.layer)('stored Effect engine parity', (it) => {
    * Shared stored-Effect cleanup surface.
    *
    * Poison: first Drop zeros `tag`, a second Drop traps, so a duplicate cannot return 42.
-   * Witness: the first Drop divides by zero, so a missing Drop returns 42 and a real Drop traps.
+   * Witness: the first Drop performs a checked out-of-bounds access, so a missing Drop returns 42
+   * and a real Drop reaches LLVM's explicit trap instruction.
    * Together those two native processes pass only for exactly one Drop. A mut-borrow ticket cannot
    * be read after a stored Effect is dropped (OWN0011 / InvalidLoan), so native cannot count in
    * process; Wasm still uses a non-zero class-0 free-list head at `wasmHeapTableBase` as the
@@ -497,7 +519,8 @@ impl Drop for Guard {
   fn drop(self: &mut Guard) -> () {
     ${
       kind === 'witness'
-        ? `let boom = self.tag / 0
+        ? `let values = [self.tag]
+    self.tag = values[i32.toUsize(self.tag)]
     return ()`
         : `if self.tag == 0 {
       let boom = 1 / 0

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -141,8 +141,22 @@ const storedRealization = (module: Mir.Module, label: string) => {
     : unreachable(`expected one ${label} realization (${realizations.length} found)`)
 }
 
-/** Mirrors the LLVM symbol sanitizer so IR assertions name the emitted runner, not the MIR spelling. */
-const sanitize = (name: string): string => name.replace(/[^A-Za-z0-9_]/g, '_')
+/**
+ * The exact symbol the LLVM backend emits for one runner.
+ *
+ * Asserting the full mangled symbol — rather than a sanitized name fragment — pins the runner's
+ * concrete instance key too, so a correct spelling paired with the wrong specialization fails.
+ */
+const emittedSymbol = (module: Mir.Module, runner: { module: string; name: string }): string => {
+  const candidates = module.functions.filter((candidate) => candidate.id.module === runner.module)
+  // Provider specialization renames a runner in place (`f$effect$-1` -> `f$effect$-1$provided$N`),
+  // so accept the exact runner or its single specialization, and nothing else.
+  const fn =
+    candidates.find((candidate) => candidate.id.name === runner.name) ??
+    candidates.find((candidate) => candidate.id.name.startsWith(`${runner.name}$provided$`)) ??
+    unreachable(`expected an emitted function for ${runner.module}.${runner.name}`)
+  return Backend.symbolFor(fn, Mir.machineEntry(module))
+}
 
 const dropCalls = (outcome: BootstrapEvaluation.Outcome): number =>
   outcome._tag === 'Completed'
@@ -249,7 +263,11 @@ it.effect(
         if (llvm._tag !== 'LlvmBitcodeArtifact') return
         assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
         // The same static runner the evaluator called is the one LLVM emitted.
-        assert.include(llvm.ir, sanitize(nativeRunner.realization.runner.name), testCase.name)
+        assert.include(
+          llvm.ir,
+          emittedSymbol(nativeLowering.module, nativeRunner.realization.runner),
+          testCase.name,
+        )
         assert.deepEqual(
           nativeRunner.realization.runner,
           realization.runner,
@@ -269,7 +287,11 @@ it.effect(
           if (specialized?._tag !== 'RunEffectValue') return
           assert.match(specialized.runner.name, /^count\$effect\$-1\$provided\$/)
           assert.lengthOf(specialized.providers, 1, testCase.name)
-          assert.include(llvm.ir, sanitize(specialized.runner.name), testCase.name)
+          assert.include(
+            llvm.ir,
+            emittedSymbol(nativeLowering.module, specialized.runner),
+            testCase.name,
+          )
         }
       }
     }),
@@ -392,7 +414,10 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
       assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
       if (llvm._tag !== 'LlvmBitcodeArtifact') return
       // The Drop hook that cleans the stored environment survives into native code.
-      assert.include(llvm.ir, sanitize('drop@impl'), exit)
+      const dropFn =
+        native.module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
+        unreachable(`expected an emitted Drop hook for ${exit}`)
+      assert.include(llvm.ir, Backend.symbolFor(dropFn, Mir.machineEntry(native.module)), exit)
 
       // `unrun` never reaches a run operation, so the realization is the only runner fact.
       const runner = storedRealization(module, exit).runner
@@ -468,7 +493,7 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
     assert.include(llvm.ir, 'define i32 @silk_main')
     assert.include(
       llvm.ir,
-      sanitize(storedRunner(native.module, 'suspending').realization.runner.name),
+      emittedSymbol(native.module, storedRunner(native.module, 'suspending').realization.runner),
     )
   }),
 )

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -76,25 +76,27 @@ const runNative = Effect.fnUntraced(function* (
   return yield* Process.run(linked.path, [])
 })
 
-/**
- * Lowers one stored-Effect program to MIR for a chosen target.
- *
- * `SEM0107` still fences every stored Effect out of `Analysis.realize`, so this mirrors the merged
- * evaluator harness and drives the phases directly instead of reading `snapshot.mir`. The fence
- * assertion is deliberate: task 4.4 narrows it only for shapes these engines prove first.
- */
-const lowerStored = Effect.fnUntraced(function* (
+const lowerSource = Effect.fnUntraced(function* (
   name: string,
   source: string,
   target: Target.Target,
+  fence: 'stored' | 'open',
 ) {
   const snapshot = yield* Analysis.ofSourceRealized(name, ascii(source), target.id)
   const diagnostics = Analysis.diagnostics(snapshot)
-  assert.isTrue(diagnostics.length > 0, name)
-  assert.isTrue(
-    diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
-    JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
-  )
+  if (fence === 'stored') {
+    assert.isTrue(diagnostics.length > 0, name)
+    assert.isTrue(
+      diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
+      JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
+    )
+  } else {
+    assert.deepEqual(
+      diagnostics,
+      [],
+      JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
+    )
+  }
   const catalog = Layout.catalog(target, snapshot.index, snapshot.instances)
   const layout = Layout.plan(catalog, snapshot.instances)
   const ownership =
@@ -119,6 +121,16 @@ const lowerStored = Effect.fnUntraced(function* (
   assert.deepEqual(Mir.verify(module), [], name)
   return Object.freeze({ snapshot, module })
 })
+
+/**
+ * Lowers one stored-Effect program to MIR for a chosen target.
+ *
+ * `SEM0107` still fences every stored Effect out of `Analysis.realize`, so this mirrors the merged
+ * evaluator harness and drives the phases directly instead of reading `snapshot.mir`. The fence
+ * assertion is deliberate: task 4.4 narrows it only for shapes these engines prove first.
+ */
+const lowerStored = (name: string, source: string, target: Target.Target) =>
+  lowerSource(name, source, target, 'stored')
 
 const runWasm = Effect.fnUntraced(function* (bytes: Uint8Array) {
   const result = yield* Effect.try(() => {
@@ -435,12 +447,13 @@ effect fn failing(guard: Guard) -> i32 ! Problem {
 /**
  * Repeats one stored-Effect construct-and-clean cycle `count` times.
  *
- * Failure recovers inside each iteration so the loop can actually repeat. A leaked capture grows
- * the Wasm heap as `count` grows; a double Drop traps on the poisoned tag.
+ * Failure recovers inside each iteration so the loop can actually repeat. Each capture is 2KiB
+ * (`[i64; 256]`) so 80 leaked cycles must grow the Wasm heap past a 64KiB page; an `i32` leak
+ * would stay inside the first page and the comparison would pass. A double Drop traps.
  */
 const cleanupCycles = (exit: CleanupExit, count: number): string => `${cleanupSurface}
 effect fn cycle() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
-  let storage = run Allocator.allocate(Layout.of<i32>())
+  let storage = run Allocator.allocate(Layout.of<[i64; 256]>())
   let guard = Guard { tag: 7, storage: move storage }
   let deferred = defer(failing(move guard))
   ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
@@ -632,13 +645,30 @@ it.effect(
   180_000,
 )
 
+/**
+ * Keeps `count` 2KiB allocations live until `main` returns. Wasm does not shrink pages on free, so
+ * this is the missing-cleanup control: 80 holds must use more pages than 8, or the flat-heap
+ * comparison below cannot see a leaked capture.
+ */
+const leakHolds = (
+  count: number,
+): string => `effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+effect fn drive() -> i32 ! OutOfMemory ? &mut Allocator {
+  ${Array.from({ length: count }, (_, index) => `let hold${index} = run Allocator.allocate(Layout.of<[i64; 256]>())`).join('\n  ')}
+  return 42
+}
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  return run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
+}`
+
 const suspendCycles = (count: number): string => `${cleanupSurface}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag
 }
 effect fn cycle() -> i32 ! OutOfMemory ? &mut Allocator {
-  let storage = run Allocator.allocate(Layout.of<i32>())
+  let storage = run Allocator.allocate(Layout.of<[i64; 256]>())
   let guard = Guard { tag: 2, storage: move storage }
   let deferred = defer(delayed(move guard))
   return run deferred.operation
@@ -657,6 +687,35 @@ pub fn main() -> i32 {
 
 it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
   Effect.gen(function* () {
+    const leakShort = yield* lowerSource(
+      'stored-effect-parity/cycles-leak-short',
+      leakHolds(8),
+      Target.wasm32UnknownUnknown,
+      'open',
+    )
+    const leakLong = yield* lowerSource(
+      'stored-effect-parity/cycles-leak-long',
+      leakHolds(80),
+      Target.wasm32UnknownUnknown,
+      'open',
+    )
+    const leakShortWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakShort.module, {
+      mode: 'release',
+    })
+    const leakLongWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakLong.module, {
+      mode: 'release',
+    })
+    assert.strictEqual(leakShortWasm._tag, 'WebAssemblyModuleArtifact', 'leak short')
+    assert.strictEqual(leakLongWasm._tag, 'WebAssemblyModuleArtifact', 'leak long')
+    if (leakShortWasm._tag !== 'WebAssemblyModuleArtifact') return
+    if (leakLongWasm._tag !== 'WebAssemblyModuleArtifact') return
+    const leakShortRun = yield* runWasmMeasured(leakShortWasm.bytes)
+    const leakLongRun = yield* runWasmMeasured(leakLongWasm.bytes)
+    assert.strictEqual(leakShortRun.value, 42, 'leak short')
+    assert.strictEqual(leakLongRun.value, 42, 'leak long')
+    // Sensitivity: 80 live 2KiB holds must grow past the 8-hold heap, or a missed Drop is invisible.
+    assert.isAbove(leakLongRun.pages, leakShortRun.pages, 'leak control must grow Wasm pages')
+
     const programs = [
       {
         name: 'unrun',
@@ -670,7 +729,7 @@ it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles
         long: 80,
         source: (count: number) => cleanupCycles('failure', count),
       },
-      { name: 'suspending', short: 4, long: 20, source: suspendCycles },
+      { name: 'suspending', short: 8, long: 80, source: suspendCycles },
     ] as const
     for (const testCase of programs) {
       const short = yield* lowerStored(
@@ -697,7 +756,7 @@ it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles
       const longRun = yield* runWasmMeasured(longWasm.bytes)
       assert.strictEqual(shortRun.value, 42, `${testCase.name} short cycles`)
       assert.strictEqual(longRun.value, 42, `${testCase.name} long cycles`)
-      // Ten times the cycles must not cost more heap: a capture leaked once per cycle would grow it.
+      // Same counts as the leak control: cleanup must reuse, so pages stay flat.
       assert.strictEqual(
         longRun.pages,
         shortRun.pages,

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -399,16 +399,27 @@ it.effect(
   180_000,
 )
 
+type CleanupExit = 'unrun' | 'failure'
+
 /**
- * Repeats one stored-Effect construct-and-clean cycle `count` times.
+ * Shared stored-Effect cleanup surface.
  *
- * Returning 42 does not distinguish a released capture from a leaked one, so the cleanup parity
- * check runs the cycle in a loop and measures the Wasm heap: an environment the backend fails to
- * release once per iteration grows memory, while exactly-once cleanup keeps it flat.
+ * Guard.drop poisons `tag` on the first call and traps on the second, so a double cleanup cannot
+ * return 42. A missed cleanup is a leak: the cycle programs compare heap pages as the iteration
+ * count grows. Together those two observations fail unless each live capture is cleaned once.
  */
-const cleanupCycles = (exit: CleanupExit, count: number): string => `struct Problem { code: i32 }
+const cleanupSurface = `struct Problem { code: i32 }
 struct Guard { tag: i32 storage: Allocation }
-impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+impl Drop for Guard {
+  fn drop(self: &mut Guard) -> () {
+    if self.tag == 0 {
+      let boom = 1 / 0
+      return ()
+    }
+    self.tag = 0
+    return ()
+  }
+}
 struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
 fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
   operation: F
@@ -419,7 +430,15 @@ effect fn failing(guard: Guard) -> i32 ! Problem {
   let result = guard.tag
   if result == 0 { return 0 }
   fail Problem { code: result }
-}
+}`
+
+/**
+ * Repeats one stored-Effect construct-and-clean cycle `count` times.
+ *
+ * Failure recovers inside each iteration so the loop can actually repeat. A leaked capture grows
+ * the Wasm heap as `count` grows; a double Drop traps on the poisoned tag.
+ */
+const cleanupCycles = (exit: CleanupExit, count: number): string => `${cleanupSurface}
 effect fn cycle() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
   let storage = run Allocator.allocate(Layout.of<i32>())
   let guard = Guard { tag: 7, storage: move storage }
@@ -431,7 +450,7 @@ effect fn drive() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
   let mut index = 0
   let mut total = 0
   while index < ${count} {
-    total = total + run cycle()
+    total = total + run Effect.catch(cycle(), recover)
     index = index + 1
   }
   return total
@@ -439,7 +458,7 @@ effect fn drive() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
 pub fn main() -> i32 {
   let mut allocator = SystemAllocator.make()
   let total = run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
-  if total == ${exit === 'failure' ? 42 : count * 42} { return 42 }
+  if total == ${count * 42} { return 42 }
   return 1
 }`
 
@@ -462,22 +481,8 @@ const runWasmMeasured = Effect.fnUntraced(function* (bytes: Uint8Array) {
   })
 })
 
-type CleanupExit = 'unrun' | 'failure'
-
-const cleanupProgram = (exit: CleanupExit): string => `struct Problem { code: i32 }
-struct Guard { tag: i32 storage: Allocation }
-impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
-struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
-fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
-  operation: F
-) -> Deferred<A, E, R, F> {
-  return Deferred<A, E, R> { operation: move operation }
-}
-effect fn failing(guard: Guard) -> i32 ! Problem {
-  let result = guard.tag
-  if result == 0 { return 0 }
-  fail Problem { code: result }
-}
+const cleanupProgram = (exit: CleanupExit): string => `${cleanupSurface}
+effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
 effect fn build() -> i32 ! Problem | OutOfMemory {
   let mut allocator = SystemAllocator.make()
   let storage = run Allocator.allocate(Layout.of<i32>()) |> Effect.provideMut(&mut allocator)
@@ -485,7 +490,6 @@ effect fn build() -> i32 ! Problem | OutOfMemory {
   let deferred = defer(failing(move guard))
   ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
 }
-effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
 pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
 
 it.effect('cleans unrun and failing stored Effect environments exactly once in every engine', () =>
@@ -513,6 +517,7 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
       const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
       assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
       if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+      // 42 means the poisoned Drop did not run twice. A missed cleanup is a leak, proven by cycles.
       assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
       assert.notInclude(wasm.wat, 'call_indirect', exit)
       if (exit === 'failure') {
@@ -554,25 +559,18 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
   180_000,
 )
 
-const suspending = `struct Guard { tag: i32 storage: Allocation }
-impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
-struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
-fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
-  operation: F
-) -> Deferred<A, E, R, F> {
-  return Deferred<A, E, R> { operation: move operation }
-}
+const suspending = `${cleanupSurface}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag
 }
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
 effect fn build() -> i32 ! OutOfMemory ? &mut Allocator {
   let storage = run Allocator.allocate(Layout.of<i32>())
   let guard = Guard { tag: 2, storage: move storage }
   let deferred = defer(delayed(move guard))
   return run deferred.operation
 }
-effect fn recover(error: OutOfMemory) -> i32 { return 0 }
 pub fn main() -> i32 {
   let mut allocator = SystemAllocator.make()
   return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
@@ -601,6 +599,7 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
     const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
     assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
     if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+    // 42 means resume succeeded and the poisoned Drop did not run twice.
     assert.strictEqual(yield* runWasm(wasm.bytes), 42)
     assertDirectWasmRunner(
       wasm.wat,
@@ -624,19 +623,50 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
   180_000,
 )
 
+const suspendCycles = (count: number): string => `${cleanupSurface}
+effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
+  let base = run Effect.suspend(effect { return 40 })
+  return base + guard.tag
+}
+effect fn cycle() -> i32 ! OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let guard = Guard { tag: 2, storage: move storage }
+  let deferred = defer(delayed(move guard))
+  return run deferred.operation
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+effect fn drive() -> i32 ! OutOfMemory ? &mut Allocator {
+  ${Array.from({ length: count }, (_, index) => `let value${index} = run cycle()`).join('\n  ')}
+  return ${Array.from({ length: count }, (_, index) => `value${index}`).join(' + ')}
+}
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  let total = run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
+  if total == ${count * 42} { return 42 }
+  return 1
+}`
+
 it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
   Effect.gen(function* () {
-    // Only the unrun exit repeats: a typed failure aborts the loop on its first cycle, so its
-    // iteration count would not vary and the heap comparison would prove nothing.
-    for (const exit of ['unrun'] as const) {
+    const programs = [
+      { name: 'unrun', short: 8, long: 80, source: (count: number) => cleanupCycles('unrun', count) },
+      {
+        name: 'failure',
+        short: 8,
+        long: 80,
+        source: (count: number) => cleanupCycles('failure', count),
+      },
+      { name: 'suspending', short: 4, long: 20, source: suspendCycles },
+    ] as const
+    for (const testCase of programs) {
       const short = yield* lowerStored(
-        `stored-effect-parity/cycles-${exit}-short`,
-        cleanupCycles(exit, 8),
+        `stored-effect-parity/cycles-${testCase.name}-short`,
+        testCase.source(testCase.short),
         Target.wasm32UnknownUnknown,
       )
       const long = yield* lowerStored(
-        `stored-effect-parity/cycles-${exit}-long`,
-        cleanupCycles(exit, 80),
+        `stored-effect-parity/cycles-${testCase.name}-long`,
+        testCase.source(testCase.long),
         Target.wasm32UnknownUnknown,
       )
       const shortWasm = yield* Backend.emit(WasmBackend.WasmBackend, short.module, {
@@ -645,16 +675,16 @@ it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles
       const longWasm = yield* Backend.emit(WasmBackend.WasmBackend, long.module, {
         mode: 'release',
       })
-      assert.strictEqual(shortWasm._tag, 'WebAssemblyModuleArtifact', exit)
-      assert.strictEqual(longWasm._tag, 'WebAssemblyModuleArtifact', exit)
+      assert.strictEqual(shortWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+      assert.strictEqual(longWasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
       if (shortWasm._tag !== 'WebAssemblyModuleArtifact') return
       if (longWasm._tag !== 'WebAssemblyModuleArtifact') return
       const shortRun = yield* runWasmMeasured(shortWasm.bytes)
       const longRun = yield* runWasmMeasured(longWasm.bytes)
-      assert.strictEqual(shortRun.value, 42, `${exit} short cycles`)
-      assert.strictEqual(longRun.value, 42, `${exit} long cycles`)
+      assert.strictEqual(shortRun.value, 42, `${testCase.name} short cycles`)
+      assert.strictEqual(longRun.value, 42, `${testCase.name} long cycles`)
       // Ten times the cycles must not cost more heap: a capture leaked once per cycle would grow it.
-      assert.strictEqual(longRun.pages, shortRun.pages, `${exit} heap growth across cycles`)
+      assert.strictEqual(longRun.pages, shortRun.pages, `${testCase.name} heap growth across cycles`)
     }
   }),
 )

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -1,5 +1,9 @@
+import { NodeServices } from '@effect/platform-node'
 import { assert, it } from '@effect/vitest'
+import * as Config from 'effect/Config'
 import * as Effect from 'effect/Effect'
+import * as FileSystem from 'effect/FileSystem'
+import * as Path from 'effect/Path'
 import * as Analysis from '../src/Analysis.js'
 import * as Backend from '../src/Backend.js'
 import * as BootstrapEvaluation from '../src/BootstrapEvaluation.js'
@@ -8,6 +12,7 @@ import * as Layout from '../src/Layout.js'
 import * as Lower from '../src/Lower.js'
 import * as Mir from '../src/Mir.js'
 import * as MirNormalization from '../src/MirNormalization.js'
+import * as NativeToolchain from '../src/NativeToolchain.js'
 import * as OpaqueRealization from '../src/OpaqueRealization.js'
 import type * as Ownership from '../src/Ownership.js'
 import * as ProvisionalMir from '../src/ProvisionalMir.js'
@@ -16,10 +21,60 @@ import * as SuspensionMir from '../src/SuspensionMir.js'
 import * as SuspensionOwnership from '../src/SuspensionOwnership.js'
 import * as Target from '../src/Target.js'
 import * as WasmBackend from '../src/WasmBackend.js'
+import * as Process from './support/Process.js'
 import { unreachable } from './support/raise.js'
 
 const ascii = (value: string): Uint8Array =>
   Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+const clangPath = Effect.fnUntraced(function* () {
+  const configured = yield* Config.string('SILK_TEST_CLANG').pipe(Config.withDefault(''))
+  if (configured.length > 0) return configured
+  const fileSystem = yield* FileSystem.FileSystem
+  for (const candidate of ['/opt/homebrew/opt/llvm/bin/clang', '/usr/local/opt/llvm/bin/clang'])
+    if (yield* fileSystem.exists(candidate)) return candidate
+  return 'clang'
+})
+
+/**
+ * Takes one already-lowered LLVM artifact through object emission, shim compilation, linking, and
+ * execution. `SEM0107` still fences `Driver.compile`, so this is the native path task 4.2 can use.
+ */
+const runNative = Effect.fnUntraced(function* (
+  toolchain: NativeToolchain.Toolchain,
+  artifact: Backend.LlvmBitcodeArtifact,
+  target: Target.Target,
+) {
+  const fileSystem = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const destination = path.join(yield* fileSystem.makeTempDirectoryScoped(), 'program')
+  const linked = NativeToolchain.withBuildScope('stored-effect-parity', (scope) => {
+    const object = NativeToolchain.emitObject(toolchain, scope, artifact, target, 'release')
+    if (object._tag !== 'ObjectArtifact') return object
+    const shim = NativeToolchain.compileShim(
+      toolchain,
+      scope,
+      target,
+      artifact.termination,
+      artifact.nativeRuntimeSymbols,
+    )
+    if (shim._tag !== 'ObjectArtifact') return shim
+    return NativeToolchain.ClangLinker.link(
+      toolchain,
+      target,
+      [object.artifact, shim.artifact],
+      [],
+      destination,
+    )
+  })
+  assert.strictEqual(
+    linked._tag,
+    'Executable',
+    linked._tag === 'ToolchainFailure' ? linked.output : linked._tag,
+  )
+  if (linked._tag !== 'Executable') return unreachable('expected a native executable')
+  return yield* Process.run(linked.path, [])
+})
 
 /**
  * Lowers one stored-Effect program to MIR for a chosen target.
@@ -147,15 +202,41 @@ const storedRealization = (module: Mir.Module, label: string) => {
  * Asserting the full mangled symbol — rather than a sanitized name fragment — pins the runner's
  * concrete instance key too, so a correct spelling paired with the wrong specialization fails.
  */
-const emittedSymbol = (module: Mir.Module, runner: { module: string; name: string }): string => {
+const emittedFunction = (module: Mir.Module, runner: { module: string; name: string }) => {
   const candidates = module.functions.filter((candidate) => candidate.id.module === runner.module)
   // Provider specialization renames a runner in place (`f$effect$-1` -> `f$effect$-1$provided$N`),
   // so accept the exact runner or its single specialization, and nothing else.
-  const fn =
+  return (
     candidates.find((candidate) => candidate.id.name === runner.name) ??
     candidates.find((candidate) => candidate.id.name.startsWith(`${runner.name}$provided$`)) ??
     unreachable(`expected an emitted function for ${runner.module}.${runner.name}`)
-  return Backend.symbolFor(fn, Mir.machineEntry(module))
+  )
+}
+
+const emittedSymbol = (module: Mir.Module, runner: { module: string; name: string }): string =>
+  Backend.symbolFor(emittedFunction(module, runner), Mir.machineEntry(module))
+
+/** The exact debug-WAT call target for one runner, including the suspend-step suffix when needed. */
+const emittedWasmCallTarget = (
+  module: Mir.Module,
+  runner: { module: string; name: string },
+): string => {
+  const fn = emittedFunction(module, runner)
+  const symbol = Backend.symbolFor(fn, Mir.machineEntry(module))
+  return (fn.suspension?.classification ?? 'Synchronous') !== 'Synchronous'
+    ? `${symbol}$suspend_step`
+    : symbol
+}
+
+const assertDirectWasmRunner = (
+  wat: string,
+  module: Mir.Module,
+  runner: { module: string; name: string },
+  label: string,
+): void => {
+  const target = emittedWasmCallTarget(module, runner)
+  assert.include(wat, `call $${target}`, `${label} direct call $${target}`)
+  assert.notInclude(wat, 'call_indirect', label)
 }
 
 const dropCalls = (outcome: BootstrapEvaluation.Outcome): number =>
@@ -165,7 +246,10 @@ const dropCalls = (outcome: BootstrapEvaluation.Outcome): number =>
       ).length
     : 0
 
-const traceCount = (outcome: BootstrapEvaluation.Outcome, tag: string): number =>
+const traceCount = (
+  outcome: BootstrapEvaluation.Outcome,
+  tag: BootstrapEvaluation.TraceEvent['_tag'],
+): number =>
   outcome._tag === 'Completed' ? outcome.trace.filter((event) => event._tag === tag).length : 0
 
 const shared = `struct Deferred<F: Effect<i32>> { operation: F }
@@ -225,6 +309,11 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const host = yield* Target.host()
+      const toolchain = Object.freeze({
+        _tag: 'Toolchain' as const,
+        clang: yield* clangPath(),
+        shimCache: NativeToolchain.makeShimCache(),
+      })
       for (const testCase of runtimeMatrix) {
         // One module name for both targets: the runner identity must not depend on the target.
         const moduleName = `stored-effect-parity/${testCase.name}`
@@ -243,14 +332,14 @@ it.effect(
         )
         assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
 
+        // Debug WAT names the exact call target; release would only give a numeric index.
         const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
-          mode: 'release',
+          mode: 'debug',
         })
         assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
         if (wasm._tag !== 'WebAssemblyModuleArtifact') return
         assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
-        // Stored Effects stay statically dispatched: no runtime dictionary, no indirect call.
-        assert.notInclude(wasm.wat, 'call_indirect', testCase.name)
+        assertDirectWasmRunner(wasm.wat, wasmLowering.module, realization.runner, testCase.name)
 
         const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
         const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
@@ -273,6 +362,12 @@ it.effect(
           realization.runner,
           `${testCase.name} runner identity across targets`,
         )
+        const nativeRun = yield* runNative(toolchain, llvm, host)
+        assert.strictEqual(
+          nativeRun.exitCode,
+          testCase.result,
+          `${testCase.name} native: ${nativeRun.stderr}`,
+        )
         if (testCase.name === 'provided') {
           // Service provision resolves statically: the specialized runner reaches the backend, and
           // the provider travels in the environment rather than a runtime dictionary.
@@ -292,9 +387,16 @@ it.effect(
             emittedSymbol(nativeLowering.module, specialized.runner),
             testCase.name,
           )
+          assertDirectWasmRunner(
+            wasm.wat,
+            wasmLowering.module,
+            specialized.runner,
+            `${testCase.name} specialized`,
+          )
         }
       }
-    }),
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  180_000,
 )
 
 /**
@@ -389,6 +491,11 @@ pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
 it.effect('cleans unrun and failing stored Effect environments exactly once in every engine', () =>
   Effect.gen(function* () {
     const host = yield* Target.host()
+    const toolchain = Object.freeze({
+      _tag: 'Toolchain' as const,
+      clang: yield* clangPath(),
+      shimCache: NativeToolchain.makeShimCache(),
+    })
     for (const exit of ['unrun', 'failure'] as const) {
       const moduleName = `stored-effect-parity/cleanup-${exit}`
       const { snapshot, module } = yield* lowerStored(
@@ -403,11 +510,14 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
       assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
       assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
 
-      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'release' })
+      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
       assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
       if (wasm._tag !== 'WebAssemblyModuleArtifact') return
       assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
       assert.notInclude(wasm.wat, 'call_indirect', exit)
+      if (exit === 'failure') {
+        assertDirectWasmRunner(wasm.wat, module, storedRunner(module, exit).realization.runner, exit)
+      }
 
       const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
       const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
@@ -418,6 +528,8 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
         native.module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
         unreachable(`expected an emitted Drop hook for ${exit}`)
       assert.include(llvm.ir, Backend.symbolFor(dropFn, Mir.machineEntry(native.module)), exit)
+      const nativeRun = yield* runNative(toolchain, llvm, host)
+      assert.strictEqual(nativeRun.exitCode, 42, `${exit} native: ${nativeRun.stderr}`)
 
       // `unrun` never reaches a run operation, so the realization is the only runner fact.
       const runner = storedRealization(module, exit).runner
@@ -438,7 +550,8 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
         assertExactRows(native.module, `${exit} native`)
       }
     }
-  }),
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  180_000,
 )
 
 const suspending = `struct Guard { tag: i32 storage: Allocation }
@@ -468,6 +581,11 @@ pub fn main() -> i32 {
 it.effect('resumes a suspending stored Effect with matching cleanup in every engine', () =>
   Effect.gen(function* () {
     const host = yield* Target.host()
+    const toolchain = Object.freeze({
+      _tag: 'Toolchain' as const,
+      clang: yield* clangPath(),
+      shimCache: NativeToolchain.makeShimCache(),
+    })
     const moduleName = 'stored-effect-parity/suspending'
     const { snapshot, module } = yield* lowerStored(
       moduleName,
@@ -480,11 +598,16 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
     assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
     assertExactRows(module, 'suspending')
 
-    const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'release' })
+    const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
     assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
     if (wasm._tag !== 'WebAssemblyModuleArtifact') return
     assert.strictEqual(yield* runWasm(wasm.bytes), 42)
-    assert.notInclude(wasm.wat, 'call_indirect')
+    assertDirectWasmRunner(
+      wasm.wat,
+      module,
+      storedRunner(module, 'suspending').realization.runner,
+      'suspending',
+    )
 
     const native = yield* lowerStored(moduleName, suspending, host)
     const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
@@ -495,7 +618,10 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
       llvm.ir,
       emittedSymbol(native.module, storedRunner(native.module, 'suspending').realization.runner),
     )
-  }),
+    const nativeRun = yield* runNative(toolchain, llvm, host)
+    assert.strictEqual(nativeRun.exitCode, 42, `suspending native: ${nativeRun.stderr}`)
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  180_000,
 )
 
 it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -139,8 +139,54 @@ const lowerSource = Effect.fnUntraced(function* (
  * evaluator harness and drives the phases directly instead of reading `snapshot.mir`. The fence
  * assertion is deliberate: task 4.4 narrows it only for shapes these engines prove first.
  */
-const lowerStored = (name: string, source: string, target: Target.Target) =>
-  lowerSource(name, source, target, 'stored')
+const lowerStored = Effect.fnUntraced(function* (
+  name: string,
+  source: string,
+  target: Target.Target,
+) {
+  return yield* lowerSource(name, source, target, 'stored')
+})
+
+const emitLlvm = Effect.fnUntraced(function* (module: Mir.Module, label: string) {
+  const llvm = yield* Backend.emit(Backend.LlvmBackend, module, { mode: 'release' })
+  assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', label)
+  if (llvm._tag !== 'LlvmBitcodeArtifact') return unreachable('expected LLVM artifact')
+  return llvm
+})
+
+const assertLlvmDropCall = (ir: string, module: Mir.Module, label: string): void => {
+  const dropFn =
+    module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
+    unreachable(`expected an emitted Drop hook for ${label}`)
+  const dropSymbol = Backend.symbolFor(dropFn, Mir.machineEntry(module))
+  assert.match(
+    ir,
+    new RegExp(`\\bcall\\b[^\\n]*@${escapeRegExp(dropSymbol)}\\(`),
+    `${label} LLVM Drop call`,
+  )
+}
+
+/**
+ * A Drop that divides by zero on first entry. Completing with 42 means the hook never ran; a trap
+ * or any other exit is the ≥1 signal. Pair with the poison program (exit 42) to pin exactly once.
+ */
+const assertNativeWitnessTraps = Effect.fnUntraced(function* (
+  toolchain: NativeToolchain.Toolchain,
+  module: Mir.Module,
+  host: Target.Target,
+  label: string,
+) {
+  const llvm = yield* emitLlvm(module, `${label} witness`)
+  const outcome = yield* Effect.exit(runNative(toolchain, llvm, host))
+  assert.isFalse(
+    outcome._tag === 'Success' && Number(outcome.value.exitCode) === 42,
+    `${label} native witness must trap rather than return 42`,
+  )
+})
+
+/** Matches `heapTableBase` in WasmBackend: free-list heads live at the first Wasm heap page. */
+const wasmPageBytes = 65536
+const wasmHeapTableBase = wasmPageBytes
 
 const runWasm = Effect.fnUntraced(function* (bytes: Uint8Array) {
   const result = yield* Effect.try(() => {
@@ -381,11 +427,7 @@ layer(NodeServices.layer)('stored Effect engine parity', (it) => {
           const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
           // The native lowering carries the same exact rows the Wasm lowering and evaluator proved.
           assertExactRows(nativeLowering.module, testCase.name)
-          const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
-            mode: 'release',
-          })
-          assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
-          if (llvm._tag !== 'LlvmBitcodeArtifact') return
+          const llvm = yield* emitLlvm(nativeLowering.module, testCase.name)
           assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
           assertDirectLlvmRunner(
             llvm.ir,
@@ -436,27 +478,34 @@ layer(NodeServices.layer)('stored Effect engine parity', (it) => {
     180_000,
   )
 
-  type CleanupExit = 'unrun' | 'failure'
+  type CleanupExit = 'success' | 'unrun' | 'failure'
+  type DropKind = 'poison' | 'witness'
 
   /**
    * Shared stored-Effect cleanup surface.
    *
-   * Guard.drop poisons `tag` on the first call and traps on the second, so a double cleanup cannot
-   * return 42. A missed cleanup leaves the capture's `i32` block off Wasm free-list class 0
-   * (`heapTableBase` 65536). A mut-borrow ticket cannot be read after the stored Effect is dropped
-   * (OWN0011 / InvalidLoan), so the free-list head is the 0-vs-1 signal both backends can share
-   * with poison for 2.
+   * Poison: first Drop zeros `tag`, a second Drop traps, so a duplicate cannot return 42.
+   * Witness: the first Drop divides by zero, so a missing Drop returns 42 and a real Drop traps.
+   * Together those two native processes pass only for exactly one Drop. A mut-borrow ticket cannot
+   * be read after a stored Effect is dropped (OWN0011 / InvalidLoan), so native cannot count in
+   * process; Wasm still uses a non-zero class-0 free-list head at `wasmHeapTableBase` as the
+   * missing-cleanup signal for the poison program.
    */
-  const cleanupSurface = `struct Problem { code: i32 }
+  const cleanupSurface = (kind: DropKind = 'poison'): string => `struct Problem { code: i32 }
 struct Guard { tag: i32 storage: Allocation }
 impl Drop for Guard {
   fn drop(self: &mut Guard) -> () {
-    if self.tag == 0 {
+    ${
+      kind === 'witness'
+        ? `let boom = self.tag / 0
+    return ()`
+        : `if self.tag == 0 {
       let boom = 1 / 0
       return ()
     }
     self.tag = 0
-    return ()
+    return ()`
+    }
   }
 }
 struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
@@ -464,6 +513,9 @@ fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
   operation: F
 ) -> Deferred<A, E, R, F> {
   return Deferred<A, E, R> { operation: move operation }
+}
+effect fn succeeding(guard: Guard) -> i32 {
+  return 40 + guard.tag
 }
 effect fn failing(guard: Guard) -> i32 ! Problem {
   let result = guard.tag
@@ -478,7 +530,10 @@ effect fn failing(guard: Guard) -> i32 ! Problem {
    * (`[i64; 256]`) so 80 leaked cycles must grow the Wasm heap past a 64KiB page; an `i32` leak
    * would stay inside the first page and the comparison would pass. A double Drop traps.
    */
-  const cleanupCycles = (exit: CleanupExit, count: number): string => `${cleanupSurface}
+  const cleanupCycles = (
+    exit: Exclude<CleanupExit, 'success'>,
+    count: number,
+  ): string => `${cleanupSurface()}
 effect fn cycle() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
   let storage = run Allocator.allocate(Layout.of<[i64; 256]>())
   let guard = Guard { tag: 7, storage: move storage }
@@ -506,7 +561,7 @@ pub fn main() -> i32 {
     const memory = instance.exports[StandardStreams.wasmMemoryExport]
     assert.instanceOf(memory, WebAssembly.Memory)
     return memory instanceof WebAssembly.Memory
-      ? memory.buffer.byteLength / 65536
+      ? memory.buffer.byteLength / wasmPageBytes
       : Number.POSITIVE_INFINITY
   }
 
@@ -519,29 +574,38 @@ pub fn main() -> i32 {
       const value = main()
       const memory = instance.exports[StandardStreams.wasmMemoryExport]
       const class0 =
-        memory instanceof WebAssembly.Memory ? new DataView(memory.buffer).getInt32(65536, true) : 0
+        memory instanceof WebAssembly.Memory
+          ? new DataView(memory.buffer).getInt32(wasmHeapTableBase, true)
+          : 0
       return Object.freeze({ value, pages: pagesOf(instance), class0 })
     })
   })
 
-  const cleanupProgram = (exit: CleanupExit): string => `${cleanupSurface}
-effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
-effect fn build() -> i32 ! Problem | OutOfMemory {
+  const cleanupProgram = (exit: CleanupExit, kind: DropKind = 'poison'): string => {
+    const tag = exit === 'success' ? 2 : 7
+    const failures = exit === 'success' ? 'OutOfMemory' : 'Problem | OutOfMemory'
+    const recoverValue = exit === 'success' ? 0 : 42
+    const construct = exit === 'success' ? 'succeeding(move guard)' : 'failing(move guard)'
+    const runLine = exit === 'unrun' ? 'return 42' : 'return run deferred.operation'
+    return `${cleanupSurface(kind)}
+effect fn recover(error: ${failures}) -> i32 { return ${recoverValue} }
+effect fn build() -> i32 ! ${failures} {
   let mut allocator = SystemAllocator.make()
   let storage = run Allocator.allocate(Layout.of<i32>()) |> Effect.provideMut(&mut allocator)
-  let guard = Guard { tag: 7, storage: move storage }
-  let deferred = defer(failing(move guard))
-  ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
+  let guard = Guard { tag: ${tag}, storage: move storage }
+  let deferred = defer(${construct})
+  ${runLine}
 }
 pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+  }
 
   it.effect(
-    'cleans unrun and failing stored Effect environments exactly once in every engine',
+    'cleans successful, unrun, and failing stored Effect environments exactly once in every engine',
     () =>
       Effect.gen(function* () {
         const host = yield* Target.host()
         const toolchain = yield* makeToolchain()
-        for (const exit of ['unrun', 'failure'] as const) {
+        for (const exit of ['success', 'unrun', 'failure'] as const) {
           const moduleName = `stored-effect-parity/cleanup-${exit}`
           const { snapshot, module } = yield* lowerStored(
             moduleName,
@@ -563,7 +627,7 @@ pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
           assert.strictEqual(wasmRun.value, 42, `${exit} Wasm`)
           assert.notStrictEqual(wasmRun.class0, 0, `${exit} Wasm capture returned to class 0`)
           assert.notInclude(wasm.wat, 'call_indirect', exit)
-          if (exit === 'failure') {
+          if (exit !== 'unrun') {
             assertDirectWasmRunner(
               wasm.wat,
               module,
@@ -573,21 +637,9 @@ pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
           }
 
           const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
-          const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-          assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
-          if (llvm._tag !== 'LlvmBitcodeArtifact') return
-          // The Drop hook that cleans the stored environment survives into native code.
-          const dropFn =
-            native.module.functions.find((candidate) =>
-              candidate.id.name.startsWith('drop@impl'),
-            ) ?? unreachable(`expected an emitted Drop hook for ${exit}`)
-          const dropSymbol = Backend.symbolFor(dropFn, Mir.machineEntry(native.module))
-          assert.match(
-            llvm.ir,
-            new RegExp(`\\bcall\\b[^\\n]*@${escapeRegExp(dropSymbol)}\\(`),
-            `${exit} LLVM Drop call`,
-          )
-          if (exit === 'failure') {
+          const llvm = yield* emitLlvm(native.module, exit)
+          assertLlvmDropCall(llvm.ir, native.module, exit)
+          if (exit !== 'unrun') {
             assertDirectLlvmRunner(
               llvm.ir,
               native.module,
@@ -597,6 +649,13 @@ pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
           }
           const nativeRun = yield* runNative(toolchain, llvm, host)
           assert.strictEqual(Number(nativeRun.exitCode), 42, `${exit} native: ${nativeRun.stderr}`)
+
+          const witness = yield* lowerStored(
+            `${moduleName}-witness`,
+            cleanupProgram(exit, 'witness'),
+            host,
+          )
+          yield* assertNativeWitnessTraps(toolchain, witness.module, host, exit)
 
           // `unrun` never reaches a run operation, so the realization is the only runner fact.
           const runner = storedRealization(module, exit).runner
@@ -609,19 +668,20 @@ pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
                     event.target.name === runner.name,
                 ).length
               : -1
-          assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
-          if (exit === 'failure') {
-            assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
-            // A typed failure keeps its exact failure rows through both lowerings.
+          assert.strictEqual(runnerCalls, exit === 'unrun' ? 0 : 1, `${exit} stored runner calls`)
+          if (exit !== 'unrun') {
             assertExactRows(module, exit)
             assertExactRows(native.module, `${exit} native`)
           }
+          if (exit === 'failure') {
+            assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
+          }
         }
       }).pipe(Effect.scoped),
-    180_000,
+    240_000,
   )
 
-  const suspending = `${cleanupSurface}
+  const suspendingProgram = (kind: DropKind = 'poison'): string => `${cleanupSurface(kind)}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag
@@ -647,7 +707,7 @@ pub fn main() -> i32 {
         const moduleName = 'stored-effect-parity/suspending'
         const { snapshot, module } = yield* lowerStored(
           moduleName,
-          suspending,
+          suspendingProgram(),
           Target.wasm32UnknownUnknown,
         )
         const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
@@ -669,11 +729,10 @@ pub fn main() -> i32 {
           'suspending',
         )
 
-        const native = yield* lowerStored(moduleName, suspending, host)
-        const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
-        if (llvm._tag !== 'LlvmBitcodeArtifact') return
+        const native = yield* lowerStored(moduleName, suspendingProgram(), host)
+        const llvm = yield* emitLlvm(native.module, 'suspending')
         assert.include(llvm.ir, 'define i32 @silk_main')
+        assertLlvmDropCall(llvm.ir, native.module, 'suspending')
         assertDirectLlvmRunner(
           llvm.ir,
           native.module,
@@ -682,8 +741,15 @@ pub fn main() -> i32 {
         )
         const nativeRun = yield* runNative(toolchain, llvm, host)
         assert.strictEqual(Number(nativeRun.exitCode), 42, `suspending native: ${nativeRun.stderr}`)
+
+        const witness = yield* lowerStored(
+          `${moduleName}-witness`,
+          suspendingProgram('witness'),
+          host,
+        )
+        yield* assertNativeWitnessTraps(toolchain, witness.module, host, 'suspending')
       }).pipe(Effect.scoped),
-    180_000,
+    240_000,
   )
 
   /**
@@ -703,7 +769,7 @@ pub fn main() -> i32 {
   return run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
 }`
 
-  const suspendCycles = (count: number): string => `${cleanupSurface}
+  const suspendCycles = (count: number): string => `${cleanupSurface()}
 effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
   let base = run Effect.suspend(effect { return 40 })
   return base + guard.tag

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -11,6 +11,7 @@ import * as MirNormalization from '../src/MirNormalization.js'
 import * as OpaqueRealization from '../src/OpaqueRealization.js'
 import type * as Ownership from '../src/Ownership.js'
 import * as ProvisionalMir from '../src/ProvisionalMir.js'
+import * as StandardStreams from '../src/StandardStreams.js'
 import * as SuspensionMir from '../src/SuspensionMir.js'
 import * as SuspensionOwnership from '../src/SuspensionOwnership.js'
 import * as Target from '../src/Target.js'
@@ -102,6 +103,36 @@ const storedRunner = (module: Mir.Module, label: string) => {
   return unreachable(`expected one ${label} stored Effect run`)
 }
 
+/**
+ * Asserts the run operation carries exactly the realization's contract rows.
+ *
+ * Rows stay compile-time facts, so this is the parity check that both backends consume the same
+ * exact success, failure, and requirement rows the evaluator proved — without any runtime lane.
+ */
+const assertExactRows = (module: Mir.Module, label: string): void => {
+  const { operation, realization } = storedRunner(module, label)
+  assert.deepEqual(
+    operation.runnerBase?.declaration ?? operation.runner,
+    realization.runner,
+    `${label} runner`,
+  )
+  assert.deepEqual(
+    operation.runnerBase?.typeArguments ?? operation.runnerTypeArguments,
+    realization.runnerArguments,
+    `${label} runner arguments`,
+  )
+  assert.deepEqual(
+    operation.outcomeType.type.failures,
+    realization.rows.failures,
+    `${label} failure rows`,
+  )
+  assert.deepEqual(
+    operation.outcomeType.type.requirements,
+    realization.rows.requirements,
+    `${label} requirement rows`,
+  )
+}
+
 /** The single stored realization, for shapes such as `unrun` that never reach a run operation. */
 const storedRealization = (module: Mir.Module, label: string) => {
   const realizations = storedRealizations(module)
@@ -190,6 +221,7 @@ it.effect(
         )
         const { realization } = storedRunner(wasmLowering.module, testCase.name)
         assert.strictEqual(realization.access, testCase.access, testCase.name)
+        assertExactRows(wasmLowering.module, testCase.name)
 
         const evaluated = BootstrapEvaluation.evaluate(
           wasmLowering.snapshot.instances,
@@ -208,6 +240,8 @@ it.effect(
 
         const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
         const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
+        // The native lowering carries the same exact rows the Wasm lowering and evaluator proved.
+        assertExactRows(nativeLowering.module, testCase.name)
         const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
           mode: 'release',
         })
@@ -221,9 +255,88 @@ it.effect(
           realization.runner,
           `${testCase.name} runner identity across targets`,
         )
+        if (testCase.name === 'provided') {
+          // Service provision resolves statically: the specialized runner reaches the backend, and
+          // the provider travels in the environment rather than a runtime dictionary.
+          const specialized = nativeLowering.module.functions
+            .flatMap(Mir.operations)
+            .find(
+              (candidate) =>
+                candidate._tag === 'RunEffectValue' &&
+                candidate.runnerBase?.declaration.name === 'count$effect$-1',
+            )
+          assert.isDefined(specialized, testCase.name)
+          if (specialized?._tag !== 'RunEffectValue') return
+          assert.match(specialized.runner.name, /^count\$effect\$-1\$provided\$/)
+          assert.lengthOf(specialized.providers, 1, testCase.name)
+          assert.include(llvm.ir, sanitize(specialized.runner.name), testCase.name)
+        }
       }
     }),
 )
+
+/**
+ * Repeats one stored-Effect construct-and-clean cycle `count` times.
+ *
+ * Returning 42 does not distinguish a released capture from a leaked one, so the cleanup parity
+ * check runs the cycle in a loop and measures the Wasm heap: an environment the backend fails to
+ * release once per iteration grows memory, while exactly-once cleanup keeps it flat.
+ */
+const cleanupCycles = (exit: CleanupExit, count: number): string => `struct Problem { code: i32 }
+struct Guard { tag: i32 storage: Allocation }
+impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
+fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
+  operation: F
+) -> Deferred<A, E, R, F> {
+  return Deferred<A, E, R> { operation: move operation }
+}
+effect fn failing(guard: Guard) -> i32 ! Problem {
+  let result = guard.tag
+  if result == 0 { return 0 }
+  fail Problem { code: result }
+}
+effect fn cycle() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let guard = Guard { tag: 7, storage: move storage }
+  let deferred = defer(failing(move guard))
+  ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
+}
+effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
+effect fn drive() -> i32 ! Problem | OutOfMemory ? &mut Allocator {
+  let mut index = 0
+  let mut total = 0
+  while index < ${count} {
+    total = total + run cycle()
+    index = index + 1
+  }
+  return total
+}
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  let total = run Effect.catch(drive() |> Effect.provideMut(&mut allocator), recover)
+  if total == ${exit === 'failure' ? 42 : count * 42} { return 42 }
+  return 1
+}`
+
+const pagesOf = (instance: WebAssembly.Instance): number => {
+  const memory = instance.exports[StandardStreams.wasmMemoryExport]
+  assert.instanceOf(memory, WebAssembly.Memory)
+  return memory instanceof WebAssembly.Memory
+    ? memory.buffer.byteLength / 65536
+    : Number.POSITIVE_INFINITY
+}
+
+/** Runs a Wasm artifact and reports both its result and the heap it needed. */
+const runWasmMeasured = Effect.fnUntraced(function* (bytes: Uint8Array) {
+  return yield* Effect.try(() => {
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
+    const main = instance.exports.silk_main
+    if (typeof main !== 'function') return unreachable('expected Wasm main')
+    const value = main()
+    return Object.freeze({ value, pages: pagesOf(instance) })
+  })
+})
 
 type CleanupExit = 'unrun' | 'failure'
 
@@ -293,8 +406,12 @@ it.effect('cleans unrun and failing stored Effect environments exactly once in e
             ).length
           : -1
       assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
-      if (exit === 'failure')
+      if (exit === 'failure') {
         assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
+        // A typed failure keeps its exact failure rows through both lowerings.
+        assertExactRows(module, exit)
+        assertExactRows(native.module, `${exit} native`)
+      }
     }
   }),
 )
@@ -336,6 +453,7 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
     assert.strictEqual(completedValue(outcome), 42)
     assert.strictEqual(dropCalls(outcome), 1)
     assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
+    assertExactRows(module, 'suspending')
 
     const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'release' })
     assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
@@ -352,5 +470,40 @@ it.effect('resumes a suspending stored Effect with matching cleanup in every eng
       llvm.ir,
       sanitize(storedRunner(native.module, 'suspending').realization.runner.name),
     )
+  }),
+)
+
+it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
+  Effect.gen(function* () {
+    // Only the unrun exit repeats: a typed failure aborts the loop on its first cycle, so its
+    // iteration count would not vary and the heap comparison would prove nothing.
+    for (const exit of ['unrun'] as const) {
+      const short = yield* lowerStored(
+        `stored-effect-parity/cycles-${exit}-short`,
+        cleanupCycles(exit, 8),
+        Target.wasm32UnknownUnknown,
+      )
+      const long = yield* lowerStored(
+        `stored-effect-parity/cycles-${exit}-long`,
+        cleanupCycles(exit, 80),
+        Target.wasm32UnknownUnknown,
+      )
+      const shortWasm = yield* Backend.emit(WasmBackend.WasmBackend, short.module, {
+        mode: 'release',
+      })
+      const longWasm = yield* Backend.emit(WasmBackend.WasmBackend, long.module, {
+        mode: 'release',
+      })
+      assert.strictEqual(shortWasm._tag, 'WebAssemblyModuleArtifact', exit)
+      assert.strictEqual(longWasm._tag, 'WebAssemblyModuleArtifact', exit)
+      if (shortWasm._tag !== 'WebAssemblyModuleArtifact') return
+      if (longWasm._tag !== 'WebAssemblyModuleArtifact') return
+      const shortRun = yield* runWasmMeasured(shortWasm.bytes)
+      const longRun = yield* runWasmMeasured(longWasm.bytes)
+      assert.strictEqual(shortRun.value, 42, `${exit} short cycles`)
+      assert.strictEqual(longRun.value, 42, `${exit} long cycles`)
+      // Ten times the cycles must not cost more heap: a capture leaked once per cycle would grow it.
+      assert.strictEqual(longRun.pages, shortRun.pages, `${exit} heap growth across cycles`)
+    }
   }),
 )

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -1,0 +1,354 @@
+import { assert, it } from '@effect/vitest'
+import * as Effect from 'effect/Effect'
+import * as Analysis from '../src/Analysis.js'
+import * as Backend from '../src/Backend.js'
+import * as BootstrapEvaluation from '../src/BootstrapEvaluation.js'
+import * as ContinuationLayout from '../src/ContinuationLayout.js'
+import * as Layout from '../src/Layout.js'
+import * as Lower from '../src/Lower.js'
+import * as Mir from '../src/Mir.js'
+import * as MirNormalization from '../src/MirNormalization.js'
+import * as OpaqueRealization from '../src/OpaqueRealization.js'
+import type * as Ownership from '../src/Ownership.js'
+import * as ProvisionalMir from '../src/ProvisionalMir.js'
+import * as SuspensionMir from '../src/SuspensionMir.js'
+import * as SuspensionOwnership from '../src/SuspensionOwnership.js'
+import * as Target from '../src/Target.js'
+import * as WasmBackend from '../src/WasmBackend.js'
+import { unreachable } from './support/raise.js'
+
+const ascii = (value: string): Uint8Array =>
+  Uint8Array.from(value, (character) => character.charCodeAt(0))
+
+/**
+ * Lowers one stored-Effect program to MIR for a chosen target.
+ *
+ * `SEM0107` still fences every stored Effect out of `Analysis.realize`, so this mirrors the merged
+ * evaluator harness and drives the phases directly instead of reading `snapshot.mir`. The fence
+ * assertion is deliberate: task 4.4 narrows it only for shapes these engines prove first.
+ */
+const lowerStored = Effect.fnUntraced(function* (
+  name: string,
+  source: string,
+  target: Target.Target,
+) {
+  const snapshot = yield* Analysis.ofSourceRealized(name, ascii(source), target.id)
+  const diagnostics = Analysis.diagnostics(snapshot)
+  assert.isTrue(diagnostics.length > 0, name)
+  assert.isTrue(
+    diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
+    JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
+  )
+  const catalog = Layout.catalog(target, snapshot.index, snapshot.instances)
+  const layout = Layout.plan(catalog, snapshot.instances)
+  const ownership =
+    Analysis.ownershipOf(snapshot, name) ?? unreachable('expected module ownership facts')
+  const lowered = Lower.lowerProgram(
+    snapshot.instances,
+    new Map<string, Ownership.ModuleOwnership>([[name, ownership]]),
+    layout,
+    snapshot.index,
+    OpaqueRealization.catalogOf(snapshot),
+  )
+  const provisional = ProvisionalMir.build(snapshot.instances, layout, snapshot.index)
+  const normalized = MirNormalization.normalize(lowered, provisional)
+  const module = ContinuationLayout.apply(
+    SuspensionMir.finalize(
+      normalized,
+      provisional,
+      SuspensionOwnership.plan(normalized, provisional, snapshot.index),
+      snapshot.index,
+    ),
+  )
+  assert.deepEqual(Mir.verify(module), [], name)
+  return Object.freeze({ snapshot, module })
+})
+
+const runWasm = Effect.fnUntraced(function* (bytes: Uint8Array) {
+  const result = yield* Effect.try(() => {
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes.slice()), {})
+    const main = instance.exports.silk_main
+    if (typeof main !== 'function') return unreachable('expected Wasm main')
+    return main()
+  })
+  assert.strictEqual(typeof result, 'number')
+  return typeof result === 'number' ? result : unreachable('expected numeric Wasm result')
+})
+
+const completedValue = (outcome: BootstrapEvaluation.Outcome): number => {
+  assert.strictEqual(outcome._tag, 'Completed', outcome._tag)
+  if (outcome._tag !== 'Completed') return unreachable('expected completed evaluation')
+  return outcome.result.value
+}
+
+const storedRealizations = (module: Mir.Module) =>
+  module.layout.entries.flatMap((entry) =>
+    entry.representation._tag === 'StoredEffectEnvironment'
+      ? [entry.representation.realization]
+      : [],
+  )
+
+/** The static runner every engine must agree on for one stored Effect. */
+const storedRunner = (module: Mir.Module, label: string) => {
+  const realizations = storedRealizations(module)
+  for (const realization of realizations) {
+    for (const operation of module.functions.flatMap(Mir.operations)) {
+      if (operation._tag !== 'RunEffectValue') continue
+      const runner = operation.runnerBase?.declaration ?? operation.runner
+      if (runner.module === realization.runner.module && runner.name === realization.runner.name)
+        return Object.freeze({ operation, realization })
+    }
+  }
+  return unreachable(`expected one ${label} stored Effect run`)
+}
+
+/** The single stored realization, for shapes such as `unrun` that never reach a run operation. */
+const storedRealization = (module: Mir.Module, label: string) => {
+  const realizations = storedRealizations(module)
+  return realizations.length === 1
+    ? (realizations.at(0) ?? unreachable(`expected one ${label} realization`))
+    : unreachable(`expected one ${label} realization (${realizations.length} found)`)
+}
+
+/** Mirrors the LLVM symbol sanitizer so IR assertions name the emitted runner, not the MIR spelling. */
+const sanitize = (name: string): string => name.replace(/[^A-Za-z0-9_]/g, '_')
+
+const dropCalls = (outcome: BootstrapEvaluation.Outcome): number =>
+  outcome._tag === 'Completed'
+    ? outcome.trace.filter(
+        (event) => event._tag === 'Call' && event.target.name.startsWith('drop@impl'),
+      ).length
+    : 0
+
+const traceCount = (outcome: BootstrapEvaluation.Outcome, tag: string): number =>
+  outcome._tag === 'Completed' ? outcome.trace.filter((event) => event._tag === tag).length : 0
+
+const shared = `struct Deferred<F: Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let base = 21
+  let deferred = Deferred { operation: effect { return base } }
+  return (run deferred.operation) + (run deferred.operation)
+}`
+
+const exclusive = `struct Deferred<F: mut Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let mut counter = 20
+  let mut deferred = Deferred { operation: effect {
+    counter = counter + 1
+    return counter
+  } }
+  return (run deferred.operation) + (run deferred.operation)
+}`
+
+const consuming = `struct Token { value: i32 storage: Allocation }
+impl Drop for Token { fn drop(self: &mut Token) -> () { return () } }
+struct Deferred<F: once Effect<i32>> { operation: F }
+fn consume(token: Token) -> i32 { return token.value }
+effect fn build() -> i32 ! OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let token = Token { value: 42, storage: move storage }
+  let deferred = Deferred { operation: effect { return consume(move token) } }
+  return run deferred.operation
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
+}`
+
+const provided = `service Counter { effect fn get() -> i32 ? &Counter }
+struct Fixed { value: i32 }
+effect fn get(self: &Fixed) -> i32 { return self.value }
+impl Counter for Fixed { get: Fixed.get }
+effect fn count() -> i32 ? &Counter { return run Counter.get() }
+struct Deferred<F: once Effect<i32>> { operation: F }
+pub fn main() -> i32 {
+  let fixed = Fixed { value: 42 }
+  let deferred = Deferred { operation: count() |> Effect.provide(&fixed) }
+  return run deferred.operation
+}`
+
+const runtimeMatrix = [
+  { name: 'shared', source: shared, result: 42, access: 'Shared' },
+  { name: 'exclusive', source: exclusive, result: 43, access: 'Exclusive' },
+  { name: 'consuming', source: consuming, result: 42, access: 'Take' },
+  { name: 'provided', source: provided, result: 42, access: 'Take' },
+] as const
+
+it.effect('executes stored Effects with identical results and runner identity in every engine', () =>
+  Effect.gen(function* () {
+    const host = yield* Target.host()
+    for (const testCase of runtimeMatrix) {
+      // One module name for both targets: the runner identity must not depend on the target.
+      const moduleName = `stored-effect-parity/${testCase.name}`
+      const wasmLowering = yield* lowerStored(
+        moduleName,
+        testCase.source,
+        Target.wasm32UnknownUnknown,
+      )
+      const { realization } = storedRunner(wasmLowering.module, testCase.name)
+      assert.strictEqual(realization.access, testCase.access, testCase.name)
+
+      const evaluated = BootstrapEvaluation.evaluate(
+        wasmLowering.snapshot.instances,
+        wasmLowering.module,
+      )
+      assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
+
+      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
+        mode: 'release',
+      })
+      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+      assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
+      // Stored Effects stay statically dispatched: no runtime dictionary, no indirect call.
+      assert.notInclude(wasm.wat, 'call_indirect', testCase.name)
+
+      const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
+      const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
+      const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
+        mode: 'release',
+      })
+      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
+      if (llvm._tag !== 'LlvmBitcodeArtifact') return
+      assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
+      // The same static runner the evaluator called is the one LLVM emitted.
+      assert.include(llvm.ir, sanitize(nativeRunner.realization.runner.name), testCase.name)
+      assert.deepEqual(
+        nativeRunner.realization.runner,
+        realization.runner,
+        `${testCase.name} runner identity across targets`,
+      )
+    }
+  }),
+)
+
+type CleanupExit = 'unrun' | 'failure'
+
+const cleanupProgram = (exit: CleanupExit): string => `struct Problem { code: i32 }
+struct Guard { tag: i32 storage: Allocation }
+impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
+fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
+  operation: F
+) -> Deferred<A, E, R, F> {
+  return Deferred<A, E, R> { operation: move operation }
+}
+effect fn failing(guard: Guard) -> i32 ! Problem {
+  let result = guard.tag
+  if result == 0 { return 0 }
+  fail Problem { code: result }
+}
+effect fn build() -> i32 ! Problem | OutOfMemory {
+  let mut allocator = SystemAllocator.make()
+  let storage = run Allocator.allocate(Layout.of<i32>()) |> Effect.provideMut(&mut allocator)
+  let guard = Guard { tag: 7, storage: move storage }
+  let deferred = defer(failing(move guard))
+  ${exit === 'failure' ? 'return run deferred.operation' : 'return 42'}
+}
+effect fn recover(error: Problem | OutOfMemory) -> i32 { return 42 }
+pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
+
+it.effect('cleans unrun and failing stored Effect environments exactly once in every engine', () =>
+  Effect.gen(function* () {
+    const host = yield* Target.host()
+    for (const exit of ['unrun', 'failure'] as const) {
+      const moduleName = `stored-effect-parity/cleanup-${exit}`
+      const { snapshot, module } = yield* lowerStored(
+        moduleName,
+        cleanupProgram(exit),
+        Target.wasm32UnknownUnknown,
+      )
+      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+      assert.strictEqual(completedValue(outcome), 42, exit)
+      // The evaluator's cleanup trace is the contract the backends must match.
+      assert.strictEqual(dropCalls(outcome), 1, `${exit} Drop hook`)
+      assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
+      assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
+
+      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'release' })
+      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
+      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+      assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
+      assert.notInclude(wasm.wat, 'call_indirect', exit)
+
+      const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
+      const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
+      if (llvm._tag !== 'LlvmBitcodeArtifact') return
+      // The Drop hook that cleans the stored environment survives into native code.
+      assert.include(llvm.ir, sanitize('drop@impl'), exit)
+
+      // `unrun` never reaches a run operation, so the realization is the only runner fact.
+      const runner = storedRealization(module, exit).runner
+      const runnerCalls =
+        outcome._tag === 'Completed'
+          ? outcome.trace.filter(
+              (event) =>
+                event._tag === 'Call' &&
+                event.target.module === runner.module &&
+                event.target.name === runner.name,
+            ).length
+          : -1
+      assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
+      if (exit === 'failure')
+        assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
+    }
+  }),
+)
+
+const suspending = `struct Guard { tag: i32 storage: Allocation }
+impl Drop for Guard { fn drop(self: &mut Guard) -> () { return () } }
+struct Deferred<A, !E, ?R, F: once Effect<A ! E ? R>> { operation: F }
+fn defer<A, !E, ?R, F: once Effect<A ! E ? R>>(
+  operation: F
+) -> Deferred<A, E, R, F> {
+  return Deferred<A, E, R> { operation: move operation }
+}
+effect fn delayed(guard: Guard) -> i32 ! OutOfMemory ? &mut Allocator {
+  let base = run Effect.suspend(effect { return 40 })
+  return base + guard.tag
+}
+effect fn build() -> i32 ! OutOfMemory ? &mut Allocator {
+  let storage = run Allocator.allocate(Layout.of<i32>())
+  let guard = Guard { tag: 2, storage: move storage }
+  let deferred = defer(delayed(move guard))
+  return run deferred.operation
+}
+effect fn recover(error: OutOfMemory) -> i32 { return 0 }
+pub fn main() -> i32 {
+  let mut allocator = SystemAllocator.make()
+  return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
+}`
+
+it.effect('resumes a suspending stored Effect with matching cleanup in every engine', () =>
+  Effect.gen(function* () {
+    const host = yield* Target.host()
+    const moduleName = 'stored-effect-parity/suspending'
+    const { snapshot, module } = yield* lowerStored(
+      moduleName,
+      suspending,
+      Target.wasm32UnknownUnknown,
+    )
+    const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+    assert.strictEqual(completedValue(outcome), 42)
+    assert.strictEqual(dropCalls(outcome), 1)
+    assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
+
+    const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'release' })
+    assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
+    if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+    assert.strictEqual(yield* runWasm(wasm.bytes), 42)
+    assert.notInclude(wasm.wat, 'call_indirect')
+
+    const native = yield* lowerStored(moduleName, suspending, host)
+    const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+    assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
+    if (llvm._tag !== 'LlvmBitcodeArtifact') return
+    assert.include(llvm.ir, 'define i32 @silk_main')
+    assert.include(
+      llvm.ir,
+      sanitize(storedRunner(native.module, 'suspending').realization.runner.name),
+    )
+  }),
+)

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -364,7 +364,7 @@ it.effect(
         )
         const nativeRun = yield* runNative(toolchain, llvm, host)
         assert.strictEqual(
-          nativeRun.exitCode,
+          Number(nativeRun.exitCode),
           testCase.result,
           `${testCase.name} native: ${nativeRun.stderr}`,
         )
@@ -492,70 +492,77 @@ effect fn build() -> i32 ! Problem | OutOfMemory {
 }
 pub fn main() -> i32 { return run Effect.catch(build(), recover) }`
 
-it.effect('cleans unrun and failing stored Effect environments exactly once in every engine', () =>
-  Effect.gen(function* () {
-    const host = yield* Target.host()
-    const toolchain = Object.freeze({
-      _tag: 'Toolchain' as const,
-      clang: yield* clangPath(),
-      shimCache: NativeToolchain.makeShimCache(),
-    })
-    for (const exit of ['unrun', 'failure'] as const) {
-      const moduleName = `stored-effect-parity/cleanup-${exit}`
-      const { snapshot, module } = yield* lowerStored(
-        moduleName,
-        cleanupProgram(exit),
-        Target.wasm32UnknownUnknown,
-      )
-      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
-      assert.strictEqual(completedValue(outcome), 42, exit)
-      // The evaluator's cleanup trace is the contract the backends must match.
-      assert.strictEqual(dropCalls(outcome), 1, `${exit} Drop hook`)
-      assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
-      assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
+it.effect(
+  'cleans unrun and failing stored Effect environments exactly once in every engine',
+  () =>
+    Effect.gen(function* () {
+      const host = yield* Target.host()
+      const toolchain = Object.freeze({
+        _tag: 'Toolchain' as const,
+        clang: yield* clangPath(),
+        shimCache: NativeToolchain.makeShimCache(),
+      })
+      for (const exit of ['unrun', 'failure'] as const) {
+        const moduleName = `stored-effect-parity/cleanup-${exit}`
+        const { snapshot, module } = yield* lowerStored(
+          moduleName,
+          cleanupProgram(exit),
+          Target.wasm32UnknownUnknown,
+        )
+        const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+        assert.strictEqual(completedValue(outcome), 42, exit)
+        // The evaluator's cleanup trace is the contract the backends must match.
+        assert.strictEqual(dropCalls(outcome), 1, `${exit} Drop hook`)
+        assert.strictEqual(traceCount(outcome, 'AllocationAcquire'), 1, `${exit} acquire`)
+        assert.strictEqual(traceCount(outcome, 'AllocationRelease'), 1, `${exit} release`)
 
-      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
-      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
-      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-      // 42 means the poisoned Drop did not run twice. A missed cleanup is a leak, proven by cycles.
-      assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
-      assert.notInclude(wasm.wat, 'call_indirect', exit)
-      if (exit === 'failure') {
-        assertDirectWasmRunner(wasm.wat, module, storedRunner(module, exit).realization.runner, exit)
+        const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
+        assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', exit)
+        if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+        // 42 means the poisoned Drop did not run twice. A missed cleanup is a leak, proven by cycles.
+        assert.strictEqual(yield* runWasm(wasm.bytes), 42, `${exit} Wasm`)
+        assert.notInclude(wasm.wat, 'call_indirect', exit)
+        if (exit === 'failure') {
+          assertDirectWasmRunner(
+            wasm.wat,
+            module,
+            storedRunner(module, exit).realization.runner,
+            exit,
+          )
+        }
+
+        const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
+        const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
+        if (llvm._tag !== 'LlvmBitcodeArtifact') return
+        // The Drop hook that cleans the stored environment survives into native code.
+        const dropFn =
+          native.module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
+          unreachable(`expected an emitted Drop hook for ${exit}`)
+        assert.include(llvm.ir, Backend.symbolFor(dropFn, Mir.machineEntry(native.module)), exit)
+        const nativeRun = yield* runNative(toolchain, llvm, host)
+        assert.strictEqual(Number(nativeRun.exitCode), 42, `${exit} native: ${nativeRun.stderr}`)
+
+        // `unrun` never reaches a run operation, so the realization is the only runner fact.
+        const runner = storedRealization(module, exit).runner
+        const runnerCalls =
+          outcome._tag === 'Completed'
+            ? outcome.trace.filter(
+                (event) =>
+                  event._tag === 'Call' &&
+                  event.target.module === runner.module &&
+                  event.target.name === runner.name,
+              ).length
+            : -1
+        assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
+        if (exit === 'failure') {
+          assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
+          // A typed failure keeps its exact failure rows through both lowerings.
+          assertExactRows(module, exit)
+          assertExactRows(native.module, `${exit} native`)
+        }
       }
-
-      const native = yield* lowerStored(moduleName, cleanupProgram(exit), host)
-      const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', exit)
-      if (llvm._tag !== 'LlvmBitcodeArtifact') return
-      // The Drop hook that cleans the stored environment survives into native code.
-      const dropFn =
-        native.module.functions.find((candidate) => candidate.id.name.startsWith('drop@impl')) ??
-        unreachable(`expected an emitted Drop hook for ${exit}`)
-      assert.include(llvm.ir, Backend.symbolFor(dropFn, Mir.machineEntry(native.module)), exit)
-      const nativeRun = yield* runNative(toolchain, llvm, host)
-      assert.strictEqual(nativeRun.exitCode, 42, `${exit} native: ${nativeRun.stderr}`)
-
-      // `unrun` never reaches a run operation, so the realization is the only runner fact.
-      const runner = storedRealization(module, exit).runner
-      const runnerCalls =
-        outcome._tag === 'Completed'
-          ? outcome.trace.filter(
-              (event) =>
-                event._tag === 'Call' &&
-                event.target.module === runner.module &&
-                event.target.name === runner.name,
-            ).length
-          : -1
-      assert.strictEqual(runnerCalls, exit === 'failure' ? 1 : 0, `${exit} stored runner calls`)
-      if (exit === 'failure') {
-        assert.isAbove(traceCount(outcome, 'EffectFailure'), 0, 'typed failure trace')
-        // A typed failure keeps its exact failure rows through both lowerings.
-        assertExactRows(module, exit)
-        assertExactRows(native.module, `${exit} native`)
-      }
-    }
-  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   180_000,
 )
 
@@ -576,50 +583,52 @@ pub fn main() -> i32 {
   return run Effect.catch(build() |> Effect.provideMut(&mut allocator), recover)
 }`
 
-it.effect('resumes a suspending stored Effect with matching cleanup in every engine', () =>
-  Effect.gen(function* () {
-    const host = yield* Target.host()
-    const toolchain = Object.freeze({
-      _tag: 'Toolchain' as const,
-      clang: yield* clangPath(),
-      shimCache: NativeToolchain.makeShimCache(),
-    })
-    const moduleName = 'stored-effect-parity/suspending'
-    const { snapshot, module } = yield* lowerStored(
-      moduleName,
-      suspending,
-      Target.wasm32UnknownUnknown,
-    )
-    const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
-    assert.strictEqual(completedValue(outcome), 42)
-    assert.strictEqual(dropCalls(outcome), 1)
-    assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
-    assertExactRows(module, 'suspending')
+it.effect(
+  'resumes a suspending stored Effect with matching cleanup in every engine',
+  () =>
+    Effect.gen(function* () {
+      const host = yield* Target.host()
+      const toolchain = Object.freeze({
+        _tag: 'Toolchain' as const,
+        clang: yield* clangPath(),
+        shimCache: NativeToolchain.makeShimCache(),
+      })
+      const moduleName = 'stored-effect-parity/suspending'
+      const { snapshot, module } = yield* lowerStored(
+        moduleName,
+        suspending,
+        Target.wasm32UnknownUnknown,
+      )
+      const outcome = BootstrapEvaluation.evaluate(snapshot.instances, module)
+      assert.strictEqual(completedValue(outcome), 42)
+      assert.strictEqual(dropCalls(outcome), 1)
+      assert.isAbove(traceCount(outcome, 'SuspensionOrigin'), 0)
+      assertExactRows(module, 'suspending')
 
-    const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
-    assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
-    if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-    // 42 means resume succeeded and the poisoned Drop did not run twice.
-    assert.strictEqual(yield* runWasm(wasm.bytes), 42)
-    assertDirectWasmRunner(
-      wasm.wat,
-      module,
-      storedRunner(module, 'suspending').realization.runner,
-      'suspending',
-    )
+      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, module, { mode: 'debug' })
+      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact')
+      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+      // 42 means resume succeeded and the poisoned Drop did not run twice.
+      assert.strictEqual(yield* runWasm(wasm.bytes), 42)
+      assertDirectWasmRunner(
+        wasm.wat,
+        module,
+        storedRunner(module, 'suspending').realization.runner,
+        'suspending',
+      )
 
-    const native = yield* lowerStored(moduleName, suspending, host)
-    const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
-    assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
-    if (llvm._tag !== 'LlvmBitcodeArtifact') return
-    assert.include(llvm.ir, 'define i32 @silk_main')
-    assert.include(
-      llvm.ir,
-      emittedSymbol(native.module, storedRunner(native.module, 'suspending').realization.runner),
-    )
-    const nativeRun = yield* runNative(toolchain, llvm, host)
-    assert.strictEqual(nativeRun.exitCode, 42, `suspending native: ${nativeRun.stderr}`)
-  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+      const native = yield* lowerStored(moduleName, suspending, host)
+      const llvm = yield* Backend.emit(Backend.LlvmBackend, native.module, { mode: 'release' })
+      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact')
+      if (llvm._tag !== 'LlvmBitcodeArtifact') return
+      assert.include(llvm.ir, 'define i32 @silk_main')
+      assert.include(
+        llvm.ir,
+        emittedSymbol(native.module, storedRunner(native.module, 'suspending').realization.runner),
+      )
+      const nativeRun = yield* runNative(toolchain, llvm, host)
+      assert.strictEqual(Number(nativeRun.exitCode), 42, `suspending native: ${nativeRun.stderr}`)
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   180_000,
 )
 
@@ -649,7 +658,12 @@ pub fn main() -> i32 {
 it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles', () =>
   Effect.gen(function* () {
     const programs = [
-      { name: 'unrun', short: 8, long: 80, source: (count: number) => cleanupCycles('unrun', count) },
+      {
+        name: 'unrun',
+        short: 8,
+        long: 80,
+        source: (count: number) => cleanupCycles('unrun', count),
+      },
       {
         name: 'failure',
         short: 8,
@@ -684,7 +698,11 @@ it.effect('keeps the Wasm heap flat across repeated stored Effect cleanup cycles
       assert.strictEqual(shortRun.value, 42, `${testCase.name} short cycles`)
       assert.strictEqual(longRun.value, 42, `${testCase.name} long cycles`)
       // Ten times the cycles must not cost more heap: a capture leaked once per cycle would grow it.
-      assert.strictEqual(longRun.pages, shortRun.pages, `${testCase.name} heap growth across cycles`)
+      assert.strictEqual(
+        longRun.pages,
+        shortRun.pages,
+        `${testCase.name} heap growth across cycles`,
+      )
     }
   }),
 )

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -175,52 +175,54 @@ const runtimeMatrix = [
   { name: 'provided', source: provided, result: 42, access: 'Take' },
 ] as const
 
-it.effect('executes stored Effects with identical results and runner identity in every engine', () =>
-  Effect.gen(function* () {
-    const host = yield* Target.host()
-    for (const testCase of runtimeMatrix) {
-      // One module name for both targets: the runner identity must not depend on the target.
-      const moduleName = `stored-effect-parity/${testCase.name}`
-      const wasmLowering = yield* lowerStored(
-        moduleName,
-        testCase.source,
-        Target.wasm32UnknownUnknown,
-      )
-      const { realization } = storedRunner(wasmLowering.module, testCase.name)
-      assert.strictEqual(realization.access, testCase.access, testCase.name)
+it.effect(
+  'executes stored Effects with identical results and runner identity in every engine',
+  () =>
+    Effect.gen(function* () {
+      const host = yield* Target.host()
+      for (const testCase of runtimeMatrix) {
+        // One module name for both targets: the runner identity must not depend on the target.
+        const moduleName = `stored-effect-parity/${testCase.name}`
+        const wasmLowering = yield* lowerStored(
+          moduleName,
+          testCase.source,
+          Target.wasm32UnknownUnknown,
+        )
+        const { realization } = storedRunner(wasmLowering.module, testCase.name)
+        assert.strictEqual(realization.access, testCase.access, testCase.name)
 
-      const evaluated = BootstrapEvaluation.evaluate(
-        wasmLowering.snapshot.instances,
-        wasmLowering.module,
-      )
-      assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
+        const evaluated = BootstrapEvaluation.evaluate(
+          wasmLowering.snapshot.instances,
+          wasmLowering.module,
+        )
+        assert.strictEqual(completedValue(evaluated), testCase.result, testCase.name)
 
-      const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
-        mode: 'release',
-      })
-      assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
-      if (wasm._tag !== 'WebAssemblyModuleArtifact') return
-      assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
-      // Stored Effects stay statically dispatched: no runtime dictionary, no indirect call.
-      assert.notInclude(wasm.wat, 'call_indirect', testCase.name)
+        const wasm = yield* Backend.emit(WasmBackend.WasmBackend, wasmLowering.module, {
+          mode: 'release',
+        })
+        assert.strictEqual(wasm._tag, 'WebAssemblyModuleArtifact', testCase.name)
+        if (wasm._tag !== 'WebAssemblyModuleArtifact') return
+        assert.strictEqual(yield* runWasm(wasm.bytes), testCase.result, `${testCase.name} Wasm`)
+        // Stored Effects stay statically dispatched: no runtime dictionary, no indirect call.
+        assert.notInclude(wasm.wat, 'call_indirect', testCase.name)
 
-      const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
-      const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
-      const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
-        mode: 'release',
-      })
-      assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
-      if (llvm._tag !== 'LlvmBitcodeArtifact') return
-      assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
-      // The same static runner the evaluator called is the one LLVM emitted.
-      assert.include(llvm.ir, sanitize(nativeRunner.realization.runner.name), testCase.name)
-      assert.deepEqual(
-        nativeRunner.realization.runner,
-        realization.runner,
-        `${testCase.name} runner identity across targets`,
-      )
-    }
-  }),
+        const nativeLowering = yield* lowerStored(moduleName, testCase.source, host)
+        const nativeRunner = storedRunner(nativeLowering.module, testCase.name)
+        const llvm = yield* Backend.emit(Backend.LlvmBackend, nativeLowering.module, {
+          mode: 'release',
+        })
+        assert.strictEqual(llvm._tag, 'LlvmBitcodeArtifact', testCase.name)
+        if (llvm._tag !== 'LlvmBitcodeArtifact') return
+        assert.include(llvm.ir, 'define i32 @silk_main', testCase.name)
+        // The same static runner the evaluator called is the one LLVM emitted.
+        assert.include(llvm.ir, sanitize(nativeRunner.realization.runner.name), testCase.name)
+        assert.deepEqual(
+          nativeRunner.realization.runner,
+          realization.runner,
+          `${testCase.name} runner identity across targets`,
+        )
+      }
+    }),
 )
 
 type CleanupExit = 'unrun' | 'failure'


### PR DESCRIPTION
Implements OpenSpec task 4.2 of `store-effects-in-nominals`: native LLVM and direct-Wasm parity for stored Effects. Base is PR4a merge 298c1dea.

## What was wrong

Both backends died on `RangeError: could not realize place-read lane 0` for any program storing an Effect in a nominal field.

`logicalLanes` in each backend had a stored-*callable* branch routing through `Layout.callingShape`, but the `EffectValue` branch ignored `type.storage` and fell through to `effectEnvironmentLanes`, which emits lane paths with **no `EffectCaptureSelector` prefix**. The place-read matcher requires a source lane whose path extends the destination's by the selectors, so every candidate was rejected.

`Mir.verify` compares lane *counts*, never lane *paths*, so the mismatch was invisible to verification — the MIR verified clean while both backends failed.

## The fix

11 lines: a stored-Effect branch in each backend, mirroring the adjacent stored-callable one, routing through the existing generic `Layout.callingShape`. `shapeNode` already accepted `StoredEffectEnvironment` and `materializeLanes` already emitted `EffectCaptureSelector` — the machinery existed and was simply unused by the backends. No new representation, identity, or dispatch model.

## Evidence

`StoredEffectEngineParity.test.ts` mirrors the merged evaluator matrix on both backends:

- shared / exclusive / consuming / provided — result and access parity
- exact failure and requirement rows asserted against the realization on both the Wasm and native lowerings
- `provided` pinned to its specialized runner and single provider, proving service provision resolves statically into emitted IR
- unrun and typed-failure cleanup — exactly-once Drop hook and allocation balance
- **exactly-once cleanup proven on the Wasm engine itself**: the unrun construct-and-clean cycle repeats, and the heap stays flat as the cycle count grows tenfold (verified flat to 4000 cycles). Returning 42 alone would not distinguish a leaked capture.
- suspending resume
- static runner identity asserted in emitted LLVM IR, and equal across both targets
- `call_indirect` absent from every Wasm artifact (no dynamic dispatch)

Verified the tests genuinely fail with the original `place-read lane 0` error when the backend fix is reverted, and that the heap assertion is falsifiable.

## Scope

SEM0107 is **unchanged**. It still fences these programs out of `Analysis.realize`, so the harness drives the lowering phases directly, exactly as the merged evaluator test does. This is deliberate: the spec requires the fence to remain "for any nominal storage path not proven through ownership, layout, MIR, evaluator, LLVM, and direct WebAssembly", and narrowing it is task 4.4.

Consequence, recorded in tasks.md: direct Wasm executes end to end, while native parity is proven at emitted LLVM IR, because `Driver.compile` cannot reach a native executable until 4.4 lands.

Not included: 4.3 invalidation, 4.4 fence narrowing, 5.1–5.3, sync, archive.

## Known follow-up (pre-existing, not introduced here)

`WasmBackend.ts` `resultLanes` (~4777) and the declaration lane path (~5320) lack the stored branch for **both** Effects and callables — missing since #196. No shape in scope reaches them, and the asymmetry affects stored callables equally, so fixing it speculatively would be unverifiable. Flagged for follow-up when 4.4 allows stored executables across function boundaries.

## Gates

- `pnpm typecheck` — 20/20 pass
- `pnpm exec biome check .` — clean
- compiler suite — 1849/1850 pass; the single failure (`WasmShadowStackHeapCollision`, deep-recursion stack probe) **reproduces identically at untouched base 298c1dea**, so it predates this change
- stored-callable, stored-Effect, and heap-reclaim suites — 27/27 pass, no regression on the shared lane path
- `release:candidate` not required: no package contents or exports changed