### PR TITLE
Optimize standard library documentation analysis

### DIFF
--- a/packages/compiler/scripts/check-stdlib-documentation.mjs
+++ b/packages/compiler/scripts/check-stdlib-documentation.mjs
@@ -7,7 +7,9 @@ import { readFileSync } from 'node:fs'
 import * as Effect from 'effect/Effect'
 import * as DocumentationPolicy from '../../documentation/dist/Policy.js'
 import * as DocumentationProject from '../../documentation/dist/Project.js'
-import * as Analysis from '../dist/Analysis.js'
+import * as ProjectAnalysis from '../dist/ProjectAnalysis.js'
+import * as SourceFile from '../dist/SourceFile.js'
+import * as SourceResolver from '../dist/SourceResolver.js'
 import * as CompilerStdlib from '../dist/Stdlib.js'
 
 const lineAt = (bytes, offset) => {
@@ -25,19 +27,21 @@ const program = Effect.gen(function* () {
         Uint8Array.from(readFileSync(new URL(`../stdlib/${manifest.path}`, import.meta.url))),
       catch: (cause) => new Error(`Missing stdlib source: ${manifest.module}`, { cause }),
     })
-    const snapshot = yield* Analysis.ofSource(manifest.module, bytes)
-    const project = DocumentationProject.make(snapshot)
-    const documented = project.modules.find((module) => module.name === manifest.module)
-    if (documented === undefined)
-      return yield* Effect.fail(`Missing documentation model: ${manifest.module}`)
-    analyzed.push({ manifest, bytes, snapshot, documented })
+    analyzed.push({ manifest, bytes, root: SourceFile.make(manifest.module, bytes) })
   }
-  const project = Object.freeze({
-    schema: 'silk-documentation',
-    experimental: true,
-    modules: Object.freeze(analyzed.map((entry) => entry.documented)),
-  })
-  return analyzed.flatMap((entry) =>
+  const analysis = yield* ProjectAnalysis.make(analyzed.map((entry) => entry.root)).pipe(
+    Effect.provide(SourceResolver.empty),
+  )
+  const project = DocumentationProject.fromProjectAnalysis(analysis)
+  const checked = []
+  for (const entry of analyzed) {
+    const documented = project.modules.find((module) => module.name === entry.manifest.module)
+    const snapshot = ProjectAnalysis.view(analysis, entry.manifest.module)
+    if (documented === undefined || snapshot === undefined)
+      return yield* Effect.fail(`Missing documentation model: ${entry.manifest.module}`)
+    checked.push({ ...entry, documented, snapshot })
+  }
+  return checked.flatMap((entry) =>
     DocumentationPolicy.check(entry.documented, entry.snapshot, project).map((violation) => ({
       violation,
       path: entry.manifest.path,

--- a/packages/compiler/scripts/generate-documentation.mjs
+++ b/packages/compiler/scripts/generate-documentation.mjs
@@ -11,7 +11,9 @@ import { fileURLToPath } from 'node:url'
 import * as Effect from 'effect/Effect'
 import * as DocumentationProject from '../../documentation/dist/Project.js'
 import * as DocumentationReference from '../../documentation/dist/Reference.js'
-import * as Analysis from '../dist/Analysis.js'
+import * as ProjectAnalysis from '../dist/ProjectAnalysis.js'
+import * as SourceFile from '../dist/SourceFile.js'
+import * as SourceResolver from '../dist/SourceResolver.js'
 import * as Stdlib from '../dist/Stdlib.js'
 
 const documentationRoot = fileURLToPath(new URL('../../language/docs/', import.meta.url))
@@ -19,7 +21,7 @@ const stdlibRoot = fileURLToPath(new URL('../../language/docs/stdlib/', import.m
 const diagnosticSource = fileURLToPath(new URL('../src/Diagnostic.ts', import.meta.url))
 
 const stdlibTree = async () => {
-  const modules = []
+  const roots = []
   for (const module of Stdlib.manifest) {
     // Read the canonical source rather than the compiler's generated source map. Documentation is
     // commonly regenerated immediately after editing a .silk file, before compiler dist has been
@@ -27,17 +29,12 @@ const stdlibTree = async () => {
     const bytes = Uint8Array.from(
       readFileSync(new URL(`../stdlib/${module.path}`, import.meta.url)),
     )
-    const snapshot = await Effect.runPromise(Analysis.ofSource(module.module, bytes))
-    const project = DocumentationProject.make(snapshot)
-    const documented = project.modules.find((entry) => entry.name === module.module)
-    if (documented !== undefined) modules.push({ manifest: module, documented })
+    roots.push(SourceFile.make(module.module, bytes))
   }
-
-  const project = Object.freeze({
-    schema: 'silk-documentation',
-    experimental: true,
-    modules: Object.freeze(modules.map((entry) => entry.documented)),
-  })
+  const analysis = await Effect.runPromise(
+    ProjectAnalysis.make(roots).pipe(Effect.provide(SourceResolver.empty)),
+  )
+  const project = DocumentationProject.fromProjectAnalysis(analysis)
   const rendered = DocumentationReference.make(Stdlib.manifest, project)
   if (rendered._tag === 'Failure') {
     for (const error of rendered.errors) console.error('Stdlib reference generation failed:', error)

--- a/packages/compiler/scripts/inventory-stdlib-documentation.mjs
+++ b/packages/compiler/scripts/inventory-stdlib-documentation.mjs
@@ -8,7 +8,9 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import * as Effect from 'effect/Effect'
 import * as DocumentationProject from '../../documentation/dist/Project.js'
-import * as Analysis from '../dist/Analysis.js'
+import * as ProjectAnalysis from '../dist/ProjectAnalysis.js'
+import * as SourceFile from '../dist/SourceFile.js'
+import * as SourceResolver from '../dist/SourceResolver.js'
 import * as CompilerStdlib from '../dist/Stdlib.js'
 
 const outputPath = fileURLToPath(
@@ -79,7 +81,7 @@ const render = (modules) => {
 }
 
 const program = Effect.gen(function* () {
-  const modules = []
+  const sources = []
   for (const manifest of CompilerStdlib.manifest) {
     // Inventory the working source, even when the compiler's generated source map has not yet been
     // rebuilt. This keeps the rollout ledger honest while authors work module by module.
@@ -88,12 +90,18 @@ const program = Effect.gen(function* () {
         Uint8Array.from(readFileSync(new URL(`../stdlib/${manifest.path}`, import.meta.url))),
       catch: (cause) => new Error(`Missing stdlib source: ${manifest.module}`, { cause }),
     })
-    const snapshot = yield* Analysis.ofSource(manifest.module, bytes)
-    const project = DocumentationProject.make(snapshot)
-    const documented = project.modules.find((module) => module.name === manifest.module)
+    sources.push({ manifest, bytes, root: SourceFile.make(manifest.module, bytes) })
+  }
+  const analysis = yield* ProjectAnalysis.make(sources.map((entry) => entry.root)).pipe(
+    Effect.provide(SourceResolver.empty),
+  )
+  const project = DocumentationProject.fromProjectAnalysis(analysis)
+  const modules = []
+  for (const source of sources) {
+    const documented = project.modules.find((module) => module.name === source.manifest.module)
     if (documented === undefined)
-      return yield* Effect.fail(`Missing documentation model: ${manifest.module}`)
-    modules.push({ manifest, documented, bytes })
+      return yield* Effect.fail(`Missing documentation model: ${source.manifest.module}`)
+    modules.push({ manifest: source.manifest, documented, bytes: source.bytes })
   }
   yield* Effect.try({
     try: () => {

--- a/packages/doctest/src/Stdlib.ts
+++ b/packages/doctest/src/Stdlib.ts
@@ -1,4 +1,6 @@
-import * as Analysis from '@silk-effect/compiler/Analysis'
+import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
+import * as SourceFile from '@silk-effect/compiler/SourceFile'
+import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
 import * as CompilerStdlib from '@silk-effect/compiler/Stdlib'
 import * as DocumentationProject from '@silk-effect/documentation/Project'
 import * as Effect from 'effect/Effect'
@@ -7,11 +9,9 @@ import type * as Sources from './Sources.js'
 /**
  * Documentation for the compiler-shipped standard library, and the source lookup that goes with it.
  *
- * `silk doc` documents a project rooted at one module, and the standard library is not a project —
- * it is 38 modules the compiler carries, with no root that reaches all of them. So the value is
- * built the same way the generated standard-library page is built: one analysis per manifest entry,
- * each contributing its own documented module. Coverage follows the manifest, so a module added to
- * the library is doctested without anything here being edited.
+ * Every manifest entry is a project root, so the compiler can analyze their union once while still
+ * covering modules that are not reachable from one distinguished root. Coverage follows the
+ * manifest, so a module added to the library is doctested without anything here being edited.
  */
 
 /** Answers with the compiler-shipped bytes of a standard-library module. */
@@ -28,18 +28,14 @@ export const documentation = Effect.fn('Stdlib.documentation')(function* (): Eff
   never,
   never
 > {
-  const modules: Array<DocumentationProject.Module> = []
+  const roots: Array<SourceFile.SourceFile> = []
   for (const entry of CompilerStdlib.manifest) {
     const bytes = CompilerStdlib.sources.get(entry.module)
-    if (bytes === undefined) continue
-    const snapshot = yield* Analysis.ofSource(entry.module, bytes)
-    const project = DocumentationProject.make(snapshot, { includePrivate: true })
-    const documented = project.modules.find((module) => module.name === entry.module)
-    if (documented !== undefined) modules.push(documented)
+    if (bytes === undefined)
+      return yield* Effect.die(`Missing compiler-shipped stdlib source: ${entry.module}`)
+    roots.push(SourceFile.make(entry.module, bytes))
   }
-  return Object.freeze({
-    schema: 'silk-documentation',
-    experimental: true,
-    modules: Object.freeze(modules),
-  })
+  if (roots.length === 0) return yield* Effect.die('The stdlib manifest is empty')
+  const analysis = yield* ProjectAnalysis.make(roots).pipe(Effect.provide(SourceResolver.empty))
+  return DocumentationProject.fromProjectAnalysis(analysis, { includePrivate: true })
 })

--- a/packages/doctest/test/support/stdlibDocumentation.ts
+++ b/packages/doctest/test/support/stdlibDocumentation.ts
@@ -5,9 +5,8 @@ import * as Stdlib from '../../src/Stdlib.js'
 /**
  * The standard library's documentation, built once for the whole test file.
  *
- * Building it analyzes every module of the shipped manifest and its import closure, which costs
- * around a minute. Three tests need the same value, and rebuilding it per test spent that minute
- * three times over — enough to blow a test timeout on a loaded runner while proving nothing.
+ * Three tests need the same immutable value, so they share one project analysis rather than proving
+ * the same input-to-documentation relationship repeatedly.
  *
  * The memo lives here rather than in `Stdlib.documentation` itself: a module-level cache in the
  * shipped workflow would hand a long-running process a stale answer after the sources changed

--- a/packages/documentation-site/test/support/stdlibDocumentation.ts
+++ b/packages/documentation-site/test/support/stdlibDocumentation.ts
@@ -1,4 +1,6 @@
-import * as Analysis from '@silk-effect/compiler/Analysis'
+import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
+import * as SourceFile from '@silk-effect/compiler/SourceFile'
+import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
 import * as CompilerStdlib from '@silk-effect/compiler/Stdlib'
 import * as Json from '@silk-effect/documentation/Json'
 import * as DocumentationProject from '@silk-effect/documentation/Project'
@@ -17,31 +19,23 @@ const build = Effect.fn('stdlibDocumentation.build')(function* (): Effect.fn.Ret
   never,
   never
 > {
-  const modules: Array<DocumentationProject.Module> = []
+  const roots: Array<SourceFile.SourceFile> = []
   for (const entry of CompilerStdlib.manifest) {
     const bytes = CompilerStdlib.sources.get(entry.module)
-    if (bytes === undefined) continue
-    const snapshot = yield* Analysis.ofSource(entry.module, bytes)
-    const documented = DocumentationProject.make(snapshot, { includePrivate: false }).modules.find(
-      (module) => module.name === entry.module,
-    )
-    if (documented !== undefined) modules.push(documented)
+    if (bytes === undefined)
+      return yield* Effect.die(`Missing compiler-shipped stdlib source: ${entry.module}`)
+    roots.push(SourceFile.make(entry.module, bytes))
   }
-  return Json.encode(
-    Object.freeze({
-      schema: 'silk-documentation',
-      experimental: true,
-      modules: Object.freeze(modules),
-    }),
-  )
+  if (roots.length === 0) return yield* Effect.die('The stdlib manifest is empty')
+  const analysis = yield* ProjectAnalysis.make(roots).pipe(Effect.provide(SourceResolver.empty))
+  return Json.encode(DocumentationProject.fromProjectAnalysis(analysis, { includePrivate: false }))
 })
 
 /**
  * The same text for every test in the file, built once.
  *
- * Building it analyzes every module of the shipped manifest and its import closure, which costs
- * around a minute; three tests need the same bytes, and rebuilding per test spent that minute three
- * times over — enough to blow a test timeout on a loaded runner while proving nothing new.
+ * Three tests need the same immutable bytes, so they share one project analysis rather than proving
+ * the same input-to-documentation relationship repeatedly.
  */
 let pending: Promise<string> | undefined
 

--- a/packages/documentation/src/Project.ts
+++ b/packages/documentation/src/Project.ts
@@ -1,6 +1,7 @@
 import * as Analysis from '@silk-effect/compiler/Analysis'
 import type * as DeclarationFacts from '@silk-effect/compiler/DeclarationFacts'
 import * as Presentation from '@silk-effect/compiler/Presentation'
+import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
 import type * as SourceFile from '@silk-effect/compiler/SourceFile'
 import type * as SyntaxTree from '@silk-effect/compiler/SyntaxTree'
 import * as Document from './Document.js'
@@ -373,3 +374,16 @@ export const make = (snapshot: Analysis.FrontendSnapshot, options: Options = {})
       }),
     ),
   })
+
+/** Builds documentation from one multi-root compiler project without repeating shared analysis. */
+export const fromProjectAnalysis = (
+  self: ProjectAnalysis.ProjectAnalysis,
+  options: Options = {},
+): Project => {
+  const root = self.roots.at(0)
+  if (root === undefined) throw new RangeError('Documentation requires at least one project root')
+  const snapshot = ProjectAnalysis.view(self, root)
+  if (snapshot === undefined)
+    throw new RangeError(`Documentation could not find project root ${root}`)
+  return make(snapshot, options)
+}

--- a/packages/documentation/test/Project.test.ts
+++ b/packages/documentation/test/Project.test.ts
@@ -1,5 +1,8 @@
 import { assert, it } from '@effect/vitest'
 import * as Analysis from '@silk-effect/compiler/Analysis'
+import * as ProjectAnalysis from '@silk-effect/compiler/ProjectAnalysis'
+import * as SourceFile from '@silk-effect/compiler/SourceFile'
+import * as SourceResolver from '@silk-effect/compiler/SourceResolver'
 import * as Effect from 'effect/Effect'
 import * as Json from '../src/Json.js'
 import * as Project from '../src/Project.js'
@@ -69,5 +72,68 @@ pub struct Problem {
     assert.strictEqual(json, Json.encode(publicProject))
     assert.match(json, /"schema": "silk-documentation"/)
     assert.isTrue(json.endsWith('\n'))
+  }),
+)
+
+it.effect('builds one documentation model from a shared multi-root analysis', () =>
+  Effect.gen(function* () {
+    const roots = [
+      SourceFile.make(
+        'app/A',
+        encode(`import shared.Core
+
+/// Public A.
+pub fn a() -> i32 { return Core.answer() }
+
+/// Private A helper.
+fn helper() -> i32 { return 0 }
+`),
+      ),
+      SourceFile.make(
+        'app/B',
+        encode(`import shared.Core
+
+/// Public B.
+pub fn b() -> i32 { return Core.answer() }
+`),
+      ),
+    ]
+    const analysis = yield* ProjectAnalysis.make(roots).pipe(
+      Effect.provide(
+        SourceResolver.memory(
+          new Map([
+            [
+              'shared/Core',
+              encode(`/// Shared answer.
+pub fn answer() -> i32 { return 42 }
+`),
+            ],
+          ]),
+        ),
+      ),
+    )
+
+    const publicProject = Project.fromProjectAnalysis(analysis)
+    assert.deepStrictEqual(
+      publicProject.modules.map((module) => module.name),
+      ['app/A', 'app/B', 'shared/Core'],
+    )
+    assert.strictEqual(new Set(publicProject.modules.map((module) => module.name)).size, 3)
+    assert.isFalse(
+      publicProject.modules
+        .find((module) => module.name === 'app/A')
+        ?.items.some((item) => item.name === 'helper') ?? true,
+    )
+
+    const privateProject = Project.fromProjectAnalysis(analysis, { includePrivate: true })
+    assert.isTrue(
+      privateProject.modules
+        .find((module) => module.name === 'app/A')
+        ?.items.some((item) => item.name === 'helper') ?? false,
+    )
+    const closure = ProjectAnalysis.phases(analysis).find((phase) => phase.phase === 'closure')
+    assert.strictEqual(closure?.inputs, 2)
+    assert.strictEqual(closure?.outputs, 3)
+    assert.strictEqual(closure?.diagnostics, 0)
   }),
 )


### PR DESCRIPTION
## Summary

- build standard-library documentation from one multi-root `ProjectAnalysis`
- migrate doctest, documentation-site, policy, generation, and inventory consumers
- add a structural regression test proving shared modules are analyzed once while preserving private filtering
- fail fast when the shipped manifest and embedded source map disagree

## Performance

| Gate | Before | After |
| --- | ---: | ---: |
| documentation policy | 19.68s | 2.43s |
| documentation check | 19.91s | 2.37s |
| documentation examples | 39.74s | 22.30s |

This removes approximately 52 seconds from the compiler package test command. Policy still checks all 45 modules and all 54 doctests pass.

## Verification

- `pnpm typecheck`
- `pnpm test` — 28/28 package tasks passed
- `pnpm release:candidate` — 9/9 tests passed
- Biome passes on every file in this PR
- compiler documentation policy, check, examples, and inventory all pass

The aggregate `pnpm check` was also attempted locally, but its initial Biome step stopped on trailing whitespace in an unrelated uncommitted `BootstrapEvaluation.ts` edit that is not included in this PR.