### PR TITLE
docs: confirm stable language reference rules

### DIFF
--- a/apps/docs/content/reference/lexical-form.md
+++ b/apps/docs/content/reference/lexical-form.md
@@ -7,7 +7,7 @@ reference pages.
 
 ## LEXICAL-001 — Identifiers use the ASCII identifier alphabet
 
-**Status:** Candidate
+**Status:** Confirmed
 
 An identifier starts with an ASCII letter or `_` and continues with ASCII letters, decimal digits,
 and `_`. Matching is case-sensitive. `_` is an identifier token; it gains its wildcard meaning only
@@ -31,7 +31,7 @@ rather than emitting one error per byte.
 
 ## LEXICAL-002 — The keyword vocabulary is closed
 
-**Status:** Candidate
+**Status:** Confirmed
 
 The following complete identifiers are keywords:
 
@@ -59,7 +59,7 @@ different token. There is no separate lexical diagnostic for a correctly spelled
 
 ## LEXICAL-003 — Line comments end at the physical line boundary
 
-**Status:** Candidate
+**Status:** Confirmed
 
 `//` begins an ordinary comment. `///` begins a documentation comment attached to the following
 declaration, and `//!` begins documentation for the containing module. Consecutive documentation
@@ -81,8 +81,8 @@ block. Documentation attachment and which declarations may receive comments are 
 **Boundary:** Silk has no block-comment token. Comment markers inside a static literal are literal
 content, and quote characters inside a comment do not begin literals.
 
-**Diagnostics:** Comments themselves do not produce a diagnostic. An unsupported documentation
-position is diagnosed by the declaration or documentation layer, not by the lexer.
+**Diagnostics:** Comments themselves do not produce a diagnostic. Documentation comments that do
+not attach at a supported declaration position remain trivia and do not become API documentation.
 
 **Evidence:** [lexer specification](../../../../openspec/specs/bootstrap-lexer/spec.md),
 [documentation attachment tests](../../../../packages/compiler/test/DocBlock.test.ts),
@@ -90,7 +90,7 @@ position is diagnosed by the declaration or documentation layer, not by the lexe
 
 ## LEXICAL-004 — Numeric literals have explicit base, separator, and sign rules
 
-**Status:** Candidate
+**Status:** Confirmed
 
 An integer literal is decimal by default. Prefixes `0b`, `0o`, and `0x` select binary, octal, and
 hexadecimal digits; the base letter may be uppercase. `_` may separate digits only when a valid
@@ -125,7 +125,7 @@ and an exponent with no digits are invalid numeric spellings.
 
 ## LEXICAL-005 — Static text and byte literals have a closed form vocabulary
 
-**Status:** Candidate
+**Status:** Confirmed
 
 Silk recognizes six quote-delimited text and byte forms. A modifier must touch its opening
 delimiter.
@@ -205,7 +205,7 @@ reports `LEX0003`; malformed escapes receive their literal diagnostic.
 
 ## LEXICAL-007 — Tokenization is longest and lossless
 
-**Status:** Candidate
+**Status:** Confirmed
 
 At each byte position, the lexer recognizes the longest committed token introduction. Compound
 punctuation such as `==`, `!=`, `<=`, `>=`, `&&`, `||`, `|>`, `=>`, `->`, and `..` is therefore one

--- a/apps/docs/content/reference/values-and-types.md
+++ b/apps/docs/content/reference/values-and-types.md
@@ -352,19 +352,20 @@ conversions use the enclosing type-mismatch diagnostic.
 
 ## Constant values
 
-### CONST-001 — A constant has an explicit scalar type and one static initializer
+### CONST-001 — A constant has an explicit scalar or string type and one static initializer
 
-**Status:** Candidate
+**Status:** Confirmed
 
-A `const` declaration requires a type annotation. Its initializer is one bare scalar literal whose
-value is valid for that type. Constants do not infer their type, evaluate computed expressions, or
-hold aggregate values.
+A `const` declaration requires a type annotation. Its type is one foundational scalar type or
+`string`, and its initializer is one matching literal whose value is valid for that type. Constants
+do not infer their type, evaluate computed expressions, or hold aggregate values.
 
 ```silk
 pub const limit: i32 = 2
 const ratio: f64 = 1.5
 const enabled: bool = true
 const separator: char = ':'
+const pattern: string = r"\d+"
 ```
 
 A constant lowers to an immediate value. It has no address and cannot be borrowed, assigned, or
@@ -375,12 +376,13 @@ expressions are not constant initializers. An initializer of the wrong scalar ty
 
 **Diagnostics:** A constant outside this contract reports `SEM0086` at its declaration.
 
-**Evidence:** [numeric constant tests](../../../../packages/compiler/test/NumericConstants.test.ts),
-[constant analysis](../../../../packages/compiler/src/DeclarationIndex.ts).
+**Evidence:** [typed constant tests](../../../../packages/compiler/test/TypedConstants.test.ts),
+[numeric constant tests](../../../../packages/compiler/test/NumericConstants.test.ts),
+[constant analysis](../../../../packages/compiler/src/ExpressionAnalysis.ts).
 
 ### CONST-002 — Target facts are the only non-literal constant initializers
 
-**Status:** Candidate
+**Status:** Confirmed
 
 The following target facts may replace the literal in a constant declaration. The selected target
 determines their values.


### PR DESCRIPTION
## Summary

- promote all eight remaining language reference candidates to Confirmed
- clarify that unattached documentation comments remain trivia
- document string and raw-string constant initializers and correct their implementation evidence

No Candidate statuses remain in the language reference.

## Validation

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm check`
- docs production build
- relative-link audit
- focused lexer, literal, documentation comment, constant, and target-fact tests (91 tests)