### PR TITLE
Retire the stored Effect fence for proven nominal shapes

### DIFF
--- a/openspec/changes/store-effects-in-nominals/design.md
+++ b/openspec/changes/store-effects-in-nominals/design.md
@@ -51,8 +51,9 @@ later phases never recover them from binding initializers.
 Effect tag enriches the existing `RepresentationField` identity with the discovered runner, exact
 contract rows, actual run access, ordered environment, unrun cleanup lanes, and suspendability. It
 contains no sizes, offsets, row dictionaries, or dispatch ABI. Callable consumers explicitly narrow
-to the callable tag, and no Effect consumer is enabled in this slice, so `SEM0107` still stops every
-stored Effect before layout and MIR.
+to the callable tag. Effect storage crosses `SEM0107` only when the shared field index proves the
+complete concrete nominal instance; arrays and every other unsupported storage path remain fenced
+before layout and MIR.
 
 The task-2 cleanup and suspension cases are realization proofs, not runtime claims. The unrun case
 records the owned lanes that later ownership and cleanup phases must release; the suspension case

--- a/openspec/changes/store-effects-in-nominals/tasks.md
+++ b/openspec/changes/store-effects-in-nominals/tasks.md
@@ -21,7 +21,7 @@
 - [x] 4.1 Execute shared, exclusive, consuming, unrun, failing, and suspending stored Effects in the evaluator.
 - [x] 4.2 Add native LLVM and direct-Wasm parity for results, failures, runner identity, and cleanup traces.
 - [x] 4.3 Add capture-shape, target, access, cleanup, and suspendability invalidation fixtures.
-- [ ] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
+- [x] 4.4 Narrow the unavailable-Effect-layout fence only for shapes proven by all engines.
 
 ## 5. Verification
 

--- a/packages/compiler/src/Instances.ts
+++ b/packages/compiler/src/Instances.ts
@@ -496,8 +496,7 @@ const storedExecutableViolations = (
   index: DeclarationIndex.Index,
   kind: 'Callable' | 'Effect',
 ): ReadonlyArray<Diagnostic.Diagnostic> => {
-  const callableRealizations =
-    kind === 'Callable' ? callableFieldRealizations(self, index) : undefined
+  const fieldRealizations = callableFieldRealizations(self, index)
   const specializingCalls = new Map<string, CallInstance>()
   for (const call of self.calls) {
     const target = keyText(call.target)
@@ -520,9 +519,8 @@ const storedExecutableViolations = (
           if (found === undefined) return []
           if (
             found.represented &&
-            callableRealizations !== undefined &&
             Type.isNominal(aggregate) &&
-            CallableFieldRealization.supportsInstance(callableRealizations, aggregate)
+            CallableFieldRealization.supportsInstance(fieldRealizations, aggregate)
           )
             return []
           const declared = storedExecutable(index, expression.type, kind)

--- a/packages/compiler/test/CallableFieldRealization.test.ts
+++ b/packages/compiler/test/CallableFieldRealization.test.ts
@@ -57,6 +57,16 @@ const soleEffectRealization = (
   return supported.at(0) ?? unreachable('expected one supported Effect field realization')
 }
 
+const assertEffectRealized = (snapshot: Analysis.Snapshot): void => {
+  assert.notInclude(
+    Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+    'SEM0107',
+  )
+  assert.strictEqual(snapshot.layoutCatalog._tag, 'Available')
+  assert.strictEqual(snapshot.layout._tag, 'Available')
+  assert.strictEqual(snapshot.mir._tag, 'Available')
+}
+
 const namedCallable = `struct Parser<F: fn(i32) -> i32> { parse: F }
 fn decode(value: i32) -> i32 { return value }
 pub fn main() -> i32 {
@@ -117,14 +127,12 @@ it.effect('realizes a capturing section field with one ordered inline capture la
   }),
 )
 
-it.effect(
-  'records exactly-once cleanup for an unrun stored Effect without crossing its fence',
-  () =>
-    Effect.gen(function* () {
-      const module = 'effect-field/unrun-cleanup'
-      const snapshot = yield* realized(
-        module,
-        `struct Token { value: i32 }
+it.effect('records exactly-once cleanup for an unrun stored Effect in the realized pipeline', () =>
+  Effect.gen(function* () {
+    const module = 'effect-field/unrun-cleanup'
+    const snapshot = yield* realized(
+      module,
+      `struct Token { value: i32 }
 struct Deferred<F: once Effect<i32>> { operation: F }
 fn consume(token: Token) -> i32 { return token.value }
 pub fn main() -> i32 {
@@ -132,35 +140,31 @@ pub fn main() -> i32 {
   let deferred = Deferred { operation: effect { return consume(move token) } }
   return 0
 }`,
-      )
-      const realization = soleEffectRealization(realizationsOf(snapshot))
+    )
+    const realization = soleEffectRealization(realizationsOf(snapshot))
 
-      assert.include(
-        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-        'SEM0107',
-      )
-      assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
-      assert.deepEqual(realization.runner, {
-        _tag: 'CanonicalDeclarationId',
-        module,
-        name: 'main$effect$0',
-      })
-      assert.deepEqual(realization.runnerArguments, [])
-      assert.strictEqual(realization.access, 'Take')
-      assert.strictEqual(realization.suspendable, false)
-      assert.deepEqual(realization.rows.failures, [])
-      assert.deepEqual(realization.rows.requirements, [])
-      assert.strictEqual(realization.environment.length, 1)
-      const capture =
-        realization.environment.at(0) ?? unreachable('expected one owned Effect environment slot')
-      assert.strictEqual(capture.source, 'Binding')
-      assert.strictEqual(capture.sourceOrdinal, 0)
-      assert.strictEqual(capture.access, 'Take')
-      assert.strictEqual(Type.encode(capture.type), `${module}.Token`)
-      assert.strictEqual(capture.owned, true)
-      assert.deepEqual(realization.cleanup.unrunLanes, [0])
-      assert.strictEqual(realization.cleanup.consumedByRun, true)
-    }),
+    assertEffectRealized(snapshot)
+    assert.deepEqual(realization.runner, {
+      _tag: 'CanonicalDeclarationId',
+      module,
+      name: 'main$effect$0',
+    })
+    assert.deepEqual(realization.runnerArguments, [])
+    assert.strictEqual(realization.access, 'Take')
+    assert.strictEqual(realization.suspendable, false)
+    assert.deepEqual(realization.rows.failures, [])
+    assert.deepEqual(realization.rows.requirements, [])
+    assert.strictEqual(realization.environment.length, 1)
+    const capture =
+      realization.environment.at(0) ?? unreachable('expected one owned Effect environment slot')
+    assert.strictEqual(capture.source, 'Binding')
+    assert.strictEqual(capture.sourceOrdinal, 0)
+    assert.strictEqual(capture.access, 'Take')
+    assert.strictEqual(Type.encode(capture.type), `${module}.Token`)
+    assert.strictEqual(capture.owned, true)
+    assert.deepEqual(realization.cleanup.unrunLanes, [0])
+    assert.strictEqual(realization.cleanup.consumedByRun, true)
+  }),
 )
 
 it.effect('realizes a suspending stored runner with exact rows and no structural Effect ABI', () =>
@@ -181,11 +185,7 @@ pub fn main() -> i32 {
     )
     const realization = soleEffectRealization(realizationsOf(snapshot))
 
-    assert.include(
-      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-      'SEM0107',
-    )
-    assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+    assertEffectRealized(snapshot)
     assert.strictEqual(realization.suspendable, true)
     assert.strictEqual(realization.runner.module, 'effect-field/suspending')
     assert.strictEqual(realization.runner.name, 'main$effect$0')
@@ -226,10 +226,7 @@ pub fn main() -> i32 {
           : [],
       )
 
-      assert.deepEqual(
-        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-        ['SEM0107', 'SEM0107'],
-      )
+      assertEffectRealized(snapshot)
       assert.strictEqual(realizations.length, 2)
       assert.deepEqual(
         realizations
@@ -272,10 +269,7 @@ pub fn main() -> i32 {
         : [],
     )
 
-    assert.deepEqual(
-      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-      ['SEM0107', 'SEM0107'],
-    )
+    assertEffectRealized(snapshot)
     assert.strictEqual(realizations.length, 2)
     assert.strictEqual(
       realizations.every(
@@ -345,10 +339,7 @@ pub fn main() -> i32 {
     )
     const realization = soleEffectRealization(realizationsOf(snapshot))
 
-    assert.include(
-      Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-      'SEM0107',
-    )
+    assertEffectRealized(snapshot)
     assert.deepEqual(
       realization.environment.map((slot) => [slot.source, slot.sourceOrdinal]),
       [

--- a/packages/compiler/test/RepresentationFence.test.ts
+++ b/packages/compiler/test/RepresentationFence.test.ts
@@ -32,6 +32,17 @@ const assertRealizedCallable = (snapshot: Analysis.Snapshot): void => {
   if (snapshot.mir._tag === 'Available') assert.deepEqual(Mir.verify(snapshot.mir.value), [])
 }
 
+const assertRealizedEffect = (snapshot: Analysis.Snapshot): void => {
+  assert.notInclude(
+    Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+    'SEM0107',
+  )
+  assert.strictEqual(snapshot.layoutCatalog._tag, 'Available')
+  assert.strictEqual(snapshot.layout._tag, 'Available')
+  assert.strictEqual(snapshot.mir._tag, 'Available')
+  if (snapshot.mir._tag === 'Available') assert.deepEqual(Mir.verify(snapshot.mir.value), [])
+}
+
 it.effect('realizes exact represented callable storage through layout and MIR', () =>
   Effect.gen(function* () {
     const snapshot = yield* realized(
@@ -64,7 +75,7 @@ pub fn main() -> i32 {
   }),
 )
 
-it.effect('fences exact represented Effect storage before layout and MIR', () =>
+it.effect('realizes exact represented Effect storage through layout and MIR', () =>
   Effect.gen(function* () {
     const snapshot = yield* realized(
       'representation-fence/effect-exact',
@@ -75,11 +86,11 @@ pub fn main() -> i32 {
 }`,
     )
 
-    assertFenced(snapshot, 'SEM0107')
+    assertRealizedEffect(snapshot)
   }),
 )
 
-it.effect('keeps represented Effect storage fenced for every declared run mode', () =>
+it.effect('realizes represented Effect storage for every proven run mode', () =>
   Effect.gen(function* () {
     const modes = [
       ['shared', 'Effect<i32>'],
@@ -97,12 +108,12 @@ pub fn main() -> i32 {
 }`,
       )
 
-      assertFenced(snapshot, 'SEM0107')
+      assertRealizedEffect(snapshot)
     }
   }),
 )
 
-it.effect('fences an open Effect field after reachable exact specialization', () =>
+it.effect('realizes an open Effect field after reachable exact specialization', () =>
   Effect.gen(function* () {
     const source = `struct Deferred<F: Effect<i32>> { operation: F }
 fn defer<F: Effect<i32>>(operation: F) -> Deferred<F> {
@@ -113,17 +124,7 @@ pub fn main() -> i32 {
   return run deferred.operation
 }`
     const snapshot = yield* realized('representation-fence/effect-open', source)
-    const diagnostic = Analysis.diagnostics(snapshot).find(
-      (candidate) => candidate.code === 'SEM0107',
-    )
-
-    assertFenced(snapshot, 'SEM0107')
-    assert.strictEqual(
-      diagnostic === undefined
-        ? undefined
-        : source.slice(diagnostic.span.start, diagnostic.span.end).trim(),
-      'defer(effect { return 1 })',
-    )
+    assertRealizedEffect(snapshot)
   }),
 )
 
@@ -371,7 +372,7 @@ pub fn main() -> i32 {
     }),
 )
 
-it.effect('fences nested repeated represented Effect fields through the shared field index', () =>
+it.effect('realizes nested repeated represented Effect fields through the shared field index', () =>
   Effect.gen(function* () {
     const snapshot = yield* realized(
       'representation-fence/effect-nested-repeated',
@@ -390,16 +391,7 @@ pub fn main() -> i32 {
   return 0
 }`,
     )
-    const diagnostics = Analysis.diagnostics(snapshot).filter(
-      (diagnostic) => diagnostic.code === 'SEM0107',
-    )
-
-    assertFenced(snapshot, 'SEM0107')
-    assert.strictEqual(diagnostics.length, 3)
-    assert.strictEqual(
-      diagnostics.some((diagnostic) => diagnostic.message.includes('field first')),
-      true,
-    )
+    assertRealizedEffect(snapshot)
   }),
 )
 

--- a/packages/compiler/test/RepresentationField.test.ts
+++ b/packages/compiler/test/RepresentationField.test.ts
@@ -444,15 +444,13 @@ pub fn main() -> i32 {
     const movedRealized = Analysis.realize(moved, 'wasm32-unknown-unknown')
     assert.deepEqual(
       Analysis.diagnostics(firstRealized).map((diagnostic) => diagnostic.code),
-      ['SEM0107'],
+      [],
     )
     assert.deepEqual(
       Analysis.diagnostics(movedRealized).map((diagnostic) => diagnostic.code),
-      ['SEM0107'],
+      [],
     )
-    assert.notDeepEqual(
-      Analysis.diagnostics(firstRealized).map((diagnostic) => diagnostic.span),
-      Analysis.diagnostics(movedRealized).map((diagnostic) => diagnostic.span),
-    )
+    assert.strictEqual(firstRealized.mir._tag, 'Available')
+    assert.strictEqual(movedRealized.mir._tag, 'Available')
   }),
 )

--- a/packages/compiler/test/StoredEffectEngineParity.test.ts
+++ b/packages/compiler/test/StoredEffectEngineParity.test.ts
@@ -44,7 +44,8 @@ const clangPath = Effect.fnUntraced(function* () {
 
 /**
  * Takes one already-lowered LLVM artifact through object emission, shim compilation, linking, and
- * execution. `SEM0107` still fences `Driver.compile`, so this is the native path task 4.2 can use.
+ * execution. Keeping this boundary explicit lets the parity suite inspect and run the same LLVM
+ * artifact without involving CLI filesystem policy.
  */
 const runNative = Effect.fnUntraced(function* (
   toolchain: NativeToolchain.Toolchain,
@@ -94,23 +95,14 @@ const lowerSource = Effect.fnUntraced(function* (
   name: string,
   source: string,
   target: Target.Target,
-  fence: 'stored' | 'open',
 ) {
   const snapshot = yield* Analysis.ofSourceRealized(name, ascii(source), target.id)
   const diagnostics = Analysis.diagnostics(snapshot)
-  if (fence === 'stored') {
-    assert.isTrue(diagnostics.length > 0, name)
-    assert.isTrue(
-      diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
-      JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
-    )
-  } else {
-    assert.deepEqual(
-      diagnostics,
-      [],
-      JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
-    )
-  }
+  assert.deepEqual(
+    diagnostics,
+    [],
+    JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
+  )
   const catalog = Layout.catalog(target, snapshot.index, snapshot.instances)
   const layout = Layout.plan(catalog, snapshot.instances)
   const ownership =
@@ -139,16 +131,15 @@ const lowerSource = Effect.fnUntraced(function* (
 /**
  * Lowers one stored-Effect program to MIR for a chosen target.
  *
- * `SEM0107` still fences every stored Effect out of `Analysis.realize`, so this mirrors the merged
- * evaluator harness and drives the phases directly instead of reading `snapshot.mir`. The fence
- * assertion is deliberate: task 4.4 narrows it only for shapes these engines prove first.
+ * These fixtures are the proven shapes for which task 4.4 retires `SEM0107`. Driving the phases
+ * directly keeps the cross-engine comparison on the same MIR module for every target.
  */
 const lowerStored = Effect.fnUntraced(function* (
   name: string,
   source: string,
   target: Target.Target,
 ) {
-  return yield* lowerSource(name, source, target, 'stored')
+  return yield* lowerSource(name, source, target)
 })
 
 const emitLlvm = Effect.fnUntraced(function* (module: Mir.Module, label: string) {
@@ -934,13 +925,11 @@ pub fn main() -> i32 {
         'stored-effect-parity/cycles-leak-short',
         leakHolds(8),
         Target.wasm32UnknownUnknown,
-        'open',
       )
       const leakLong = yield* lowerSource(
         'stored-effect-parity/cycles-leak-long',
         leakHolds(80),
         Target.wasm32UnknownUnknown,
-        'open',
       )
       const leakShortWasm = yield* Backend.emit(WasmBackend.WasmBackend, leakShort.module, {
         mode: 'release',

--- a/packages/compiler/test/StoredEffectLayout.test.ts
+++ b/packages/compiler/test/StoredEffectLayout.test.ts
@@ -48,11 +48,13 @@ pub fn main() -> i32 {
           (entry) => Type.isNominal(entry.type) && entry.type.name === 'Deferred',
         ) ?? unreachable('expected Deferred layout')
 
-      assert.include(
+      assert.notInclude(
         Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
         'SEM0107',
       )
-      assert.strictEqual(snapshot.layoutCatalog._tag, 'Unavailable')
+      assert.strictEqual(snapshot.layoutCatalog._tag, 'Available')
+      assert.strictEqual(snapshot.layout._tag, 'Available')
+      assert.strictEqual(snapshot.mir._tag, 'Available')
       assert.strictEqual(represented.representation._tag, 'StoredEffectEnvironment')
       if (represented.representation._tag !== 'StoredEffectEnvironment') continue
       assert.deepEqual(

--- a/packages/compiler/test/StoredEffectMir.test.ts
+++ b/packages/compiler/test/StoredEffectMir.test.ts
@@ -151,10 +151,13 @@ pub fn main() -> i32 {
       .flatMap((fn) => fn.localTypes)
       .find((type) => type._tag === 'EffectValue' && type.storage !== undefined)
 
-    assert.include(
+    assert.notInclude(
       Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
       'SEM0107',
     )
+    assert.strictEqual(snapshot.layoutCatalog._tag, 'Available')
+    assert.strictEqual(snapshot.layout._tag, 'Available')
+    assert.strictEqual(snapshot.mir._tag, 'Available')
     assert.strictEqual(make?._tag, 'MakeEffect')
     assert.strictEqual(stored?._tag, 'StoredEffectField')
     assert.strictEqual(projected?._tag, 'EffectValue')

--- a/packages/compiler/test/StoredEffectOwnership.test.ts
+++ b/packages/compiler/test/StoredEffectOwnership.test.ts
@@ -6,8 +6,8 @@ import { unreachable } from './support/raise.js'
 /**
  * Aggregate receiver access for Effect representations stored in nominal fields.
  *
- * This is an ownership-only contract: every concrete storage attempt remains fenced by `SEM0107`
- * until later slices prove the complete runtime realization in every engine.
+ * These receiver rules remain the ownership admission boundary after proven nominal realizations
+ * cross the layout fence.
  */
 
 const ascii = (value: string): Uint8Array =>

--- a/packages/compiler/test/StoredEffectRuntime.test.ts
+++ b/packages/compiler/test/StoredEffectRuntime.test.ts
@@ -25,9 +25,9 @@ const lowerStored = Effect.fnUntraced(function* (name: string, source: string) {
     Target.wasm32UnknownUnknown.id,
   )
   const diagnostics = Analysis.diagnostics(snapshot)
-  assert.isTrue(diagnostics.length > 0)
-  assert.isTrue(
-    diagnostics.every((diagnostic) => diagnostic.code === 'SEM0107'),
+  assert.deepEqual(
+    diagnostics,
+    [],
     JSON.stringify(diagnostics.map(({ code, message }) => ({ code, message }))),
   )
   const catalog = Layout.catalog(Target.wasm32UnknownUnknown, snapshot.index, snapshot.instances)


### PR DESCRIPTION
## Summary
- allow concrete nominal stored-Effect realizations supported by the shared field index to reach layout and MIR
- preserve SEM0107 for arrays and other unsupported storage paths
- update stored-Effect fixtures to exercise the realized pipeline

## Local gates
- compiler typecheck
- targeted Biome
- 8 stored-Effect/fence files: 73 tests passed

Part of #190 (task 4.4 only).