### PR TITLE
test(compiler): measure host stack headroom instead of assuming ten times

### DIFF
--- a/packages/compiler/scripts/generate-documentation.mjs
+++ b/packages/compiler/scripts/generate-documentation.mjs
@@ -56,6 +56,168 @@ const phases = {
   LAY: 'Layout',
 }
 
+// The diagnostic message scanners. Message expressions are walked character by character with
+// string, template, and bracket state, because a regular expression cannot see where a template
+// hole or a ternary branch ends once literals nest inside interpolations.
+
+/** Index just past the string or template literal opening at `index`. */
+const literalEnd = (text, index) => {
+  const quote = text[index]
+  let cursor = index + 1
+  while (cursor < text.length) {
+    const character = text[cursor]
+    if (character === '\\') cursor += 2
+    else if (character === quote) return cursor + 1
+    else if (quote === '`' && character === '$' && text[cursor + 1] === '{')
+      cursor = expressionEnd(text, cursor + 2, '}') + 1
+    else cursor += 1
+  }
+  return cursor
+}
+
+/** Index of the first occurrence of `terminator` at bracket depth zero, outside literals. */
+const expressionEnd = (text, index, terminator) => {
+  let depth = 0
+  let cursor = index
+  while (cursor < text.length) {
+    const character = text[cursor]
+    if (character === "'" || character === '"' || character === '`') {
+      cursor = literalEnd(text, cursor)
+      continue
+    }
+    if (depth === 0 && character === terminator) return cursor
+    if (character === '(' || character === '[' || character === '{') depth += 1
+    else if (character === ')' || character === ']' || character === '}') depth -= 1
+    cursor += 1
+  }
+  return cursor
+}
+
+/**
+ * Index where the expression starting at `index` ends: the first unnested line break whose next
+ * line does not continue it, or an unnested closing bracket. This is how far a `return` reaches
+ * in the semicolon-free house style, where a wrapped conditional opens its lines with `?` or `:`.
+ */
+const statementEnd = (text, index) => {
+  let depth = 0
+  let cursor = index
+  while (cursor < text.length) {
+    const character = text[cursor]
+    if (character === "'" || character === '"' || character === '`') {
+      cursor = literalEnd(text, cursor)
+      continue
+    }
+    if (character === '(' || character === '[' || character === '{') depth += 1
+    else if (character === ')' || character === ']' || character === '}') {
+      if (depth === 0) return cursor
+      depth -= 1
+    } else if (character === '\n' && depth === 0) {
+      if (!/^\s*(?:[?:.]|\|\||&&|\?\?)/.test(text.slice(cursor + 1, cursor + 12))) return cursor
+    }
+    cursor += 1
+  }
+  return cursor
+}
+
+/** The template's text with each interpolation hole replaced by a `<placeholder>` name. */
+const templateOf = (content) => {
+  let rendered = ''
+  let cursor = 0
+  while (cursor < content.length) {
+    if (content[cursor] === '$' && content[cursor + 1] === '{') {
+      const end = expressionEnd(content, cursor + 2, '}')
+      const expression = content.slice(cursor + 2, end)
+      const tail = expression.trim().split('.').pop() ?? expression
+      rendered += `<${tail.replace(/[^A-Za-z0-9]/g, '')}>`
+      cursor = end + 1
+    } else {
+      rendered += content[cursor]
+      cursor += 1
+    }
+  }
+  return rendered
+}
+
+/** The two branches of the expression's outermost conditional, or undefined without one. */
+const branchesOf = (text) => {
+  let depth = 0
+  let question = -1
+  let pending = 0
+  let cursor = 0
+  while (cursor < text.length) {
+    const character = text[cursor]
+    if (character === "'" || character === '"' || character === '`') {
+      cursor = literalEnd(text, cursor)
+      continue
+    }
+    if (character === '(' || character === '[' || character === '{') depth += 1
+    else if (character === ')' || character === ']' || character === '}') depth -= 1
+    else if (
+      depth === 0 &&
+      character === '?' &&
+      text[cursor + 1] !== '?' &&
+      text[cursor + 1] !== '.' &&
+      text[cursor - 1] !== '?'
+    ) {
+      if (question === -1) question = cursor
+      else pending += 1
+    } else if (depth === 0 && character === ':' && question !== -1) {
+      if (pending === 0)
+        return Object.freeze([text.slice(question + 1, cursor), text.slice(cursor + 1)])
+      pending -= 1
+    }
+    cursor += 1
+  }
+  return undefined
+}
+
+/** The unnested string and template literals of the expression, holes already renamed. */
+const literalsOf = (text) => {
+  const literals = []
+  let depth = 0
+  let cursor = 0
+  while (cursor < text.length) {
+    const character = text[cursor]
+    if (character === "'" || character === '"' || character === '`') {
+      const end = literalEnd(text, cursor)
+      if (depth === 0) literals.push(templateOf(text.slice(cursor + 1, end - 1)))
+      cursor = end
+      continue
+    }
+    if (character === '(' || character === '[' || character === '{') depth += 1
+    else if (character === ')' || character === ']' || character === '}') depth -= 1
+    cursor += 1
+  }
+  return literals
+}
+
+/**
+ * Every complete template the message expression can produce, in source order.
+ *
+ * A conditional contributes both branches and drops its condition, whose literals are
+ * discriminants rather than wording. An expression with no literal of its own must be a call to a
+ * message helper in the same file; its templates are the ones its `return` statements produce.
+ */
+const templatesOf = (source, expression) => {
+  const text = expression.trim()
+  const branches = branchesOf(text)
+  if (branches !== undefined)
+    return [...templatesOf(source, branches[0]), ...templatesOf(source, branches[1])]
+  const literals = literalsOf(text)
+  if (literals.length > 0) return literals
+  const call = /^(\w+)\(/.exec(text)
+  if (call === null) return []
+  const opening = source.indexOf(`const ${call[1]} = `)
+  if (opening === -1) return []
+  const body = source.slice(source.indexOf('=> {', opening), statementEnd(source, opening))
+  const templates = []
+  for (const returned of body.matchAll(/\breturn\s/g)) {
+    const start = (returned.index ?? 0) + returned[0].length
+    templates.push(...templatesOf(source, body.slice(start, statementEnd(body, start))))
+  }
+  return templates
+}
+
 const diagnosticsPage = () => {
   const source = readFileSync(diagnosticSource, 'utf8')
 
@@ -89,24 +251,24 @@ const diagnosticsPage = () => {
     process.exit(1)
   }
 
-  // The constructor bodies carry the user-visible message template, which is the most precise
-  // one-line meaning available for the codes whose constant carries no comment.
+  // The constructor bodies carry the user-visible message templates, which are the most precise
+  // one-line meaning available for the codes whose constant carries no comment. A message is not
+  // always one literal: some factories choose between complete templates with a conditional, and
+  // one delegates to a helper whose switch returns a template per problem. `templatesOf` below
+  // walks the message expression by nesting rather than by pattern, so every complete wording a
+  // code can report lands in this catalog — and is thereby gated against drift.
   const messages = new Map()
-  // `message:` may wrap onto its own line before the string literal.
-  const factory = /code: (\w+)Code,[\s\S]{0,400}?message:\s*([`'"])((?:\\.|(?!\2)[\s\S])*)\2/g
-  for (const match of source.matchAll(factory)) {
-    const template = match[3].replace(/\$\{([^}]*)\}/g, (_, expression) => {
-      const tail = expression.trim().split('.').pop() ?? expression
-      return `<${tail.replace(/[^A-Za-z0-9]/g, '')}>`
-    })
-    if (!messages.has(match[1])) messages.set(match[1], template)
+  for (const match of source.matchAll(/code: (\w+)Code,[\s\S]{0,400}?\bmessage:/g)) {
+    const start = (match.index ?? 0) + match[0].length
+    const variants = templatesOf(source, source.slice(start, expressionEnd(source, start, ',')))
+    if (variants.length > 0 && !messages.has(match[1])) messages.set(match[1], variants)
   }
   const byName = new Map(
     [...documented.entries()].map(([code, entry]) => [entry.name, { code, ...entry }]),
   )
-  for (const [name, template] of messages) {
+  for (const [name, templates] of messages) {
     const entry = byName.get(name)
-    if (entry !== undefined) entry.message = template
+    if (entry !== undefined) entry.messages = templates
   }
 
   const codes = [...documented.entries()]
@@ -148,8 +310,12 @@ const diagnosticsPage = () => {
     )
     for (const entry of group) {
       const meaning = entry.comment.length > 0 ? entry.comment : ''
-      const reported =
-        entry.message === undefined ? '' : `\`${entry.message.replace(/\|/g, '\\|')}\``
+      // A code with several complete templates lists each: they are all wording this page gates.
+      // A template that itself contains a backtick needs the padded double-backtick span form.
+      const reported = (entry.messages ?? [])
+        .map((template) => template.replace(/\|/g, '\\|'))
+        .map((template) => (template.includes('`') ? `\`\` ${template} \`\`` : `\`${template}\``))
+        .join('<br>')
       lines.push(`| \`${entry.code}\` | ${meaning.replace(/\|/g, '\\|')} | ${reported} |`)
     }
     lines.push('')

--- a/packages/compiler/src/Diagnostic.ts
+++ b/packages/compiler/src/Diagnostic.ts
@@ -1252,16 +1252,22 @@ export const unexpectedTokens = (
       ? 'invalid token'
       : Token.describe(firstUnexpected)
   const expectations = Object.freeze([...expected])
-  const message =
-    context === 'syntax'
-      ? `Unexpected ${encountered}; expected ${expectations[0] ?? 'valid syntax'}`
-      : `Unexpected ${encountered} while parsing ${context === 'statement' ? 'a statement' : `a ${context}`}`
+  const expectation = expectations[0]
   return Object.freeze({
     _tag: 'Diagnostic',
     phase: 'parser',
     code: unexpectedTokensCode,
     severity: 'error',
-    message,
+    // Each branch is one complete template, so the generated diagnostic catalog pins every wording
+    // this code can report rather than a fragment with the choice buried in an interpolation.
+    message:
+      context === 'syntax'
+        ? expectation === undefined
+          ? `Unexpected ${encountered}; expected valid syntax`
+          : `Unexpected ${encountered}; expected ${expectation}`
+        : context === 'statement'
+          ? `Unexpected ${encountered} while parsing a statement`
+          : `Unexpected ${encountered} while parsing a ${context}`,
     reason: Object.freeze({
       _tag: 'UnexpectedTokens',
       unexpected: Object.freeze([...unexpected]),
@@ -2753,7 +2759,11 @@ const contractRowInferenceMessage = (problem: ContractRowInferenceProblem): stri
     case 'AmbiguousFailureRemainder':
       return `Failure row remainder is ambiguous across ${problem.parameters.join(', ')}`
     case 'AbsentRequirementMember':
-      return `Requirement row does not contain ${problem.access === 'Exclusive' ? '&mut ' : '&'}${problem.capability}@${problem.role}`
+      // Two complete templates rather than one with the access marker interpolated, so the
+      // generated diagnostic catalog pins both wordings this problem can report.
+      return problem.access === 'Exclusive'
+        ? `Requirement row does not contain &mut ${problem.capability}@${problem.role}`
+        : `Requirement row does not contain &${problem.capability}@${problem.role}`
     case 'IncompatibleRequirementRole':
       return `Requirement ${problem.capability} has role ${problem.actual.join(' or ')}, expected ${problem.expected}`
     case 'IncompatibleRequirementAccess':

--- a/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
+++ b/packages/compiler/test/WasmShadowStackHeapCollision.test.ts
@@ -35,8 +35,10 @@ import { statusAddress, statusStackOverflow } from '../src/WasmBackend.js'
  *    just under a thousand levels deep.
  * 2. **Crossing reports.** Past that depth the module traps at the reservation and names the reason,
  *    and its frames never reach the heap page.
- * 3. **The host is not involved.** A recursion that needs no shadow-stack frame carries ten times
- *    that depth on the same engine before V8 raises `RangeError`.
+ * 3. **The host is not involved.** A recursion that needs no shadow-stack frame carries the depth
+ *    that reported on the same engine, and at least double it, before V8 raises `RangeError`. The
+ *    headroom is measured rather than assumed, because engines draw their own execution-stack
+ *    bound differently across versions and platforms.
  * 4. **Only the walk pays.** Building and releasing the same chain iteratively reserves one frame,
  *    so it is unaffected at any depth.
  *
@@ -183,19 +185,23 @@ const unwalked = (depth: number): string =>
   )
 
 /**
- * Recursion with nothing to spill: no borrow, no aggregate, no frame. The backend gives this
- * function no shadow-stack frame at all — the module has no linear memory — so its only limit is
- * the engine's, which is the control this test needs.
+ * Recursion with nothing to spill: no borrow, no aggregate, no frame. The backend gives these
+ * functions no shadow-stack frame at all — the module has no linear memory — so their only limit
+ * is the engine's own execution stack, which is the control this test needs. The probe takes its
+ * depth as a parameter rather than baking it into the source, so one instance answers at every
+ * depth the host-control case walks.
  */
-const plainRecursion = (depth: number): string => `fn count(n: i32) -> i32 {
+const framelessProbe = `fn count(n: i32) -> i32 {
   if n == 0 { return 0 }
   return 1 + count(n - 1)
 }
 
-pub fn main() -> i32 {
-  if count(${depth}) == ${depth} { return 0 }
+pub fn probe(depth: i32) -> i32 {
+  if count(depth) == depth { return 0 }
   return 2
-}`
+}
+
+pub fn main() -> i32 { return probe(1) }`
 
 interface Run {
   /** `silk_main`'s value, or `undefined` when the module failed instead of returning. */
@@ -204,8 +210,9 @@ interface Run {
   readonly failure: string | undefined
   /**
    * Highest address below the allocator's own region that the module ever wrote, or `undefined`
-   * without a memory — which only the frameless control is allowed to be. Everywhere else
-   * `measuredReach` turns that `undefined` into a named failure.
+   * without a memory — which no fixture measured this way may be: every one of them spends shadow
+   * stack, and `measuredReach` turns that `undefined` into a named failure. (The frameless
+   * host-control module also has no memory, but it never comes through here.)
    *
    * Between the end of static data and the heap page there is nothing but the shadow stack, so for
    * this fixture — whose static data is a handful of bytes — this is the high-water mark of
@@ -296,7 +303,7 @@ const measure = (id: string, source: string) =>
     const artifact = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
     const globals = globalInitializers(artifact.wat)
     // The backend declares the shadow-stack pointer first and the heap pointer second; a module
-    // with neither has no linear memory and no shadow stack, which is the control case.
+    // with neither has no linear memory and no shadow stack, which `measuredReach` names below.
     const heapBase = globals.at(1) ?? 0
     return Object.freeze({ heapBase, ...execute(artifact.bytes, heapBase) })
   })
@@ -416,19 +423,67 @@ it.effect(
 )
 
 it.effect(
-  'has host stack to spare an order of magnitude past the depth that reported',
+  'has host stack to spare past the depth that reported',
   () =>
     Effect.gen(function* () {
       const measured = yield* growth
 
-      // Same engine, same call depth times ten, no shadow-stack frame: it returns. So the report
-      // above is not the machine stack running out, and the bound that fired was not the host's.
-      const deep = yield* measure(
-        `shadow-stack-collision/host-control/${measured.bounded * 10}`,
-        plainRecursion(measured.bounded * 10),
+      const id = 'shadow-stack-collision/host-control'
+      const snapshot = yield* Analysis.ofSourceRealized(
+        id,
+        ascii(framelessProbe),
+        'wasm32-unknown-unknown',
       )
-      assert.strictEqual(deep.value, 0)
-      assert.isUndefined(deep.stackReach, 'a frameless recursion needs no linear memory at all')
+      assert.deepEqual(
+        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+        [],
+        id,
+      )
+      const artifact = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(artifact.bytes.slice()), {})
+      assert.isUndefined(
+        instance.exports[wasmMemoryExport],
+        'a frameless recursion needs no linear memory at all',
+      )
+      // Non-entry functions carry a mangled symbol; the declaration's name survives inside it.
+      const probeExport = Object.keys(instance.exports).find((name) => name.includes('_probe__'))
+      assert.isDefined(probeExport, 'the control must export its probe')
+      const probe = instance.exports[probeExport ?? ''] as (depth: number) => number
+
+      // The host's own bound is measured here rather than assumed, because it is the one number
+      // in this file the emitted module cannot derive: V8 sizes its execution stack differently
+      // across versions and platforms, so a fixed multiple of the shadow-stack depth fits some
+      // engines and not others. `RangeError` is the host refusing; anything else is a real
+      // failure and propagates.
+      const completes = (depth: number): boolean => {
+        try {
+          assert.strictEqual(probe(depth), 0, `frameless recursion at ${depth} must count itself`)
+          return true
+        } catch (error) {
+          if (error instanceof RangeError) return false
+          throw error
+        }
+      }
+
+      // Same engine, the exact call depth whose reservation reported, no shadow-stack frame: it
+      // returns. So the report above is not the machine stack running out, and the bound that
+      // fired was not the host's.
+      assert.isTrue(
+        completes(measured.bounded),
+        `the host must carry ${measured.bounded} frameless levels — the depth that reported`,
+      )
+
+      // And with room to spare: doubling the depth until the host refuses shows the engine's own
+      // bound sits at least a factor of two past the module's, which is what makes the two
+      // distinguishable. The walk is capped because some hosts never refuse within useful range —
+      // by then the headroom is proven many times over.
+      let headroom = 1
+      while (headroom < 16 && completes(measured.bounded * headroom * 2)) headroom *= 2
+      assert.isAtLeast(
+        headroom,
+        2,
+        `the host refused between ${measured.bounded} and ${measured.bounded * 2} frameless levels — too close to the shadow-stack bound to tell the module's report from the engine's`,
+      )
     }),
   120_000,
 )

--- a/packages/language/docs/diagnostics.md
+++ b/packages/language/docs/diagnostics.md
@@ -39,7 +39,7 @@ There are 151 codes in total.
 | Code | Meaning | Reported as |
 | --- | --- | --- |
 | `PAR0001` | Stable code for one required token that is absent at its insertion position. | `Expected <describeexpected>` |
-| `PAR0002` | Stable code for one maximal region of unexpected concrete tokens. |  |
+| `PAR0002` | Stable code for one maximal region of unexpected concrete tokens. | `Unexpected <encountered>; expected valid syntax`<br>`Unexpected <encountered>; expected <expectation>`<br>`Unexpected <encountered> while parsing a statement`<br>`Unexpected <encountered> while parsing a <context>` |
 | `PAR0003` | Stable code for a primary-expression template start reserved for future support. | `Template syntax is reserved but not implemented` |
 | `PAR0004` | Stable code for one wholly absent required return statement. | `Expected return statement` |
 
@@ -109,7 +109,7 @@ There are 151 codes in total.
 | `SEM0051` |  | `<target> expects <expected> type argument<expected1s>, received <actual>` |
 | `SEM0052` |  | `Cannot infer all type arguments for <target> from supplied values` |
 | `SEM0053` |  | `Recursive specialization changes type arguments from <caller> to <target>` |
-| `SEM0054` | Stable code for a borrowed slice type outside a direct ordinary-function parameter. |  |
+| `SEM0054` | Stable code for a borrowed slice type outside a direct ordinary-function parameter. | `A slice must be the complete type of an ordinary function parameter`<br>`A slice cannot appear in a <position> type` |
 | `SEM0055` |  | `A slice borrow is only valid as an immediate ordinary-call argument` |
 | `SEM0056` |  | `A slice borrow requires a direct stable array binding or slice parameter` |
 | `SEM0057` |  | `Exclusive borrowing requires mutable binding <spelling>` |
@@ -143,12 +143,12 @@ There are 151 codes in total.
 | `SEM0086` | Stable code for a typed constant whose type or literal is outside the constant contract. | `Invalid constant: <detail>` |
 | `SEM0087` | Stable code for an expression statement whose result cannot be intentionally ignored. | `Expression statement produces <actual>, but only () or never may be ignored` |
 | `SEM0088` | Stable code for using a generic binder in a value, failure-row, or requirement-row position of another kind. | `Generic parameter <spelling> has kind <actual>, expected <expected>` |
-| `SEM0089` | Stable code for a failure or requirement row that cannot be finitely decomposed. |  |
+| `SEM0089` | Stable code for a failure or requirement row that cannot be finitely decomposed. | `Failure row does not contain selected member <member>`<br>`Failure row remainder is ambiguous across <join>`<br>`Requirement row does not contain &mut <capability>@<role>`<br>`Requirement row does not contain &<capability>@<role>`<br>`Requirement <capability> has role <joinor>, expected <expected>`<br>`Requirement <capability>@<role> has access <joinor>, expected <expected>`<br>`Requirement row remainder is ambiguous across <join>`<br>`Failure row specialization is not finite and concrete`<br>`Requirement row specialization is not finite and concrete` |
 | `SEM0090` | Stable code for storage, bodies, or defaults inside a source service contract. | `Invalid service declaration: <detail>` |
 | `SEM0091` |  | `A returned slice must belong to an ordinary function with exactly one borrowed parameter; an exclusive result requires an exclusive parameter` |
 | `SEM0092` |  | `The returned slice does not originate from the function's single borrowed parameter` |
 | `SEM0093` | Stable code for one reachable intrinsic unavailable on the requested execution target. | `<operation> is unavailable for <target>` |
-| `SEM0094` | Stable code for wrapping the already-borrowed string view in another reference or slice. |  |
+| `SEM0094` | Stable code for wrapping the already-borrowed string view in another reference or slice. | `` `string` is already a borrowed immutable view and cannot be referenced again ``<br>`` `string` cannot be the element of another borrowed slice view `` |
 | `SEM0095` | Stable code for a float literal spelling no floating-point value can represent. | `Invalid float literal: <spelling>` |
 | `SEM0096` | Stable code for an effect site or a move inside the conditional right operand of `&&` or `\|\|`. | `The right operand of <operator> must be pure, found <detail>` |
 | `SEM0097` | Stable code for a bound operation call whose receiver names more than one bounded parameter. | `<spelling> is ambiguous across bounded type parameters <join>` |
@@ -157,7 +157,7 @@ There are 151 codes in total.
 | `SEM0100` | Stable code for an explicit type argument contradicting the type its value arguments imply. | `Type argument <parameter> of <target> is <written>, but the supplied values imply <implied>` |
 | `SEM0101` | Stable code for a bound operation whose selected witness has no lowering. | `<spelling> has no witness that can be lowered for <provider>` |
 | `SEM0102` | Stable code for selecting a suspending provider to allocate continuation storage. | `Allocator <provider> cannot provide continuation storage because <implementation> can suspend` |
-| `SEM0103` | Stable code for constructing an aggregate that stores a bare callable value. |  |
+| `SEM0103` | Stable code for constructing an aggregate that stores a bare callable value. | `Cannot construct <aggregate>: <site> retains the static identity of <callable>, but represented callable storage has no supported runtime layout`<br>`Cannot construct <aggregate>: <site> would store the callable <callable>, whose environment layout depends on a hidden concrete identity that <aggregate> does not carry` |
 | `SEM0104` | Stable code for the first struct initializer that contradicts an inferred representation. | `Representation <parameter> was inferred as <expected>, but this initializer uses <actual>` |
 | `SEM0105` | Stable code for the first exact representation that diverges at a static value join. | `Cannot join <expected> with <actual>; consume each represented value inside its branch before joining` |
 | `SEM0106` | Stable code for a representation argument whose contract cannot satisfy its required bound. | `Representation <parameter> requires <required>, but the supplied bound <actual> is not admissible` |


### PR DESCRIPTION
The host-control case of the shadow-stack bound asserted that a frameless
recursion carries ten times the reporting depth before V8 refuses. That
multiplier is an engine constant in disguise: V8 sizes its execution stack
differently across versions and platforms, and node 26 on darwin/arm64 no
longer fits ten thousand frameless frames (this container's node 22 fits
about 10,400 — the old assertion was passing by under five percent).

The control now takes its depth as an exported parameter, so one instance
proves the fact the test actually needs: the exact depth whose reservation
reported completes framelessly, and doubling the depth until the host
refuses shows at least twofold headroom. The headroom is measured off the
running engine like every other depth in the file is measured off the
emitted module, instead of being written down.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BiBYbB23Jj8GKS2AEVEHX4