### PR TITLE
docs: refresh Silk language reference

### DIFF
--- a/docs/language/README.md
+++ b/docs/language/README.md
@@ -89,18 +89,20 @@ not belong in a language rule unless a program can observe them.
   affine strong handles, callback-scoped access, conflict traps, exact last-handle cleanup, and the
   explicit cycle and thread-transfer boundaries.
 - [Functions, callables, and control flow](functions-callables-and-control-flow.md) — named function
-  contracts, ordered calls, returns, callable sections, pipelines, conditionals, loops, and matches.
+  contracts, Effect-block terminal inference, ordered calls, returns, callable sections, pipelines,
+  conditionals, loops, and matches.
 - [Patterns and destructuring](patterns-and-destructuring.md) — one pattern language across exact
-  union-member matches, irrefutable local destructuring, and conditional `if let`.
+  union-member matches, scalar enum member matches, irrefutable local destructuring, and
+  conditional `if let`.
 - [Values and types](values-and-types.md) — foundational scalars, literals, nominal structs, fixed
-  arrays, lexical views, structural unions, precise inference, and compatibility.
+  arrays, lexical views, structural unions, scalar enums, precise inference, and compatibility.
 - [Expressions and operators](expressions-and-operators.md) — deterministic evaluation, expression
-  composition, scalar and explicitly declared custom operators, short-circuiting, assignment,
-  atomic replacement, and explicit conversion.
+  composition, scalar and explicitly declared custom operators, scalar enum equality,
+  short-circuiting, assignment, atomic replacement, and explicit conversion.
 - [Modules, names, and visibility](modules-names-and-visibility.md) — path-derived module identity,
   source-root lookup, contextual import-path segments, static imports, cycles, namespace bindings,
-  aliases, collisions, public declaration boundaries, redundancy, explicit standard-library
-  imports, and re-export boundaries.
+  aliases, collisions, file-named struct and contract scopes, public declaration boundaries,
+  redundancy, explicit standard-library imports, and re-export boundaries.
 - [Generics, interfaces, and specialization](generics-interfaces-and-specialization.md) — generic
   parameters and inference, compile-time interface contracts, conformances, coherence, and finite
   static specialization, including exact and opaque callable and Effect representations.

--- a/docs/language/documentation-style-guide.md
+++ b/docs/language/documentation-style-guide.md
@@ -46,7 +46,7 @@ content, and each example heading. Declaration comments use this form:
 /// Explain a choice only when the code cannot show it.
 ///
 /// ```silk
-/// import silk.option as Option
+/// import silk.option { Option }
 ///
 /// pub fn main() -> i32 {
 ///   let value = Option.some<i32>(2)
@@ -365,18 +365,20 @@ each line after the example.
 Order multiple examples from the most common case to the most specialized case. Give each example
 a different title.
 
-### Namespace imports
+### Actor imports
 
-Use a namespace import in standard-library code and examples. Call an operation through its
-actor or module name. This form keeps the operation name contextual and follows
-[STYLE-003](style-guide.md#style-003--examples-prefer-namespace-imports-and-qualified-operations).
+When a standard-library module contains a struct, service, or interface matching its filename,
+import that actor directly in documentation examples. The imported actor makes the module's public
+operations available through its qualifier, so calls remain qualified and contextual. Service and
+interface contract operations still take precedence over same-named module members. This follows
+[STYLE-003](style-guide.md#style-003--examples-prefer-actor-imports-and-qualified-operations).
 
 Preferred:
 
 ```silk
 import silk.usize as usize
 
-import silk.vector as Vector
+import silk.vector { Vector }
 
 pub fn main() -> i32 {
   let values = Vector.make<i32>()
@@ -386,11 +388,12 @@ pub fn main() -> i32 {
 }
 ```
 
-Do not destructure a module when that form removes useful context. For example, avoid importing
-`make`, `append`, `get`, and `length` as unqualified names from `silk.vector`.
+Use a namespace import when a module has no matching struct, service, or interface. A matching
+scalar enum does not expose the module's top-level operations. Do not import actor operations such
+as `make`, `append`, `get`, and `length` as unqualified names when that removes useful context.
 
-`Vector.length` gives context that `length` does not give. This rule is mandatory in the standard
-library and official examples.
+`Vector.length` gives context that `length` does not give. This rule is mandatory in official
+documentation examples.
 
 ### Pipe operator
 
@@ -483,7 +486,7 @@ This comment documents `Vector.length`. The signature gives the remaining inform
 /// ## Use a present and an absent value
 ///
 /// ```silk
-/// import silk.option as Option
+/// import silk.option { Option }
 ///
 /// pub fn main() -> i32 {
 ///   let present = Option.some<i32>(7)
@@ -500,8 +503,8 @@ This comment documents `Vector.length`. The signature gives the remaining inform
 /// ```
 ````
 
-This comment documents `Option.unwrapOr`. The example uses a namespace import and an owned value
-pipeline.
+This comment documents `Option.unwrapOr`. The example imports the matching `Option` actor and uses
+an owned value pipeline.
 
 ### Gotchas state a trap condition
 
@@ -528,11 +531,11 @@ pipeline.
 /// ```silk
 /// import silk.allocator { Allocator }
 ///
-/// import silk.effect as Effect
+/// import silk.effect { Effect }
 ///
 /// import silk.usize as usize
 ///
-/// import silk.vector as Vector
+/// import silk.vector { Vector }
 ///
 /// pub effect fn main() -> ()
 /// ! Allocator.OutOfMemoryError {

--- a/docs/language/effect-contracts.md
+++ b/docs/language/effect-contracts.md
@@ -178,7 +178,7 @@ been written explicitly. Omitting `-> ()` is valid, including on `pub effect fn 
 produce a missing-entry or unresolved-result diagnostic.
 
 **Evidence:** [function grammar](../../packages/compiler/src/Parser.ts),
-[declaration default](../../packages/compiler/src/DeclarationIndex.ts).
+[declaration default](../../packages/compiler/src/DeclarationCollection.ts).
 
 ## EFF-011 — Omitted channels have fixed empty meanings
 
@@ -191,6 +191,12 @@ accepting that edit changes the source signature explicitly.
 
 This does not prevent an `effect {}` expression from deriving a contract locally from its body and
 its immediate expected type.
+
+Local derivation examines every reachable `return` and `fail`, including terminals nested inside
+`unsafe {}`. Return types use the canonical result join rather than lexical last-return-wins, and a
+value-kind type parameter used by `fail` remains in the derived failure channel until concrete
+specialization. `unsafe` changes which operations source may perform; it does not hide an Effect
+terminal or erase one of its channels.
 
 **Boundary:** A body that needs a channel omitted by its declaration is invalid under EFF-009. A
 caller or later use cannot supply the missing channel through expected-type inference.
@@ -206,7 +212,9 @@ function has one locally readable contract. Tooling may propose an explicit cont
 language does not silently infer one.
 
 **Evidence:** [function grammar](../../packages/compiler/src/Parser.ts),
-[declaration defaults](../../packages/compiler/src/DeclarationIndex.ts).
+[declaration defaults](../../packages/compiler/src/DeclarationCollection.ts),
+[effect-block contract collection](../../packages/compiler/src/ExpressionAnalysis.ts),
+[effect-block typing regressions](../../packages/compiler/test/EffectBlockTyping.test.ts).
 
 ## EFF-012 — Ordinary failure types and generic requirement rows preserve a contract
 
@@ -251,11 +259,14 @@ typed-failure validity diagnostic. Supplying an argument of the wrong kind for `
 `SEM0088`. A requirement row that cannot be specialized to one finite, unambiguous contract reports
 `SEM0089` at the call and explains the missing, conflicting, or ambiguous row evidence.
 
-**Current compiler:** Aligned. Generic failure parameters are ordinary parameters such as `E` and
-may be used in every ordinary type position. Generic requirement parameters remain the distinct
-`?R` kind.
+**Current compiler:** Aligned. Generic failure parameters are ordinary value-kind parameters such
+as `E` and may be used in every ordinary type position. A `fail` inside an inferred effect block
+retains symbolic `E` in that block's failure channel; specialization substitutes the concrete
+failure and the enclosing `run` must then propagate or handle it. Generic requirement parameters
+remain the distinct `?R` kind.
 
 **Evidence:** [row-preserving ownership tests](../../packages/compiler/test/Ownership.test.ts),
+[generic effect-block failure regression](../../packages/compiler/test/EffectBlockTyping.test.ts),
 [contract-row inference diagnostics](../../packages/compiler/src/Diagnostic.ts).
 
 ## EFF-013 — Compatible Effects may join across construction sites
@@ -298,6 +309,12 @@ This rule covers finite statically known alternatives. It does not by itself int
 heterogeneous Effect collections, unknown runtime implementations, universal boxing, or infinitely
 recursive inline representations. Those require a separate explicit erasure, indirection, or
 storage design.
+
+This construction-site join is distinct from the success-type join used while deriving an
+`effect {}` contract. Return sites first establish one observable success type through the
+canonical result join; only then can Effect values with that contract join across hidden
+construction identities. A non-representable return-type join reports `SEM0163`, while an
+incompatible finite Effect-representation join reports `SEM0132`.
 
 **Diagnostics:** Compatible construction sites produce no diagnostic. An incompatible join must
 identify the observable contract, access, ownership, or lifetime difference at the branch that

--- a/docs/language/effect-suspension.md
+++ b/docs/language/effect-suspension.md
@@ -10,6 +10,8 @@ or introduce a scheduler. It also does not make ordinary recursion stack safe au
 Explicit owner-controlled parking and later resumption are defined separately by
 [independently resumable Effect executions](independent-execution.md). Allocation-backed dynamic
 local state shared by those owners is defined by [local shared ownership](local-shared-ownership.md).
+The current source-level scheduler and Fiber policy built over that substrate is defined by
+[single-threaded schedulers and Fibers](single-threaded-fibers.md).
 
 The intended public contract is:
 
@@ -103,8 +105,9 @@ Signaling or dropping the cancelled Wake releases the final package authority an
 readiness.
 
 Schedulers, deferred values, timers, coroutine ports, ready queues, and cancellation policies are
-ordinary source actors built over this narrow seam. The language does not select one of these
-actors, and the compiler does not recognize their source names.
+ordinary source actors built over this narrow seam. The shipped `silk.scheduler`, `silk.fiber`, and
+`silk.local_scheduler` modules follow this rule: the language does not select those actors, and the
+compiler does not recognize their source names.
 
 ## Public contract and recursion
 
@@ -245,8 +248,10 @@ Exhausting the finite compiler-owned execution stack terminates with a fatal tra
 failure channel, like exhausting the ordinary machine stack.
 
 **Boundary:** `Effect.catch`, `catchAll`, `result`, or another typed-failure combinator cannot recover
-execution-stack exhaustion. A future explicit task or fiber constructor may define configurable or
-fallible storage without changing `Effect.suspend`.
+execution-stack exhaustion. `Execution.make` and the source-level Fiber scheduler have their own
+declared allocation and publication failures while constructing owned execution packages, but
+later growth of the compiler-private execution stack remains fatal and does not change
+`Effect.suspend`.
 
 **Diagnostics:** No failure member or requirement is inferred. A reached exhaustion reports a fatal
 runtime trap according to the program-termination rules.
@@ -388,8 +393,9 @@ If this implementation satisfies the ordinary `Allocator` contract, its use of s
 extra conformance rule.
 
 **Boundary:** An allocator operation may independently be recursive or effectful and follows its
-own declared contract. A later task or fiber feature with fallible storage must define that storage
-contract separately.
+own declared contract. `Execution.make` and Fiber task preparation define their fallible allocation
+contracts separately; those failures belong to owned execution construction, not to
+`Effect.suspend`.
 
 **Diagnostics:** No allocator-specific conformance or recursion diagnostic applies merely because
 an allocator is reachable from suspendable code.
@@ -505,14 +511,19 @@ let value = run Effect.suspend(readNext())
 This transfers stack-safe execution of `readNext`; it does not wait for another task to publish a
 value unless `readNext` already has some separately defined synchronous way to complete.
 
-**Boundary:** Runtime parking, streams, queues, tasks, fibers, executors, and async I/O require a
-separate language direction covering registration, wakeup, ownership, cancellation, and cleanup.
+**Boundary:** Runtime parking and owner-controlled resumption use the separate `Execution` and
+`Wake` lifecycle. The shipped single-threaded scheduler and Fiber APIs add ready queues, child
+tasks, observation, and structured cancellation as ordinary source policy over that lifecycle.
+Those facilities still do not turn suspension into parking or establish a general async-I/O model.
 
 **Diagnostics:** Suspension alone adds no Scheduler, Executor, or concurrency service requirement.
-Using a future unavailable async construct receives that construct's own diagnostic rather than
-changing `Effect.suspend`.
+An unowned park-capable executable, an invalid Execution lifecycle transition, or an unresolved
+Scheduler requirement receives that facility's own diagnostic or trap rather than changing
+`Effect.suspend`.
 
 **Evidence:** [no ambient runtime facilities](runtime-and-standard-library.md#runtime-004--silk-has-no-ambient-runtime-facilities),
+[independent execution lifecycle](independent-execution.md),
+[single-threaded scheduler and Fiber policy](single-threaded-fibers.md),
 [suspension implementation scope](../../openspec/changes/archive/2026-08-19-align-effect-suspension-coroutine-storage/proposal.md).
 
 ## Private lowering model
@@ -523,11 +534,18 @@ These are compiler architecture rules, not additional source obligations:
   that invocation changes its resume state; it does not allocate another continuation record.
 - Every resume state names only the values needed after that transfer. One statically known maximum
   layout covers all mutually exclusive states, including compiler-generated temporaries.
+- A suspendable specialization's frame identity includes its complete specialization key,
+  including the normalized provider contract row. Two otherwise identical specializations that
+  bind different provider rows cannot share or select each other's frame layout.
 - The parent completes its ownership and state transition before the deferred child begins. A live
   value therefore has one owner throughout transfer, execution, resumption, and cleanup.
 - Evaluation keeps frames in its activation machine. Native uses non-moving segmented private
   storage. Direct Wasm uses a private, non-overlapping linear-memory region. Growth failure follows
   SUSP-006 on all three engines.
+
+The complete-key frame invariant is exercised by the
+[coroutine-frame lookup](../../packages/compiler/src/CoroutineFrame.ts) and the
+[contract-row suspension parity corpus](../../packages/compiler/test/support/corpus.ts).
 
 The complete architecture contract remains in the archived
 [suspension implementation design](../../openspec/changes/archive/2026-08-19-align-effect-suspension-coroutine-storage/design.md).

--- a/docs/language/effects-and-execution.md
+++ b/docs/language/effects-and-execution.md
@@ -92,8 +92,22 @@ fn deferred() -> Effect<i32> { return inner() }
 fn executed() -> i32 { return run inner() }
 ```
 
-**Evidence:** [effect elaboration](../../packages/compiler/src/Elaboration.ts),
+**Local inference:** An explicit `effect {}` block derives its success and failure channels from
+every reachable `return` and `fail`, including terminals nested inside `unsafe {}`. Every available
+return type participates in the language's canonical result join. Equal types remain equal,
+joinable distinct types form their normalized union, and a set with no representable join is
+invalid; lexical order never lets the last return silently choose the block's success type.
+
+**Diagnostics:** A joinable block whose return sites produce, for example, `bool` and `i32` has
+success type `bool | i32`; a surrounding `Effect<i32>` context rejects that union with the ordinary
+conversion diagnostic such as `SEM0040`. When the return sites themselves have no representable
+join, `SEM0163` is reported at the first disagreeing return. A terminal inside `unsafe {}` keeps the
+same success or failure contribution it would have outside `unsafe`.
+
+**Evidence:** [statement return analysis](../../packages/compiler/src/StatementAnalysis.ts),
+[effect-block analysis](../../packages/compiler/src/ExpressionAnalysis.ts),
 [return-contract regressions](../../packages/compiler/test/InterfaceBounds.test.ts),
+[effect-block terminal regressions](../../packages/compiler/test/EffectBlockTyping.test.ts),
 [MIR return verification](../../packages/compiler/src/Mir.ts).
 
 ## EFF-003 — `run` executes exactly one Effect layer
@@ -193,7 +207,12 @@ Values retained by the deferred block follow the ordinary
 **Diagnostics:** This evaluation order is valid behavior, not a source restriction, so it has no
 diagnostic. Invalid captures receive the corresponding capture, borrow, move, or escape diagnostic.
 
-**Evidence:** [effect-block elaboration](../../packages/compiler/src/Elaboration.ts),
+Capture discovery visits every expression operand in the deferred body. In particular, a binding
+used only as the argument of `Enum.value(binding)` is still captured; enum conversion does not hide
+the dependency from the Effect environment.
+
+**Evidence:** [effect-block capture analysis](../../packages/compiler/src/ExpressionAnalysis.ts),
+[effect-block capture parity corpus](../../packages/compiler/test/support/corpus.ts),
 [effect-block lowering](../../packages/compiler/src/Lower.ts).
 
 ## EFF-006 — An ordinary function may run only a closed Effect
@@ -210,7 +229,7 @@ handler can fail, or a provision operation whose acquisition has requirements, d
 boundary unless those new channels are also eliminated.
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 struct ProblemError {}
 
@@ -284,7 +303,13 @@ language-level Effect model is defined in focused pages:
 | Captures, run access, reuse, and cleanup | [Ownership and borrowing](ownership-and-borrowing.md) |
 | Typed propagation, recovery, and traps | [Typed failures](typed-failures.md) |
 | Stack-safe recursive transfer | [Effect suspension and stack-safe recursion](effect-suspension.md) |
-| Cancellation, interruption, concurrency, and async cleanup | Not part of the stabilized language |
+| Owner-controlled parking and resumption | [Independently resumable Effect executions](independent-execution.md) |
+| Single-threaded scheduling, Fibers, and structured cancellation | [Single-threaded schedulers and Fibers](single-threaded-fibers.md) |
+
+These execution facilities are explicit source-level layers. They do not make ordinary Effect
+construction concurrent, add an ambient scheduler, or turn `Effect.suspend` into a parking
+operation. Parallel execution, ambient interruption, and a general async-I/O model remain outside
+the stabilized language.
 
 The standard-library operations built from these rules—including `of`, `result`, `mapBoth`, `map`,
 `mapError`, `flatMap`, `flatten`, `zip`, `zip3`, `tap`, `catch`, `catchAll`, `ensuring`,

--- a/docs/language/expressions-and-operators.md
+++ b/docs/language/expressions-and-operators.md
@@ -444,6 +444,10 @@ Effect failure channel. When overflow or invalid division is recoverable applica
 named `checked*` operation returning `Option<T>`. When modular or clamped arithmetic is intended,
 use the corresponding named `wrapping*` or `saturating*` operation where supplied.
 
+For every signed width, `checkedRemainder(MIN, -1)` returns `None` on every executor exactly where
+ordinary `%` traps. It never reaches a backend remainder instruction whose behavior differs at that
+boundary.
+
 Bitwise operators do not perform arithmetic overflow, and explicit wrapping or saturating
 functions do not inherit the ordinary operator's trap policy.
 
@@ -470,6 +474,12 @@ traps. Ordinary ordered comparisons involving NaN return `false`; `NaN == NaN` i
 `NaN != NaN` is `true`. Positive and negative zero compare equal, though representation operations
 can distinguish them.
 
+Floating `%` uses exact IEEE `fmod` semantics: for operands `x` and `y`, the mathematical result is
+`x - n*y`, where `n` is `x/y` truncated toward zero, without exposing an intermediate rounding or
+overflow. The result has the dividend's sign, including negative zero. A finite dividend modulo an
+infinite divisor returns the dividend; an infinite dividend, zero divisor, or NaN operand produces
+NaN. Evaluator, native, and WebAssembly execution produce identical finite result bits.
+
 ```silk
 fn unordered(value: f64) -> bool {
   let nan = value / 0.0
@@ -488,7 +498,8 @@ rounded finite results are values, not diagnostics or traps.
 
 **Evidence:** [floating scalar specification](../../openspec/specs/bootstrap-floating-point-scalars/spec.md),
 [floating actor modules](../../packages/compiler/stdlib/silk/f32.silk),
-[floating-point tests](../../packages/compiler/test/FloatingPointScalars.test.ts).
+[floating-point tests](../../packages/compiler/test/FloatingPointScalars.test.ts),
+[cross-engine arithmetic corpus](../../packages/compiler/test/support/corpus.ts).
 
 ### OP-006 — Concrete comparison availability is explicit and narrow
 
@@ -503,6 +514,7 @@ The concrete comparison operators are available as follows:
 | `f32` or `f64` of identical width | Yes | Yes | Ordinary IEEE comparison |
 | `char` | Yes | Yes | Unicode scalar-value order |
 | `string` | Yes | No | Exact UTF-8 sequence equality |
+| One identical scalar enum type | Yes | No | Declared member identity |
 
 Every comparison returns `bool` and evaluates both operands left to right exactly once.
 
@@ -520,9 +532,10 @@ Character ordering is not locale collation, normalization, or grapheme ordering.
 does not normalize, case-fold, or allocate.
 
 **Boundary:** Structs, arrays, unions, references, slices, callable values, Effect values, and
-services do not receive implicit structural or identity equality. Boolean and string ordering are
-also unavailable. A future user-defined equality or ordering contract must be declared explicitly;
-it cannot be inferred from representation.
+services do not receive implicit structural or identity equality. Boolean, string, and scalar enum
+ordering are also unavailable. Enum equality additionally requires one canonical enum type under
+OP-011. A future user-defined equality or ordering contract must be declared explicitly; it cannot
+be inferred from representation.
 
 **Diagnostics:** An unavailable comparison reports `SEM0012` at the incompatible operand under the
 current operator diagnostic model.
@@ -579,7 +592,9 @@ The literal `15` is contextually selected as `u8`, and the result contains only 
 
 **Boundary:** Booleans, characters, floating-point values, and other values do not admit integer
 bitwise operators. Silk currently has no `<<` or `>>` surface operator; shifts and rotates are named
-integer functions whose invalid-count behavior is defined by those APIs.
+integer functions. `rotateLeft` and `rotateRight` reduce every count by unsigned Euclidean modulo
+the value's lane width, so an out-of-range count wraps and a signed count of `-1` is equivalent to
+width minus one. Every executor applies the same reduction.
 
 Prefix `&value` is borrow syntax, while infix `left & right` is bitwise AND. Their grammatical
 positions distinguish them without runtime inspection.
@@ -746,6 +761,43 @@ diagnostic exists.
 [Effect execution boundaries](effects-and-execution.md#eff-006--an-ordinary-function-may-run-only-a-closed-effect),
 [short-circuit elaboration](../../packages/compiler/src/Elaboration.ts),
 [conditional mutation and evaluation tests](../../packages/compiler/test/ShortCircuitOperatorAcceptance.test.ts).
+
+### OP-011 — Scalar enum equality is nominal and ordering requires representation access
+
+**Status:** Confirmed
+
+`==` and `!=` accept scalar enum operands only when both have the same canonical enum type. They
+compare declared member identity and return `bool`; the enum's backing integer is not an implicit
+operand.
+
+```silk
+enum Status { Pending, Ready }
+
+fn isReady(status: Status) -> bool {
+  return status == Status.Ready
+}
+```
+
+`<`, `<=`, `>`, and `>=` do not order enum members. A program that deliberately wants discriminant
+order first exposes both integers with `Enum.value`:
+
+```silk
+fn earlier(left: Status, right: Status) -> bool {
+  return Status.value(left) < Status.value(right)
+}
+```
+
+**Boundary:** Two enums with identical member names and discriminants remain incomparable by
+equality because their nominal identities differ. An enum does not compare directly with its
+representation integer, and declaration order alone does not create source-level ordering.
+
+**Diagnostics:** Equality between different enums reports `SEM0156`; equality between an enum and
+an integer reports `SEM0155`; direct enum ordering reports `SEM0157`. The diagnostic points at the
+operator rather than pretending that either operand converted.
+
+**Evidence:** [scalar enum operator rules](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[enum operator tests](../../packages/compiler/test/OperatorContracts.test.ts),
+[enum value access](values-and-types.md#enum-004--enumvalue-exposes-the-backing-integer-in-one-direction).
 
 ## Assignment and replacement
 
@@ -955,6 +1007,11 @@ fn piped(value: i32) -> i64 {
 
 The direct and piped forms perform the same explicit conversion.
 
+Scalar enum representation access follows the same explicit-source principle but is not a general
+cast: `Status.value(status)` exposes one declared member's backing integer, and Silk provides no
+built-in integer-to-enum inverse. See
+[ENUM-004](values-and-types.md#enum-004--enumvalue-exposes-the-backing-integer-in-one-direction).
+
 **Boundary:** Contextual selection of an exact literal is not conversion. `let` inference, an
 operator result context, assignment, return, and argument passing do not silently insert `toI64`,
 change signedness, or cross between integer and floating point.
@@ -968,7 +1025,8 @@ functions use the ordinary actor-operation diagnostic.
 
 **Evidence:** [narrow compatibility](values-and-types.md#type-003--compatibility-is-exact-except-for-closed-named-relations),
 [integer actor modules](../../packages/compiler/stdlib/silk/i32.silk),
-[floating actor modules](../../packages/compiler/stdlib/silk/f64.silk).
+[floating actor modules](../../packages/compiler/stdlib/silk/f64.silk),
+[scalar enum representation access](values-and-types.md#enum-004--enumvalue-exposes-the-backing-integer-in-one-direction).
 
 ### CONV-002 — Integer conversion chooses trapping or checked range handling explicitly
 

--- a/docs/language/functions-callables-and-control-flow.md
+++ b/docs/language/functions-callables-and-control-flow.md
@@ -229,6 +229,46 @@ The contract is semantic: a trailing return is unnecessary when no reachable pat
 [Effect return semantics](effects-and-execution.md#eff-002--an-effect-body-returns-its-success-value),
 [unit fallthrough tests](../../packages/compiler/test/IntegerScalars.test.ts).
 
+### RETURN-002 — An Effect block derives its contract from every reachable terminal
+
+**Status:** Confirmed
+
+The success and failure types of `effect { ... }` come from every reachable `return` and `fail` in
+the deferred block. Equal return types remain that type; distinct joinable ordinary value types form
+their canonical union; `never` contributes no success member. Source order never makes the last
+written terminal override earlier branches.
+
+```silk
+fn later(flag: bool) -> Effect<bool | i32> {
+  return effect {
+    if flag {
+      return true
+    }
+    return 42
+  }
+}
+```
+
+The block has success type `bool | i32`, not `i32`. A `fail` contributes its precise ordinary value
+type to the failure row, including a value-kind generic type parameter. Terminals nested in an
+`unsafe { ... }` statement count exactly like terminals at the block's top level.
+
+**Boundary:** A surrounding expected `Effect` type does not discard a block terminal or coerce its
+value. If the example were returned as `Effect<i32>`, the inferred `Effect<bool | i32>` would be
+incompatible. A pair of return types with no legal finite representation cannot form a block result.
+
+Capture analysis follows the same complete block traversal. A binding used only as the argument of
+`Enum.value` is still captured when the Effect is constructed and read when it runs.
+
+**Diagnostics:** An inferred union incompatible with the surrounding expected Effect reports the
+ordinary union or type mismatch at that boundary. Return types with no legal join report `SEM0163`
+at the offending terminal and identify the contributing types. A failure left unhandled at `run`
+reports `SEM0066`; generic failure values are not dropped from that check.
+
+**Evidence:** [effect-block terminal specification](../../openspec/specs/bootstrap-flow-functions/spec.md),
+[canonical join implementation](../../packages/compiler/src/Match.ts),
+[effect-block typing tests](../../packages/compiler/test/EffectBlockTyping.test.ts).
+
 ## Callable values and pipelines
 
 ### CALLABLE-001 — Naming a function produces a first-class callable value
@@ -267,7 +307,7 @@ reports `SEM0080` or the more specific represented-storage diagnostic.
 
 **Evidence:** [callable specification](../../openspec/specs/bootstrap-callable-values/spec.md),
 [indirect-call tests](../../packages/compiler/test/IndirectCallAcceptance.test.ts),
-[unsafe callable contracts](unsafe-intrinsics-and-targets.md#unsafe-002--source-callable-contracts-carry-an-unsafe-qualifier).
+[unsafe callable contracts](unsafe-intrinsics-and-targets.md#unsafe-002--ordinary-source-may-declare-a-caller-owned-unsafe-contract).
 
 ### CALLABLE-002 — Supplying a trailing argument suffix constructs a section
 
@@ -595,13 +635,20 @@ fn classify(event: Token | End) -> i32 {
 The second `Token` arm remains necessary because the first arm's guard may be false. Every guard
 must have type `bool` and may inspect its provisional pattern bindings without consuming them.
 
+A scalar enum begins with its complete declared member set. An unguarded qualified member pattern
+such as `Status.Ready` covers that exact canonical member; a guarded occurrence does not remove it.
+Enum patterns bind no payload, and `_` covers every remaining member just as it does for a
+structural union.
+
 **Boundary:** A match missing any member is invalid. A duplicate unguarded member, an arm after `_`,
 or another arm made impossible by earlier coverage is unreachable. A guarded arm alone never makes
 a member exhaustive.
 
-**Diagnostics:** An incomplete match reports `SEM0044` and lists the uncovered members. An
-unreachable arm reports `SEM0043`. A non-boolean guard reports `SEM0045`. Consuming a provisional
-guard binding reports `OWN0008` because later arms may still need the unchanged payload.
+**Diagnostics:** An incomplete structural-union match reports `SEM0044` and lists the uncovered
+members. An unreachable arm reports `SEM0043`. Scalar enums use the more specific coverage codes:
+`SEM0158` for missing members, `SEM0159` for a duplicate unguarded member, and `SEM0160` for an arm
+after `_`. A non-boolean guard reports `SEM0045`. Consuming a provisional guard binding reports
+`OWN0008` because later arms may still need the unchanged payload.
 
 **Evidence:** [exhaustive matching specification](../../openspec/specs/bootstrap-exhaustive-matching/spec.md),
 [coverage tests](../../packages/compiler/test/ExhaustiveMatching.test.ts).
@@ -630,12 +677,17 @@ fn inspect(event: Token | End) -> i32 {
 Within the first arm, `kind` comes from a precise `Token`. Outside the match, `event` remains
 `Token | End`.
 
+A scalar enum member pattern selects one value but introduces no member subtype or backing-integer
+narrowing. The scrutinee and every use of it remain the enum's nominal type inside and outside the
+arm.
+
 **Boundary:** Match narrowing does not introduce general subtyping, mutate a binding's declared
 type, expose a union's numeric runtime tag, or carry a borrowed member binding outside its arm.
 
-**Diagnostics:** A pattern member absent from the scrutinee reports `SEM0042`. Using a member-only
-field without branch proof receives the ordinary field/type diagnostic. Escaping a borrowed narrowed
-binding reports `OWN0006`.
+**Diagnostics:** A structural pattern member absent from the scrutinee reports `SEM0042`. A scalar
+enum pattern from another enum reports `SEM0161`; an integer literal pattern against an enum reports
+`SEM0162`. Using a member-only field without branch proof receives the ordinary field/type
+diagnostic. Escaping a borrowed narrowed binding reports `OWN0006`.
 
 **Evidence:** [exhaustive matching specification](../../openspec/specs/bootstrap-exhaustive-matching/spec.md),
 [matching tests](../../packages/compiler/test/ExhaustiveMatching.test.ts).
@@ -671,10 +723,8 @@ types and the precise unavailable member. An unreachable arm contributes neither
 a second result mismatch. Ownership transfers from result expressions remain governed by their
 arm's access mode.
 
-**Current compiler:** Match joining accepts distinct nominal results only. General unions require
-the join to accept ordinary value types and require an exact type-pattern form for non-nominal
-members. PATT-015–019 define exact whole-value bindings for non-nominal union
-members; nominal patterns keep the rules in MATCH-002 and all forms share the contextual rules in
+PATT-015–019 define exact whole-value bindings for non-nominal union members; nominal patterns keep
+the rules in MATCH-002 and all forms share the contextual rules in
 [patterns and destructuring](patterns-and-destructuring.md).
 
 **Evidence:** [exhaustive matching specification](../../openspec/specs/bootstrap-exhaustive-matching/spec.md),

--- a/docs/language/generics-interfaces-and-specialization.md
+++ b/docs/language/generics-interfaces-and-specialization.md
@@ -140,7 +140,7 @@ concrete.
 
 **Evidence:** [generic application specification](../../openspec/specs/bootstrap-type-generics/spec.md),
 [nominal type identity](values-and-types.md),
-[type elaboration](../../packages/compiler/src/Elaboration.ts).
+[type resolution](../../packages/compiler/src/DeclarationResolution.ts).
 
 ### GEN-003 — A generic call infers only from supplied arguments and declared constraints
 
@@ -192,7 +192,7 @@ and stable rule use an ordered prefix because provider APIs and ordinary partial
 on it.
 
 **Evidence:** [current inference specification](../../openspec/specs/bootstrap-type-generics/spec.md),
-[call specialization](../../packages/compiler/src/Elaboration.ts),
+[call specialization](../../packages/compiler/src/CallResolution.ts),
 [provider inference](requirements-and-services.md#serv-007--provision-infers-exactly-one-compatible-requirement-key).
 
 ### GEN-004 — A generic body is checked once against its declared contract
@@ -236,6 +236,12 @@ Silk does not use duck typing, inspect a concrete type during body checking, or 
 type checking separately for each specialization. Copy and cleanup remain compiler-verified type
 properties rather than ordinary customizable interfaces.
 
+A value-kind parameter also remains an ordinary symbolic type when used as an Effect failure. If a
+generic body constructs `effect { fail move problem }` for `problem: E`, local contract collection
+retains `E` in the failure channel. A later concrete specialization must preserve that failure at
+every `run`; it cannot disappear merely because the generic body was checked before `E` became
+nominal or concrete.
+
 **Diagnostics:** An operation absent from the generic contract reports an unavailable-operation or
 missing-bound diagnostic at the use and names the parameter involved. A later conforming call does
 not suppress that declaration diagnostic. A declared bound with no visible interface reports an
@@ -243,6 +249,7 @@ unknown-interface diagnostic at the bound.
 
 **Evidence:** [generic body specification](../../openspec/specs/bootstrap-type-generics/spec.md),
 [ownership properties](ownership-and-borrowing.md),
+[generic Effect failure regression](../../packages/compiler/test/EffectBlockTyping.test.ts),
 [interface-bound tests](../../packages/compiler/test/InterfaceBounds.test.ts).
 
 ### GEN-005 — Every reachable generic application becomes finite monomorphic code
@@ -390,7 +397,7 @@ representation parameters after a written prefix, retains every origin, and reje
 conflicting evidence before HIR lowering.
 
 **Evidence:** [representation inference tests](../../packages/compiler/test/RepresentationInference.test.ts),
-[struct literal elaboration](../../packages/compiler/src/Elaboration.ts),
+[struct literal analysis](../../packages/compiler/src/ExpressionAnalysis.ts),
 [generic call inference](#gen-003--a-generic-call-infers-only-from-supplied-arguments-and-declared-constraints).
 
 ## Executable representation parameters
@@ -739,7 +746,7 @@ its written generic parameters contain only additional contract arguments. Bound
 conformances bind the provider without adding a duplicated interface argument.
 
 **Evidence:** [current interface parser](../../packages/compiler/src/Parser.ts),
-[current interface application](../../packages/compiler/src/DeclarationIndex.ts).
+[current interface application](../../packages/compiler/src/DeclarationFacts.ts).
 
 ### INTF-002 — An interface contains compile-time operation contracts, not implementations
 
@@ -844,7 +851,7 @@ application on its right; no provider argument is synthesized into that applicat
 
 **Evidence:** [current interface-bound tests](../../packages/compiler/test/InterfaceBounds.test.ts),
 [conditional conformance specification](../../openspec/specs/bootstrap-conditional-interface-conformance/spec.md),
-[bound elaboration](../../packages/compiler/src/DeclarationIndex.ts).
+[bound declaration facts](../../packages/compiler/src/DeclarationFacts.ts).
 
 ### INTF-004 — `+` joins independent bounds on one parameter
 
@@ -900,8 +907,8 @@ stop at whichever bound happens to be written first.
 **Current compiler:** Aligned. Parsing and declaration facts preserve every normalized conjunct,
 static calls can select operations from each contract, and duplicate conjuncts are diagnosed.
 
-**Evidence:** [single-bound parser](../../packages/compiler/src/Parser.ts),
-[bound facts](../../packages/compiler/src/DeclarationIndex.ts),
+**Evidence:** [bound parser](../../packages/compiler/src/Parser.ts),
+[bound facts](../../packages/compiler/src/DeclarationFacts.ts),
 [static operation selection](#intf-006--a-qualified-interface-call-requires-one-static-application).
 
 ### INTF-005 — Interface operations use their declared ownership and Effect contracts
@@ -1021,7 +1028,8 @@ unknown-interface-member diagnostic and does not fall back to a module function 
 the same `Self` substitution and witness selection. Operator eligibility remains the separate
 explicit-marker rule defined by OP-009.
 
-**Evidence:** [bound operation elaboration](../../packages/compiler/src/Elaboration.ts),
+**Evidence:** [bound operation resolution](../../packages/compiler/src/CallResolution.ts),
+[bound witness lowering](../../packages/compiler/src/WitnessLowering.ts),
 [bound-operation tests](../../packages/compiler/test/BoundOperationWitness.test.ts),
 [explicit operator eligibility](expressions-and-operators.md#op-009--an-interface-operation-may-opt-into-one-existing-operator-explicitly).
 
@@ -1074,7 +1082,7 @@ before operation mappings are checked. An invalid `Self` use retains the context
 operations inline, by mapping, or through both forms in one conformance.
 
 **Evidence:** [current impl parser](../../packages/compiler/src/Parser.ts),
-[current conformance index](../../packages/compiler/src/DeclarationIndex.ts).
+[current conformance facts](../../packages/compiler/src/DeclarationFacts.ts).
 
 ### IMPL-002 — A conformance supplies every interface operation exactly once
 
@@ -1190,7 +1198,7 @@ ordinary type names and never fall through to lowering as invalid MIR.
 result, failure, and requirement contracts for both interfaces and services.
 
 **Evidence:** [complete witness compatibility](../../openspec/specs/bootstrap-complete-interface-contracts/spec.md),
-[witness compatibility implementation](../../packages/compiler/src/DeclarationIndex.ts),
+[witness compatibility implementation](../../packages/compiler/src/DeclarationResolution.ts),
 [interface witness tests](../../packages/compiler/test/InterfaceWitnessCompatibility.test.ts),
 [nested Effect contract](effects-and-execution.md#eff-004--nested-effects-are-ordinary-values).
 
@@ -1513,7 +1521,7 @@ selection.
 | Failure parameters | Generic OpenSpec and compiler use separate `!E` failure-row binders. | Use ordinary type parameter `E`; only `?R` remains a special Effect-channel kind. |
 | Explicit call arguments | Older type-system decision requires all arguments or none; current compiler accepts an ordered prefix. | Keep the current ordered-prefix model for calls and struct literals; the older rule is superseded. |
 | Provider application | `Decoder<Schema> for Schema` repeats the provider while `T: Decoder` hides an application. | Give every interface implicit `Self`; write only additional interface arguments and bind the provider after `for` or to the left of a bound. |
-| Generic operator calls | Current tests and elaboration infer bound operations from names such as `add`. | Use [OP-009](expressions-and-operators.md#op-009--an-interface-operation-may-opt-into-one-existing-operator-explicitly). |
+| Generic operator calls | Current tests and call resolution infer bound operations from names such as `add`. | Use [OP-009](expressions-and-operators.md#op-009--an-interface-operation-may-opt-into-one-existing-operator-explicitly). |
 | Service conformance | A service first passes dependency eligibility, then uses ordinary conformance proof and operation selection. | Keep only dependency eligibility special; do not introduce service-only witness behavior. |
 | Inline implementations | General `impl` parsing accepts mappings; a narrow hook form accepts one inline function. | Implement the already confirmed general inline-or-mapped rule. |
 

--- a/docs/language/local-shared-ownership.md
+++ b/docs/language/local-shared-ownership.md
@@ -14,10 +14,9 @@ This small program creates one shared counter. It updates the value through one 
 value through a second owner.
 
 ```silk
-import silk.allocator { Allocator }
-import silk.allocator { Allocator, OutOfMemoryError, SystemAllocator }
-import silk.effect as Effect
-import silk.shared as Shared
+import silk.allocator { Allocator, OutOfMemoryError }
+import silk.effect { Effect }
+import silk.shared { Shared }
 
 struct Counter { value: i32 }
 fn increment(counter: &mut Counter) -> i32 {

--- a/docs/language/modules-names-and-visibility.md
+++ b/docs/language/modules-names-and-visibility.md
@@ -16,7 +16,10 @@ pages. Package acquisition and version selection are outside the language.
 - A **namespace binding** is a local name that qualifies members of one imported module.
 - A **selected binding** is one imported declaration available directly under a local name.
 - An **alias** is an explicit local name replacing a namespace or selected binding's default name.
-- A **qualified name** begins with a namespace binding, as in `User.make`.
+- A **qualified name** begins with a namespace binding or nominal module-scope binding, as in
+  `User.make`.
+- A **nominal module scope** is a struct, service, or interface name that also qualifies the
+  public declarations of the module whose file basename it matches.
 - A **module scope** is the set of top-level declaration and import names visible throughout one
   module.
 - A **module closure** is the root module and every module reachable through its transitive imports.
@@ -481,6 +484,58 @@ redundancy defined by IMPORT-005.
 **Evidence:** [explicit import aliases](../../openspec/specs/bootstrap-name-resolution/spec.md),
 [namespace alias tests](../../packages/compiler/test/NameResolution.test.ts).
 
+### NAME-005 — A file-named struct or contract also scopes that module's public members
+
+**Status:** Confirmed
+
+A top-level struct, service, or interface doubles as its defining module's qualifier only when its
+declaration name matches the module's final path segment after removing underscores and ignoring
+case. For example, declaration `UserProfile` in module `model/user_profile` is that module's nominal
+scope.
+
+```silk
+// model/user_profile.silk
+pub struct UserProfile {}
+
+pub fn answer() -> i32 {
+  return 42
+}
+```
+
+```silk
+// app/main.silk
+import model.user_profile { UserProfile }
+
+pub fn main() -> i32 {
+  return UserProfile.answer()
+}
+```
+
+`UserProfile.answer` resolves the public function in `model/user_profile`. The same rule applies to
+qualified type paths and follows the canonical declaration through a selected-import alias: an
+alias changes the local qualifier spelling, not whether the declaration names its module.
+
+**Boundary:** A different nominal declaration in the same file does not expose the module's
+functions or types. For example, `Provider.answer()` is unavailable when `Provider` is declared in
+`model/user_profile`; only `UserProfile` matches the basename. The comparison ignores only case and
+underscores, not arbitrary punctuation or path segments.
+
+Scalar enums are deliberately different: their qualifier is reserved for declared members and the
+generated `value` operation, so even a file-named enum does not expose other top-level module
+members. Service and interface operations remain operations of their declaring contract regardless
+of the file name. The filename rule governs their access to other top-level module members. It never
+turns a private member or an imported binding into a public re-export.
+
+**Diagnostics:** An unknown type path through a valid nominal module scope reports `SEM0014`. An
+unknown call through a struct, service, or interface qualifier—including a declaration that does
+not name its module—reports the actor-operation diagnostic `SEM0010` instead of searching that
+declaration's defining module. A private module member remains inaccessible as `SEM0015`.
+
+**Evidence:** [nominal scope selection](../../packages/compiler/src/NameResolution.ts),
+[call resolution](../../packages/compiler/src/CallResolution.ts),
+[expression resolution](../../packages/compiler/src/ExpressionAnalysis.ts),
+[completion coverage](../../packages/compiler/test/EditorIntelligence.test.ts).
+
 ## Visibility
 
 ### VIS-001 — Declarations are private by default and `pub` exposes them
@@ -503,9 +558,10 @@ fn hidden() -> i32 {
 Both functions are available inside their defining module. Another module may import or qualify
 `answer` but not `hidden`.
 
-The same default applies to nominal types, constants, services, interfaces, and other top-level
-declarations that support cross-module access. Struct fields have their own `pub` marker under the
-same private-by-default principle.
+The same default applies to nominal types, scalar enums, constants, services, interfaces, and other
+top-level declarations that support cross-module access. Struct fields have their own `pub` marker
+under the same private-by-default principle. A scalar enum's `pub` marker exposes its type and
+complete member set; individual enum members have no separate visibility marker.
 
 **Boundary:** `pub` grants name accessibility; it does not import the declaration anywhere,
 re-export it from an importing module, execute it, or weaken its type, Effect, ownership, or target
@@ -690,8 +746,7 @@ namespace alias or a selected-member list so the import never creates a binding 
 otherwise reserved.
 
 ```silk
-import silk.effect as Effect
-import silk.effect { suspend }
+import silk.effect { Effect, suspend }
 ```
 
 Reserved segments in any nonfinal position are ordinary parts of the canonical module identity.
@@ -700,8 +755,9 @@ path segments.
 
 **Boundary:** Contextual acceptance is limited to import paths. A reserved word remains invalid as a
 declaration name or explicit alias. `import silk.effect` is invalid because its implicit namespace
-binding would be named `effect`; `import silk.effect as Effect` and selected-member imports are
-valid because they state legal bindings explicitly.
+binding would be named `effect`; selected-member imports such as `import silk.effect { Effect }`
+are valid because they state legal bindings explicitly. A legal explicit namespace alias remains
+valid under IMPORT-002 when a caller specifically needs the module namespace.
 
 **Diagnostics:** A reserved final segment without an alias or selected-member list reports
 `PAR0004` at that segment and explains that the import needs an explicit binding form. The parser
@@ -722,7 +778,7 @@ without imports. Ordinary standard-library actor namespaces are not. A module im
 standard-library API it names.
 
 ```silk
-import silk.option as Option
+import silk.option { Option }
 
 pub fn main() -> i32 {
   let value = Option.some<i32>(42)
@@ -732,17 +788,19 @@ pub fn main() -> i32 {
 ```
 
 The type spelling `i32` needs no import because it is part of the language. `Option.some` needs the
-explicit `silk.option` namespace binding because `Option` is an ordinary standard-library actor.
-The same rule applies to `Effect`, `Vector`, `Result`, filesystem services, target providers, and
-primitive actor operations:
+explicit `Option` actor binding because `Option` is an ordinary standard-library actor. Because
+the actor matches the module filename, that selected declaration also qualifies the module's public
+operations under NAME-005. The same rule applies to `Effect`, `Vector`, `Result`, filesystem
+services, target providers, and primitive actor operations:
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 import silk.i32
 ```
 
-`Effect<A ! E ? R>` remains language type syntax. The namespace binding imported as `Effect` names
-ordinary standard-library functions such as `Effect.provide`.
+`Effect<A ! E ? R>` remains language type syntax. The selected actor binding `Effect` names the
+matching nominal declaration and qualifies ordinary standard-library functions such as
+`Effect.provide`.
 
 **Boundary:** The toolchain may resolve the reserved `silk/` source origin differently from project
 files, but that packaging privilege does not inject its declarations into every module scope.
@@ -750,8 +808,9 @@ Tooling may add missing imports automatically; auto-import is a source edit, not
 
 A foundational type spelling does not create an ordinary nominal declaration in the module scope.
 Therefore `import silk.i32` may bind actor namespace `i32` while type positions continue to use the
-closed language spelling `i32`; `import silk.effect as Effect` behaves similarly beside Effect
-type syntax. This does not create general separate type and value namespaces for user declarations.
+closed language spelling `i32`; selecting the matching `Effect` actor behaves similarly beside
+Effect type syntax. This does not create general separate type and value namespaces for user
+declarations.
 
 **Diagnostics:** Naming an unimported standard-library namespace uses the ordinary unknown-name
 diagnostic. Catalog-backed completion may add a visible, collision-aware import edit.

--- a/docs/language/ownership-and-borrowing.md
+++ b/docs/language/ownership-and-borrowing.md
@@ -691,6 +691,11 @@ The binding `view` does not own or copy `values`. It keeps a shared loan of `val
 its last use. An exclusive local view analogously keeps one exclusive loan active and requires a
 mutable owner.
 
+Last-use analysis follows the complete containing expression. A use nested in a place replacement,
+a backing-value observation such as `Enum.value(...)`, `Effect.result`, or requirement binding
+extends the loan through that nested use; an outer wrapper or an earlier direct callable invocation
+does not end it prematurely.
+
 A borrowed value cannot be stored inside a struct, array, union, generic wrapper, Effect success or
 failure value, or other owned value. Callable and Effect captures must satisfy the captured-loan
 rules in Batch 4 rather than gaining an untracked lifetime.
@@ -707,7 +712,9 @@ boundary reports that boundary's specific diagnostic rather than silently extend
 lifetime.
 
 **Evidence:** [runtime-slice specification](../../openspec/specs/bootstrap-runtime-slices/spec.md),
-[slice semantics tests](../../packages/compiler/test/RuntimeSliceSemantics.test.ts).
+[loan live-range correction](../../openspec/changes/archive/2026-08-26-compiler-review-stability-fixes/specs/bootstrap-ownership/spec.md),
+[slice semantics tests](../../packages/compiler/test/RuntimeSliceSemantics.test.ts),
+[loan regression tests](../../packages/compiler/test/RuntimeSliceOwnership.test.ts).
 
 ### BORROW-009 — Slice length is runtime information
 
@@ -859,9 +866,11 @@ fn invalid(token: Token, consumeNow: bool) -> i32 {
 binding must have one compatible live state on every continuing path; the compiler does not choose
 an ownership state from whichever path happens to run at runtime.
 
-**Diagnostics:** A use reached by any path on which its binding was consumed reports `OWN0001` and
-relates the consuming move. Branch-local bindings are unavailable outside their declared region and
-use the ordinary name or scope diagnostic rather than an ownership merge error.
+**Diagnostics:** Continuing `if` or `if let` arms that disagree on whether a move-only binding is
+live report `OWN0017` at the merge, even when there is no later use. A use reached by a path on which
+its binding was consumed also reports `OWN0001` and relates the consuming move. Branch-local
+bindings are unavailable outside their declared region and use the ordinary name or scope
+diagnostic rather than an ownership merge error.
 
 **Evidence:** [ownership specification](../../openspec/specs/bootstrap-ownership/spec.md),
 [branch ownership tests](../../packages/compiler/test/Ownership.test.ts).
@@ -969,16 +978,20 @@ fn repeat(token: Token, again: bool) -> i32 {
 A path may move an owner and then `break` or `return` because it does not re-enter the loop. Whether
 the owner is usable after the loop still depends on every path that reaches that later use.
 
-**Boundary:** Reassigning only one field after moving the complete owner does not restore it. The
-replacement must initialize the complete binding under OWN-005. Loans created inside an iteration
-must also end or have one compatible continuing state before the next iteration.
+**Boundary:** The loop-header baseline is the ownership state before the condition runs, because the
+condition is evaluated again on every iteration. A condition that consumes an outer owner therefore
+cannot silently establish a weaker repeating state. Reassigning only one field after moving the
+complete owner does not restore it. The replacement must initialize the complete binding under
+OWN-005. Loans created inside an iteration must also end or have one compatible continuing state
+before the next iteration.
 
 **Diagnostics:** A repeating path that reaches the loop header with an owner missing or
 incompatibly borrowed reports `OWN0005`. A direct later use after an unconditional move reports the
 ordinary `OWN0001` use-after-move diagnostic.
 
 **Evidence:** [ownership specification](../../openspec/specs/bootstrap-ownership/spec.md),
-[mutable-loop tests](../../packages/compiler/test/MutableLoops.test.ts).
+[mutable-loop tests](../../packages/compiler/test/MutableLoops.test.ts),
+[ownership regression tests](../../packages/compiler/test/Ownership.test.ts).
 
 ### GENERIC-001 — Unconstrained type parameters may be affine
 
@@ -1299,13 +1312,14 @@ root. Dropping an uninvoked callable ends its loans and cleans its owned capture
 Invoking an exclusive callable through shared access reports the callable-access diagnostic.
 Escaping the callable beyond a captured root reports an ownership escape at the boundary.
 
-**Current compiler:** Capture loans retained by callable sections currently require explicit
-`drop` before conflicting owner access, even when the preceding invocation is the callable's last
-use. Effect capture loans already end after their last run. Stabilization should apply the same
-last-use rule to both delayed-value forms.
+**Current compiler:** Aligned. Capture loans retained by callable sections end after a statically
+proven last invocation or an explicit `drop`; Effect capture loans analogously end after their last
+run. A later non-invocation use that may store, move, or escape the callable prevents the earlier
+invocation from being treated as final.
 
 **Evidence:** [ownership specification](../../openspec/specs/bootstrap-ownership/spec.md),
-[callable ownership tests](../../packages/compiler/test/Ownership.test.ts).
+[callable ownership tests](../../packages/compiler/test/Ownership.test.ts),
+[callable loan last-use tests](../../packages/compiler/test/RuntimeSliceOwnership.test.ts).
 
 ### EFFECT-OWN-001 — Effect construction captures without executing
 

--- a/docs/language/patterns-and-destructuring.md
+++ b/docs/language/patterns-and-destructuring.md
@@ -3,6 +3,7 @@
 Patterns inspect existing value structure and introduce local bindings. Silk uses the same pattern
 grammar in exhaustive `match`, unconditional `let` destructuring, and conditional `if let`.
 The surrounding construct decides whether a pattern must always match or provides a mismatch path.
+Scalar enums additionally provide a qualified, payload-free member pattern for exhaustive `match`.
 
 Patterns are not expressions. They perform no conversion, equality call, interface dispatch,
 constructor call, or user-defined extraction.
@@ -27,8 +28,10 @@ fn sum(point: Point) -> i32 {
 }
 ```
 
-**Boundary:** Sharing the grammar does not make every pattern valid everywhere. An unconditional
-`let` must prove success, while a `match` arm or `if let` may test a refutable member.
+**Boundary:** Sharing the destructuring grammar does not make every pattern valid everywhere. An
+unconditional `let` must prove success, while a `match` arm or `if let` may test a refutable union
+member. The qualified scalar enum member form is currently match-only under PATT-020; it is not an
+`if let` or unconditional destructuring form.
 
 **Diagnostics:** A pattern form unavailable in its current context reports the form, context, and
 nearest valid construct. No stable general code is assigned.
@@ -330,7 +333,7 @@ does not make `if` value-producing or replace exhaustive `match` where every res
 **Diagnostics:** Exhaustiveness, unreachable-arm, guard, and join diagnostics remain those of
 MATCH-003–005.
 
-**Evidence:** [match rules](functions-callables-and-control-flow.md#matches),
+**Evidence:** [match coverage rules](functions-callables-and-control-flow.md#match-003--match-coverage-is-exhaustive-and-guards-do-not-prove-coverage),
 [exhaustive matching specification](../../openspec/specs/bootstrap-exhaustive-matching/spec.md).
 
 ## PATT-014 — The first destructuring surface stays deliberately small
@@ -490,3 +493,42 @@ diagnostic. Member collapse during a valid complete application produces no comp
 
 **Evidence:** [generic body checking](generics-interfaces-and-specialization.md#gen-004--a-generic-body-is-checked-once-against-its-declared-contract),
 [finite specialization](generics-interfaces-and-specialization.md#gen-005--every-reachable-generic-application-becomes-finite-monomorphic-code).
+
+## PATT-020 — A qualified scalar enum member pattern selects one exact member
+
+**Status:** Confirmed
+
+A match over a scalar enum uses `Enum.Member` to select one member of that exact canonical enum.
+The pattern has no payload and introduces no binding. An unguarded member arm removes that member
+from the remaining coverage set; a guarded arm handles the member only when its guard succeeds and
+therefore proves no coverage.
+
+```silk
+enum Status { Pending, Ready, Done }
+
+fn code(status: Status) -> i32 {
+  return match status {
+    Status.Pending => 0
+    Status.Ready => 1
+    Status.Done => 2
+  }
+}
+```
+
+The match is exhaustive without `_` because every declared member appears in an unguarded arm.
+`_` may instead cover all members still remaining, after which every later arm is unreachable. The
+scrutinee remains type `Status`; a member pattern does not narrow it to an integer or a distinct
+member subtype.
+
+**Boundary:** The member name must be qualified and belong to the scrutinee's canonical enum. A bare
+`Ready`, `Other.Ready`, or integer literal equal to a discriminant does not select
+`Status.Ready`. The current qualified enum-member pattern is available only in `match`; scalar enum
+`let` and `if let` selection are not part of the stabilized surface.
+
+**Diagnostics:** Missing declared members report `SEM0158`. A duplicate unguarded member reports
+`SEM0159` at the later arm and relates the first; an arm after `_` reports `SEM0160`. A foreign enum
+member reports `SEM0161`, and an integer literal pattern against an enum reports `SEM0162`.
+
+**Evidence:** [scalar enum matching specification](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[enum matching tests](../../packages/compiler/test/ExhaustiveMatching.test.ts),
+[match coverage rules](functions-callables-and-control-flow.md#match-003--match-coverage-is-exhaustive-and-guards-do-not-prove-coverage).

--- a/docs/language/program-entry.md
+++ b/docs/language/program-entry.md
@@ -141,7 +141,7 @@ provided explicitly before the entry Effect completes. The compiler does not cur
 an implementation for a missing requirement.
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 service Clock {}
 

--- a/docs/language/program-termination-and-reporting.md
+++ b/docs/language/program-termination-and-reporting.md
@@ -137,7 +137,7 @@ channel or reach the automatic entry boundary.
 
 **Diagnostics:** No marker interface or formatting diagnostic applies to a valid error type.
 
-**Evidence:** [ordinary error values](typed-failures.md#fail-001--any-detached-owned-value-may-be-a-typed-failure),
+**Evidence:** [ordinary error values](typed-failures.md#fail-001--any-concrete-detached-value-may-be-a-typed-failure),
 [removal of Report ceremony](program-entry.md#entry-003--unhandled-effect-entry-failures-become-process-failures).
 
 ## TERM-006 — Recovery history becomes causal report context

--- a/docs/language/requirements-and-services.md
+++ b/docs/language/requirements-and-services.md
@@ -28,6 +28,12 @@ Effect requirement or a runtime provider slot.
 - A **provider** is a value whose type conforms to a service and whose operations satisfy that
   service at runtime.
 
+Standard-library constructors intentionally presented as explicit provider helpers use the
+`Provider` suffix, such as `stdoutProvider` or `systemAllocatorProvider`. Other constructors may
+return conforming implementation values under ordinary actor names such as `make` or `seeded`. The
+service remains the capability contract; a constructor named as a provider neither creates a new
+requirement key nor changes conformance selection.
+
 ## SERV-001 — A conformance may define or map each operation
 
 **Status:** Confirmed
@@ -137,7 +143,7 @@ table for interfaces and services.
 **Evidence:** [earlier service mapping requirement](../../openspec/specs/bootstrap-service-declarations/spec.md),
 [interface witness specification](../../openspec/specs/bootstrap-complete-interface-contracts/spec.md),
 [current parser](../../packages/compiler/src/Parser.ts),
-[current conformance index](../../packages/compiler/src/DeclarationIndex.ts).
+[current conformance facts](../../packages/compiler/src/DeclarationFacts.ts).
 
 ## SERV-002 — Only services may be Effect requirements
 
@@ -193,7 +199,7 @@ it must not silently synthesize a service declaration or wrapper.
 requirement parameters, while concrete structs and ordinary interfaces receive `SEM0070`.
 
 **Evidence:** [service declaration specification](../../openspec/specs/bootstrap-service-declarations/spec.md),
-[requirement validation](../../packages/compiler/src/Elaboration.ts).
+[requirement validation](../../packages/compiler/src/DeclarationResolution.ts).
 
 ## SERV-003 — A service is a dependency-eligible interface
 
@@ -249,8 +255,8 @@ Effect dependency key is formed.
 
 **Evidence:** [earlier service/interface distinction](../../openspec/specs/bootstrap-service-declarations/spec.md),
 [interface contract specification](../../openspec/specs/bootstrap-complete-interface-contracts/spec.md),
-[current conformance index](../../packages/compiler/src/DeclarationIndex.ts),
-[current elaboration](../../packages/compiler/src/Elaboration.ts).
+[current conformance facts](../../packages/compiler/src/DeclarationFacts.ts),
+[current conformance proof](../../packages/compiler/src/ConformanceProof.ts).
 
 ## SERV-004 — A requirement key is a service and nominal role
 
@@ -323,7 +329,7 @@ normalized form.
 spelling is not accepted as a compatibility alias.
 
 **Evidence:** [current requirement representation](../../packages/compiler/src/Type.ts),
-[current row elaboration](../../packages/compiler/src/Elaboration.ts),
+[current row resolution](../../packages/compiler/src/DeclarationResolution.ts),
 [current generic-row specification](../../openspec/specs/bootstrap-type-generics/spec.md).
 
 ## SERV-005 — Generic requirement rows preserve normalized entries
@@ -364,7 +370,7 @@ while the generic body is checked.
 including nominal roles and access, and concrete specializations and diagnostics use `at` spelling.
 
 **Evidence:** [generic Effect-contract rule](effect-contracts.md#eff-012--ordinary-failure-types-and-generic-requirement-rows-preserve-a-contract),
-[current row inference](../../packages/compiler/src/Elaboration.ts),
+[current row inference](../../packages/compiler/src/internal/TypeInference.ts),
 [generic-row tests](../../packages/compiler/test/TypeGenerics.test.ts).
 
 ## SERV-006 — Requirement access and provider ownership are separate
@@ -429,7 +435,7 @@ normalized requirement row. When exactly one service-role key is compatible, tha
 
 ```silk
 // The Effect has one &Clock requirement and SystemClock conforms to Clock.
-let specialized = Effect.provide(effect, &systemClock)
+let specialized = Effect.provide(target, &systemClock)
 ```
 
 Compatibility requires both an ordinary interface conformance from the provider type to the
@@ -536,6 +542,10 @@ Provider lifetime follows the capture used to construct the specialized Effect:
 - a moved provider is owned and eventually cleaned up by the specialized Effect under ordinary
   ownership rules.
 
+The current standard library exposes those modes explicitly: `Effect.provide` (or
+`bindRequirement`) stores a shared borrow, `Effect.provideMut` (or `bindRequirementMut`) stores an
+exclusive borrow, and `Effect.bindRequirementOwned` stores an owned provider.
+
 During execution, the captured provider overrides an outer provider for the selected key. Once that
 execution finishes, the outer provider is visible again. This is lexical replacement attached to
 the Effect value, not mutation of process-wide dependency state.
@@ -591,7 +601,7 @@ layer, selectors and subtraction use access-independent keys, and `flatten` unio
 both layers' requirement rows.
 
 **Evidence:** [effect construction and execution](effects-and-execution.md),
-[nested Effect rule](effects-and-execution.md#eff-004--effects-may-be-nested-and-flattening-is-explicit),
+[nested Effect rule](effects-and-execution.md#eff-004--nested-effects-are-ordinary-values),
 [flow-function provision specification](../../openspec/specs/bootstrap-flow-functions/spec.md),
 [provider ownership tests](../../packages/compiler/test/Ownership.test.ts).
 
@@ -616,7 +626,7 @@ Conceptually, the combinator is ordinary Effect composition:
 ```silk
 effect {
   let mut provider = run acquireProvider()
-  return run Effect.provide<K>(target, &mut provider)
+  return run Effect.provideMut<K>(target, &mut provider)
 }
 ```
 

--- a/docs/language/runtime-and-standard-library.md
+++ b/docs/language/runtime-and-standard-library.md
@@ -122,7 +122,7 @@ Only closed language bindings exist without source imports. Standard-library act
 types—enter a module scope only through explicit imports.
 
 ```silk
-import silk.option as Option
+import silk.option { Option }
 
 pub fn main() -> i32 {
   let value = Option.some<i32>(42)
@@ -132,8 +132,8 @@ pub fn main() -> i32 {
 ```
 
 The type spellings `i32` and `Effect<A ! E ? R>` remain language syntax. Importing `silk.i32` or
-`silk.effect as Effect` creates an ordinary value namespace containing actor operations; it does
-not define or replace the language type.
+selecting `Effect` from `silk.effect` creates an ordinary value binding containing actor operations;
+it does not define or replace the language type.
 
 Canonical standard-library modules occupy the reserved `silk.*` distribution identity. Project
 source cannot declare, replace, or shadow that identity. This reservation lets one import resolve
@@ -245,10 +245,11 @@ distribution-policy violation identifying both modules and the dependency edge. 
 import its portable contract. Catalog verification rejects a dependency cycle that makes the
 portable closure depend transitively on target-provider source.
 
-**Current standard library:** Largely aligned. Filesystem, standard input, host input, and child
-process contracts are separate from their OS providers. Allocation (`silk.allocator`) and standard
-streams (`silk.standard_streams`) are their own modules; the manifest still needs classification
-against this boundary.
+**Current standard library:** Partially aligned. The manifest now classifies every module as
+`portable` or `target-provider`, and filesystem, standard input, host input, and child-process
+contracts are separate from their OS providers. Allocation (`silk.allocator`) and standard streams
+(`silk.standard_streams`) are still classified as portable while also containing their
+process-backed providers, so those two module boundaries remain to be reconciled with this rule.
 
 **Evidence:** [portable/provider separation](../../openspec/specs/bootstrap-silk-stdlib/spec.md),
 [requirements and services](requirements-and-services.md),
@@ -265,7 +266,7 @@ resource.
 
 ```silk,ignore
 import silk.allocator { Allocator, OutOfMemoryError }
-import silk.vector as Vector
+import silk.vector { Vector }
 
 effect fn copyValues(values: &[i32]) -> Vector<i32> ! OutOfMemoryError ? &mut Allocator {
   let mut result = Vector.make<i32>()
@@ -344,10 +345,10 @@ checked only when a provider operation and its restricted intrinsic enter the se
 closure. Provider names, module paths, and conformances do not create module-level target semantics.
 
 ```silk,ignore
-import silk.os_filesystem as OsFileSystem
+import silk.os_filesystem { OsFileSystem }
 
 pub fn main() -> i32 {
-  // Importing the provider namespace is valid even when this target cannot execute its OS calls.
+  // Importing the provider actor is valid even when this target cannot execute its OS calls.
   return 0
 }
 ```
@@ -380,14 +381,14 @@ runtime do not automatically provide an allocator, logger, filesystem, clock, ho
 stream, or other service merely because an official implementation ships with the toolchain.
 
 ```silk,ignore
-import silk.effect as Effect
-import silk.logger { Logger }
+import silk.effect { Effect }
+import silk.logger { LogError, LogLevel, Logger }
 
-effect fn program() -> () ? &mut Logger {
-  return run Logger.log("ready")
+effect fn program() -> () ! LogError ? &mut Logger {
+  return run Logger.log(LogLevel.Info, "ready")
 }
 
-pub effect fn main() {
+pub effect fn main() ! LogError {
   let mut logger = Logger.stdoutProvider()
   return run Effect.provideMut<Logger>(program(), &mut logger)
 }
@@ -454,7 +455,7 @@ justified by the retained executable inventory.
 closure, while executable support follows reachable specialized operations.
 
 **Evidence:** [TARGET-002](unsafe-intrinsics-and-targets.md#target-002--unreachable-target-specific-primitives-have-no-artifact-cost),
-[explicit module closure](modules-names-and-visibility.md#mod-003--imports-build-one-deterministic-transitive-module-closure),
+[explicit module closure](modules-names-and-visibility.md#module-004--compilation-loads-only-the-transitively-reachable-module-closure),
 [current intrinsic availability](../../packages/compiler/src/IntrinsicAvailability.ts).
 
 ### RUNTIME-003 — Toolchain runtime support guarantees contracts, not implementation ABI
@@ -534,13 +535,15 @@ and target behavior. It does not select an executor. None of these contracts is 
 unprovided service receives a requirement diagnostic. The compiler must not silently initialize a
 runtime facility to make either program succeed.
 
-**Current compiler:** Directionally aligned but not fully audited. The native adapter and bootstrap
-runtime contain host support used by provider intrinsics; stabilization must verify that none becomes
-ambient source behavior or unavoidable artifact cost.
+**Current compiler:** Aligned for the current inventory. Entry and intrinsic reachability retain
+only explicitly selected facilities, while direct-Wasm and pressure tests keep trivial programs
+free of host imports, Scheduler, Fiber, LocalScheduler, Execution, and Wake machinery.
 
 **Evidence:** [explicit requirements](requirements-and-services.md),
 [Effect suspension](effect-suspension.md),
-[entry requirement closure](program-entry.md#entry-004--effect-entry-requirements-must-be-resolved).
+[entry requirement closure](program-entry.md#entry-004--effect-entry-requirements-must-be-resolved),
+[runtime-tier pressure tests](../../packages/compiler/test/LocalSharedPressure.test.ts),
+[intrinsic availability tests](../../packages/compiler/test/IntrinsicAvailability.test.ts).
 
 ### RUNTIME-005 — The compiler-generated adapter is the only mandatory program runtime boundary
 

--- a/docs/language/single-threaded-fibers.md
+++ b/docs/language/single-threaded-fibers.md
@@ -25,10 +25,10 @@ task storage, Fiber observation, and structured cancellation remain standard-lib
 
 ```silk
 import silk.allocator { OutOfMemoryError }
-import silk.effect as Effect
-import silk.fiber as Fiber
-import silk.local_scheduler as LocalScheduler
-import silk.scheduler as Scheduler
+import silk.effect { Effect }
+import silk.fiber { Fiber }
+import silk.local_scheduler { LocalScheduler }
+import silk.scheduler { Scheduler }
 
 effect fn work() -> i32 {
   return 42

--- a/docs/language/style-guide.md
+++ b/docs/language/style-guide.md
@@ -82,7 +82,7 @@ waiting for its remaining leading arguments, so the same convention supports ope
 value:
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 let specialized = Effect.provide(computation, &clock)
 let piped = computation |> Effect.provide(&clock)
@@ -124,15 +124,16 @@ and reopening another module or type remain invalid language boundaries, not sty
 
 **Evidence:** [callable pipeline specification](../../openspec/specs/bootstrap-callable-values/spec.md).
 
-## STYLE-003 — Examples prefer namespace imports and qualified operations
+## STYLE-003 — Examples prefer actor imports and qualified operations
 
 **Status:** Confirmed
 
-Documentation, tutorials, and public API examples should normally import an actor module as a
-namespace and qualify its operations:
+When a module contains a struct, service, or interface matching its filename, documentation,
+tutorials, and public API examples should normally import that actor declaration directly and
+qualify its operations through the imported name:
 
 ```silk
-import model.User
+import model.User { User }
 
 let user = User.make(42)
 let reassigned = User.withId(move user, 43)
@@ -143,18 +144,22 @@ This keeps the operation's owner visible where it is used. A reader can identify
 distinct function name. It also keeps related APIs visually grouped and matches the qualified,
 data-first convention in STYLE-002.
 
-Prefer this form in ordinary examples:
+The matching struct, service, or interface makes the module's public operations available through
+the imported actor qualifier, so this form keeps both the actor type and related operations under
+one binding. Prefer it in ordinary examples:
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 let provided = computation |> Effect.provide(&clock)
 return run provided
 ```
 
-Selective imports remain valid. Use them when the selected name itself is the subject being taught,
-when an API is conventionally read unqualified, or when repeated qualification would obscure the
-example's actual point:
+Import a module namespace when no matching struct, service, or interface exists, or when the module
+rather than a matching actor declaration is the subject being taught. A matching scalar enum is
+not a nominal module scope: its qualifier exposes only its members and generated `value` operation.
+Import other selected members when an API is conventionally read unqualified or repeated
+qualification would obscure the example's actual point:
 
 ```silk
 import model.User { User }
@@ -164,25 +169,28 @@ fn id(user: &User) -> i32 {
 }
 ```
 
-When two namespaces have the same default name, alias one explicitly and keep its operations
-qualified:
+When two matching actors have the same default name, alias one selected actor explicitly and keep
+its operations qualified:
 
 ```silk
-import model.User
-import audit.User as UserAudit
+import model.User { User }
+import audit.User { User as UserAudit }
 
 let user = User.make(42)
 UserAudit.record(&user)
 ```
 
 **Boundary:** This is a documentation and API-style preference, not a compiler restriction.
-Selective imports, member aliases, and hybrid imports have their ordinary language meaning. A
+Namespace imports, member aliases, and hybrid imports have their ordinary language meaning. A
 reference page specifically documenting those forms should show them directly even though general
-examples prefer namespace qualification.
+examples prefer the matching actor import. For a matching service or interface, declared contract
+operations take precedence over same-named top-level module members; a namespace alias performs
+ordinary module-member lookup instead. A matching struct has no separate contract-operation lookup.
 
 **Tooling:** Formatters do not rewrite between namespace and selective imports. Documentation lint
 may prefer qualification in general examples but must permit selective imports where the example is
 teaching that syntax or naming an imported type directly.
 
-**Evidence:** [namespace imports](modules-names-and-visibility.md#import-001--a-namespace-import-binds-the-targets-final-path-segment),
+**Evidence:** [nominal module scopes](modules-names-and-visibility.md#name-005--a-file-named-struct-or-contract-also-scopes-that-modules-public-members),
+[namespace imports](modules-names-and-visibility.md#import-001--a-namespace-import-binds-the-targets-final-path-segment),
 [qualified data-first APIs](#style-002--public-apis-prefer-qualified-data-first-functions).

--- a/docs/language/typed-failures.md
+++ b/docs/language/typed-failures.md
@@ -61,6 +61,11 @@ type does not need to be nominal. Built-in values, named structs, and other conc
 appear as an Effect's failure type when the particular payload is detached and can be transferred
 by value. An affine payload transfers ownership; a Copy payload copies its complete valid value.
 
+A generic value-kind parameter may stand for that ordinary failure type while its declaration is
+checked. If an inferred `effect {}` block executes `fail move problem` for `problem: E`, its failure
+channel retains symbolic `E`; each reachable specialization substitutes one concrete detached
+value type. The compiler does not discard the failure merely because it is not nominal yet.
+
 ```silk
 effect fn read() -> i32 ! string {
   fail "not found"
@@ -99,6 +104,10 @@ receives a type diagnostic at the invalid failure channel and identifies the unr
 payload that is not detached receives `SEM0073` at the failure origin or invalid contract and
 identifies the borrow or provider dependency that would escape.
 
+After a generic failure specializes successfully, an ordinary `run` that does not propagate or
+recover that concrete failure reports `SEM0066`, just as it does for a directly written nominal
+failure.
+
 Using a non-nominal concrete type is valid and produces no diagnostic.
 
 **Current compiler:** Aligned. Failure channels accept detached ordinary types, including primitive
@@ -107,6 +116,7 @@ lexical borrow out of scope.
 
 **Evidence:** [confirmed stabilization decision](README.md),
 [current row validation](../../packages/compiler/test/DeclarationIndex.test.ts),
+[generic failure preservation](../../packages/compiler/test/EffectBlockTyping.test.ts),
 [detachment diagnostics](../../packages/compiler/test/Elaboration.test.ts).
 
 ## FAIL-002 — `fail` follows ordinary ownership rules and has type `never`
@@ -244,7 +254,7 @@ the protected Effect succeeds with `A` and the handler succeeds with `B`, the re
 success type is the normalized union `A | B`.
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 struct NotFoundError {}
 
@@ -282,8 +292,8 @@ fn invalid() -> Effect<i32> {
 ```
 
 **Diagnostics:** Using the recovered Effect where only one member of its success union is accepted
-must produce a type mismatch at that use and identify the complete actual success type. A stable
-diagnostic code for this general mismatch is not yet assigned.
+produces `SEM0040` at that use and identifies the complete actual success type and the missing union
+member.
 
 **Current compiler:** Aligned. `Effect.catch` and `Effect.catchAll` use separate protected and
 handler success types and normalize the result to `A | B`.
@@ -309,7 +319,7 @@ Success and failure types use ordinary union normalization. Requirement rows ret
 capability, access, and role normalization.
 
 ```silk
-import silk.effect as Effect
+import silk.effect { Effect }
 
 struct NotFoundError {}
 struct InvalidInputError {}
@@ -461,6 +471,11 @@ cleanup; the language makes no cleanup guarantee after the trapping operation. F
 compiler-generated checked operation, the runtime should report its source origin and available
 logical execution trace before termination. Failures such as corrupted runtime state or invalid
 unsafe memory may permit only a best-effort report.
+
+Scheduler outcomes remain on the typed side of this boundary. For example,
+`Fiber.Cancelled`, `Scheduler.TaskIdExhaustedError`, and `LocalScheduler.StalledError` are ordinary
+declared outcomes of the source-level Fiber and scheduler APIs; none turns a trap into a recoverable
+Effect failure.
 
 **Boundary:** A condition the program intends to recover from must be represented before a trap
 occurs: as ordinary data or as a typed failure from a checked operation. An Effect handler cannot

--- a/docs/language/unsafe-intrinsics-and-targets.md
+++ b/docs/language/unsafe-intrinsics-and-targets.md
@@ -72,7 +72,7 @@ behavior.
 retain defined trap behavior. The language documentation has not previously separated detected
 debug violations from the portable undefined-behavior boundary this explicitly.
 
-**Evidence:** [fatal traps](typed-failures.md#fail-012--fatal-trap-is-unrecoverable-and-promises-no-cleanup),
+**Evidence:** [fatal traps](typed-failures.md#fail-007--a-trap-is-fatal-and-remains-outside-effect-outcomes),
 [safe-code vocabulary](../../CONTEXT.md),
 [intrinsic unsafe invariants](../../packages/compiler/test/fixtures/intrinsic-inventory.json).
 
@@ -118,7 +118,7 @@ source callables.
 
 **Status:** Confirmed
 
-Proposed syntax:
+Source syntax:
 
 ```silk,ignore
 pub unsafe fn fromUtf8Unchecked(bytes: &[u8]) -> string {
@@ -366,13 +366,14 @@ untracked transition visible by convention or comments.
 unsafe region use their ordinary diagnostics. A diagnostic should not suggest adding `unsafe` when
 no unsafe operation exists that expresses the required transition.
 
-**Current compiler:** Largely aligned for lexical unsafe blocks: ordinary semantic and ownership
-analysis remains active inside them. The intrinsic audit must verify that every raw state transition
-has a precise post-state rather than relying on an ambient unsafe exemption.
+**Current compiler:** Aligned for the current checked inventory. Ordinary semantic and ownership
+analysis remains active inside lexical unsafe blocks, and each unsafe catalog entry carries the
+specific invariant acknowledged by its call site rather than relying on an ambient exemption.
 
 **Evidence:** [ownership and borrowing](ownership-and-borrowing.md),
-[fatal-trap cleanup boundary](typed-failures.md#fail-012--fatal-trap-is-unrecoverable-and-promises-no-cleanup),
-[intrinsic boundary specification](../../openspec/specs/bootstrap-intrinsic-boundary/spec.md).
+[fatal-trap cleanup boundary](typed-failures.md#fail-007--a-trap-is-fatal-and-remains-outside-effect-outcomes),
+[intrinsic boundary specification](../../openspec/specs/bootstrap-intrinsic-boundary/spec.md),
+[checked intrinsic inventory](../../packages/compiler/test/IntrinsicCatalog.test.ts).
 
 ### UNSAFE-007 — Partial application preserves unsafety but does not invoke it
 
@@ -467,9 +468,10 @@ language.
 documentation is an LSP warning and does not fail parsing, semantic analysis, execution, or a
 compiler-only build. Ordinary visibility and import errors retain their ordinary diagnostics.
 
-**Current compiler:** Partially aligned. Documentation comments already attach to declarations and
-flow into editor information, while ordinary source-declared unsafe functions and the corresponding
-LSP warning do not yet exist.
+**Current compiler:** Aligned for source-declared unsafe functions, visibility, call-site
+acknowledgement, formatting, and editor presentation. Documentation comments attach to declarations
+and flow into editor information. The non-blocking LSP warning for a missing or empty `# Safety`
+section is not yet implemented.
 
 **Evidence:** [module and visibility rules](modules-names-and-visibility.md),
 [documentation block model](../../packages/compiler/src/DocBlock.ts),
@@ -514,9 +516,9 @@ collision. An unknown member reports an unknown-intrinsic diagnostic and does no
 modules for a fallback. A same-named ordinary operation under another qualifier resolves normally
 and receives no intrinsic-specific diagnostic or lowering.
 
-**Current compiler:** Largely aligned. Intrinsic operations carry canonical identities and scalar
-actor spellings now resolve to shipped source wrappers. The complete catalog and every remaining
-name-based compiler branch still require reconciliation against this rule.
+**Current compiler:** Aligned. Intrinsic operations carry canonical identities in one checked
+catalog, scalar actor spellings resolve to shipped source wrappers, and same-spelled ordinary source
+operations receive no intrinsic identity or lowering.
 
 **Evidence:** [intrinsic boundary specification](../../openspec/specs/bootstrap-intrinsic-boundary/spec.md),
 [intrinsic catalog tests](../../packages/compiler/test/IntrinsicCatalog.test.ts),
@@ -589,9 +591,9 @@ program-error condition. The deterministic inventory records the admission reaso
 consumer. Repository verification rejects missing consumers, unregistered compiler branches,
 unregistered public host imports, or duplicate abstraction-shaped operations.
 
-**Current compiler:** Partially aligned. The inventory records admission and consumer metadata and
-the bootstrap intrinsic specification has repeatedly replaced domain-shaped operations with narrow
-primitives. A stabilization audit must still remove any survivor that cannot meet this rule.
+**Current compiler:** Aligned for the current catalog. The checked inventory records a nonempty
+admission reason and concrete consumer for every operation, and catalog tests compare that inventory
+with every accepted semantic intrinsic call.
 
 **Evidence:** [minimal intrinsic requirement](../../openspec/specs/bootstrap-intrinsic-boundary/spec.md),
 [current deterministic inventory](../../packages/compiler/test/IntrinsicCatalog.test.ts).
@@ -638,10 +640,9 @@ missing-boundary error. Invalid wrapper logic receives only the diagnostics just
 Silk analysis; the compiler does not claim to have proven its semantic safety argument. LSP wrapper
 suggestions are optional actions, not correctness diagnostics.
 
-**Current compiler:** Architecturally aligned. Shipped source wrappers call narrow intrinsics from
-ordinary Silk and the compiler resolves only the intrinsic identity. A stabilization audit must
-remove any remaining name-based wrapper privilege and ensure direct intrinsic calls are treated
-uniformly.
+**Current compiler:** Aligned. Shipped source wrappers call narrow intrinsics from ordinary Silk,
+the compiler resolves only the sealed intrinsic identity, and same-spelled ordinary operations are
+verified to remain ordinary source.
 
 **Evidence:** [minimal compiler privilege](../../AGENTS.md#minimal-compiler-privilege),
 [intrinsic boundary specification](../../openspec/specs/bootstrap-intrinsic-boundary/spec.md),
@@ -698,7 +699,7 @@ before evaluation or emission.
 
 **Evidence:** [intrinsic target availability specification](../../openspec/specs/bootstrap-intrinsic-target-availability/spec.md),
 [availability selection](../../packages/compiler/src/IntrinsicAvailability.ts),
-[target-availability tests](../../packages/compiler/test/IntrinsicTargetAvailability.test.ts).
+[target-availability tests](../../packages/compiler/test/IntrinsicAvailability.test.ts).
 
 ### TARGET-002 — Unreachable target-specific primitives have no artifact cost
 

--- a/docs/language/values-and-types.md
+++ b/docs/language/values-and-types.md
@@ -7,7 +7,8 @@ language's explicitly defined compatibility relations.
 Ownership behavior is defined by [ownership and borrowing](ownership-and-borrowing.md). Function,
 callable, and match result types are defined by
 [functions, callables, and control flow](functions-callables-and-control-flow.md). This page defines
-the identities, construction rules, and ordinary compatibility of foundational values.
+the identities, construction rules, and ordinary compatibility of foundational values, nominal
+structs and scalar enums, arrays, references, slices, and structural unions.
 
 ## Terminology
 
@@ -20,7 +21,8 @@ the identities, construction rules, and ordinary compatibility of foundational v
 - **Contextual literal selection** chooses a representable type for an exact literal that has not
   yet become a typed value.
 - **Compatibility** determines whether an already-typed source value may satisfy an expected type.
-- A **scalar** is `bool`, `char`, an integer type, or a floating-point type.
+- A **foundational scalar** is `bool`, `char`, an integer type, or a floating-point type. A
+  **scalar enum** is instead a nominal type with one fixed-width integer representation.
 - A **nominal type** is identified by its declaration rather than by the shape of its fields.
 - An **aggregate** is a value containing other values, such as a struct, fixed array, or structural
   union payload.
@@ -130,11 +132,11 @@ runtime value fits, an array does not decay into a slice, and `string` does not 
 
 **Diagnostics:** The enclosing boundary selects the diagnostic: arguments use `SEM0012`, struct
 fields `SEM0025`, array elements `SEM0030`, assignments `SEM0037`, and incompatible union widening
-`SEM0040`. Return mismatches still need one stable general semantic code.
+`SEM0040`. Return mismatches report `SEM0129`.
 
 **Evidence:** [compatibility implementation](../../packages/compiler/src/TypeCompatibility.ts),
 [callable modes](functions-callables-and-control-flow.md#callable-003--invocation-mode-describes-access-to-the-callable-environment),
-[Effect access](ownership-and-borrowing.md#effect-own-002--effect-run-access-derives-from-how-each-run-uses-the-environment).
+[Effect access](ownership-and-borrowing.md#effect-own-002--run-access-derives-from-use-of-the-effect-environment).
 
 ## Scalar values and literals
 
@@ -492,6 +494,151 @@ memory cannot request Copy merely because its physical representation contains a
 
 **Evidence:** [owned value classification](ownership-and-borrowing.md#own-001--every-value-type-is-either-copy-or-affine).
 
+## Scalar enum values
+
+### ENUM-001 — A scalar enum declares one closed nominal member set
+
+**Status:** Confirmed
+
+`enum Name { ... }` declares one nonempty, source-ordered set of uniquely named, fieldless members.
+The declaration creates a nominal type identified by its canonical module and name. Only a
+qualified member path such as `Status.Ready` constructs a value; the bare spelling `Ready` does not
+become a module binding.
+
+```silk
+enum Status {
+  Pending,
+  Ready,
+  Done,
+}
+
+fn initial() -> Status {
+  return Status.Pending
+}
+```
+
+Two enum declarations remain different types even when they use the same representation, member
+names, and discriminants. Every safe value of an enum names exactly one declared member. Members
+have no payload, generic arguments, fields, or independent visibility marker; the enum
+declaration's visibility governs the complete member set.
+
+**Boundary:** Silk does not infer an enum from an unqualified member name, an integer, or another
+enum's same-spelled member. An empty enum, a repeated member name, or a payload-bearing member is
+invalid rather than creating an open or data-carrying sum type. Use structural unions of nominal
+structs when alternatives need payloads.
+
+**Diagnostics:** An empty enum reports `SEM0146`; a repeated member name reports `SEM0148` at the
+later name and relates the first declaration. An unknown qualified member reports `SEM0153`.
+Using a member through another canonical enum reports `SEM0154`. A bare member name receives the
+ordinary unknown-name diagnostic.
+
+**Evidence:** [scalar enum specification](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[enum declaration tests](../../packages/compiler/test/DeclarationIndex.test.ts),
+[enum name-resolution tests](../../packages/compiler/test/NameResolution.test.ts).
+
+### ENUM-002 — The representation and discriminant sequence are explicit and checked
+
+**Status:** Confirmed
+
+An enum without a representation uses exactly `u8`. `enum(R) Name` may select only `u8`, `u16`,
+`u32`, `u64`, `i8`, `i16`, `i32`, or `i64`; Silk never infers a wider representation from member
+values.
+
+The first implicit discriminant is `0`. Every later implicit member takes the preceding member's
+discriminant plus one, including after an explicit optionally negative decimal integer literal.
+
+```silk
+enum(i16) ExitCode {
+  Success,
+  Interrupted = 130,
+  Failed,
+}
+```
+
+The discriminants are `0`, `130`, and `131`. Each explicit value and implicit successor must fit
+the selected representation, and discriminants must be unique.
+
+**Boundary:** `usize`, `isize`, floating types, aliases, nominal integer wrappers, and inferred
+representations are unavailable. An explicit discriminant is not a general constant expression;
+the current syntax accepts an optionally negative decimal integer literal. An unsigned enum cannot
+use a negative discriminant.
+
+**Diagnostics:** An unsupported representation reports `SEM0147`; a duplicate discriminant
+reports `SEM0149` at the later member and relates the first. An explicit out-of-range discriminant
+reports `SEM0150`, an overflowing implicit successor `SEM0151`, and a negative discriminant under
+an unsigned representation `SEM0152`.
+
+**Evidence:** [scalar enum representation rules](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[enum parser tests](../../packages/compiler/test/Parser.test.ts),
+[discriminant tests](../../packages/compiler/test/DeclarationIndex.test.ts).
+
+### ENUM-003 — A scalar enum has its representation's layout but keeps nominal identity
+
+**Status:** Confirmed
+
+A valid enum has exactly the size, alignment, and calling shape of its selected fixed-width integer,
+with no hidden tag or metadata. This representation choice is not visible as type compatibility:
+the source value remains the enum's nominal type through storage, calls, equality, and matching.
+
+Every scalar enum is a compiler-sealed Copy value with no cleanup obligation. Reading or passing an
+enum copies its member value without consuming the original binding.
+
+```silk
+enum Mode { Read, Write }
+
+fn same(value: Mode) -> bool {
+  let copy = value
+  return copy == value
+}
+```
+
+**Boundary:** Matching integer layout does not permit implicit integer conversion, cross-enum
+conversion, or arbitrary bit patterns to inhabit an enum. User code cannot implement or replace
+the enum's sealed `Copy` behavior, and an enum cannot admit a `Drop` implementation.
+
+**Diagnostics:** An attempted user `Copy` conformance uses the invalid-conformance diagnostic
+`SEM0083`; an invalid `Drop` implementation uses `SEM0084`. Mixing an enum with its representation
+integer reports `SEM0155` at the incompatible boundary.
+
+**Evidence:** [sealed enum ownership](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[layout tests](../../packages/compiler/test/Layout.test.ts),
+[enum ownership tests](../../packages/compiler/test/Ownership.test.ts).
+
+### ENUM-004 — `Enum.value` exposes the backing integer in one direction
+
+**Status:** Confirmed
+
+For an enum `E` represented by integer type `R`, `E.value(value)` accepts exactly `E` and returns
+that member's declared discriminant as `R`. The generated operation is total, allocation-free,
+failure-free, and requirement-free.
+
+```silk
+enum(i8) Status {
+  Unknown = -1,
+  Ready,
+}
+
+fn code(status: Status) -> i8 {
+  return Status.value(status)
+}
+```
+
+`Status.value(Status.Unknown)` returns `-1`. There is no built-in inverse operation because only
+declared discriminants are valid enum inhabitants.
+
+**Boundary:** An enum does not become an integer in arithmetic, ordering, assignment, arguments, or
+returns. An integer does not become an enum even when its value equals a member discriminant.
+`Enum.value` exposes representation; it does not erase the nominal type of the original value or
+promise that arbitrary representation bits can be reconstructed safely.
+
+**Diagnostics:** Either implicit enum-to-integer or integer-to-enum use reports `SEM0155`. A wrong
+enum argument uses the ordinary argument mismatch or the more specific canonical-enum diagnostic
+where applicable.
+
+**Evidence:** [enum value operation](../../openspec/specs/bootstrap-scalar-enums/spec.md),
+[analysis facade tests](../../packages/compiler/test/Analysis.test.ts),
+[backend enum tests](../../packages/compiler/test/Backend.test.ts).
+
 ## Fixed arrays, references, and slices
 
 ### ARRAY-001 — A fixed array type includes its element type and length
@@ -614,8 +761,8 @@ returned views, storage restrictions, and loan endings follow the ownership refe
 uses `SEM0058`; implicit array decay uses `SEM0059`.
 
 **Evidence:** [runtime slice specification](../../openspec/specs/bootstrap-runtime-slices/spec.md),
-[borrow rules](ownership-and-borrowing.md#borrow-001--shared-borrows-permit-only-shared-access-while-live),
-[returned views](ownership-and-borrowing.md#view-001--an-ordinary-function-may-return-one-source-borrowed-view).
+[borrow rules](ownership-and-borrowing.md#borrow-001--a-shared-borrow-grants-temporary-read-access),
+[returned views](ownership-and-borrowing.md#view-001--an-ordinary-function-may-return-a-view-from-one-borrowed-parameter).
 
 ## Structural unions and inference
 


### PR DESCRIPTION
## Summary

- refresh the language reference against the current compiler, standard library, and tests
- document scalar enums, current Effect inference and failures, ownership joins and captures, runtime scheduling, Fibers, suspension, module scoping, and current intrinsic behavior
- update official examples to import matching struct, service, and interface actors directly while preserving the scalar-enum and operation-precedence boundaries
- repair stale cross-references, evidence links, and API terminology

## Review

Three independent agent reviews covered language semantics, code examples and imports, and documentation consistency and links. Their findings were addressed and re-reviewed with no remaining actionable issues.

## Verification

- `pnpm check`
- focused documentation, name-resolution, and standard-library namespace tests: 52/52 passed
- internal Markdown file and heading-anchor validation
- `git diff --check`