### PR TITLE
fix(vscode): restore inlay hint refreshes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,15 +61,7 @@
         "cwd": "${workspaceFolder}"
       },
       "isBackground": true,
-      "problemMatcher": {
-        "owner": "typescript",
-        "pattern": "$tsc-watch",
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": ".",
-          "endsPattern": "Watching for file changes"
-        }
-      },
+      "problemMatcher": "$tsc-watch",
       "presentation": {
         "reveal": "silent",
         "panel": "dedicated"
@@ -83,15 +75,7 @@
         "cwd": "${workspaceFolder}"
       },
       "isBackground": true,
-      "problemMatcher": {
-        "owner": "typescript",
-        "pattern": "$tsc-watch",
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": ".",
-          "endsPattern": "Watching for file changes"
-        }
-      },
+      "problemMatcher": "$tsc-watch",
       "presentation": {
         "reveal": "silent",
         "panel": "dedicated"

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -93,9 +93,9 @@ the real editor extension host.
 
 For the scripted form, run **Silk: LSP Extension Host Test**. The guest host drives the same edits
 through VS Code's real `vscode-languageclient` adapter, checks synchronous diagnostic retirement,
-pull-diagnostic generation gating, dependency refresh, hover/quick-fix completion, acknowledged
-restart, and diagnostic removal on close, then exits with a failing launch when an assertion does
-not hold.
+pull-diagnostic generation gating, dependency refresh, hover/inlay-hint/quick-fix completion,
+acknowledged restart, and diagnostic removal on close, then exits with a failing launch when an
+assertion does not hold.
 
 ## Reload vs restart
 

--- a/apps/vscode/test/extension-host/index.cjs
+++ b/apps/vscode/test/extension-host/index.cjs
@@ -78,6 +78,34 @@ const hover = async (document) => {
   )
 }
 
+const inlayHints = async (document) => {
+  const range = new vscode.Range(
+    document.positionAt(0),
+    document.positionAt(document.getText().length),
+  )
+  await timeout(
+    (async () => {
+      while (true) {
+        const result = await vscode.commands.executeCommand(
+          'vscode.executeInlayHintProvider',
+          document.uri,
+          range,
+        )
+        const labels = Array.isArray(result)
+          ? result.flatMap((hint) =>
+              typeof hint.label === 'string'
+                ? [hint.label]
+                : hint.label.map((part) => part.value),
+            )
+          : []
+        if (labels.includes(': i32')) return
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+    })(),
+    'inlay-hint readiness',
+  )
+}
+
 module.exports.run = async () => {
   const workspace = vscode.workspace.workspaceFolders?.[0]
   if (workspace === undefined) throw new Error('LSP acceptance workspace was not opened')
@@ -90,6 +118,7 @@ module.exports.run = async () => {
   const main = await vscode.workspace.openTextDocument(mainUri)
   const mainEditor = await vscode.window.showTextDocument(main)
   await hover(main)
+  await inlayHints(main)
 
   await replace(mainEditor, source('  effects'))
   await waitFor(

--- a/packages/lsp/src/Server.ts
+++ b/packages/lsp/src/Server.ts
@@ -91,6 +91,7 @@ export const start = (options: Options = {}): void => {
   const runtime = ManagedRuntime.make(NodeServices.layer)
   let supportsDynamicWatchers = false
   let supportsDiagnosticRefresh = false
+  let supportsInlayHintRefresh = false
   let watcherRegistration: { readonly dispose: () => void } | undefined
   let shuttingDown = false
 
@@ -146,6 +147,8 @@ export const start = (options: Options = {}): void => {
           parameters.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration === true
         supportsDiagnosticRefresh =
           parameters.capabilities.workspace?.diagnostics?.refreshSupport === true
+        supportsInlayHintRefresh =
+          parameters.capabilities.workspace?.inlayHint?.refreshSupport === true
         return {
           capabilities: {
             positionEncoding: 'utf-16',
@@ -549,6 +552,10 @@ export const start = (options: Options = {}): void => {
             case 'Committed':
               if (supportsDiagnosticRefresh && event.refreshDiagnostics)
                 yield* Effect.sync(() => connection.languages.diagnostics.refresh())
+              if (supportsInlayHintRefresh)
+                yield* Effect.tryPromise(() => connection.languages.inlayHint.refresh()).pipe(
+                  Effect.ignore,
+                )
               for (const document of event.documents)
                 yield* Effect.tryPromise({
                   try: () =>

--- a/packages/lsp/test/Server.test.ts
+++ b/packages/lsp/test/Server.test.ts
@@ -102,6 +102,10 @@ pub fn main() -> i32 {
 }`
     didOpen(client, hintUri, hintText)
     await client.waitFor((message) => pulledDiagnostics(message, hintUri))
+    await client.waitFor(
+      (message) => (message.method === 'workspace/inlayHint/refresh' ? true : undefined),
+      1_000,
+    )
     client.send({
       id: 4,
       method: 'textDocument/inlayHint',

--- a/packages/lsp/test/StdioClient.ts
+++ b/packages/lsp/test/StdioClient.ts
@@ -9,7 +9,10 @@ export interface Client {
   readonly child: ChildProcess
   readonly messages: Array<Record<string, unknown>>
   readonly send: (message: Record<string, unknown>) => void
-  readonly waitFor: <A>(select: (message: Record<string, unknown>) => A | undefined) => Promise<A>
+  readonly waitFor: <A>(
+    select: (message: Record<string, unknown>) => A | undefined,
+    timeoutMilliseconds?: number,
+  ) => Promise<A>
   readonly close: () => Promise<void>
 }
 
@@ -75,6 +78,8 @@ export const connect = (entryPath = binPath): Client => {
         rawSend({ id: message.id, result: null })
         for (const [uri, version] of openDocuments) pull(uri, version)
       }
+      if (message.method === 'workspace/inlayHint/refresh' && message.id !== undefined)
+        rawSend({ id: message.id, result: null })
     }
   })
   const send = (message: Record<string, unknown>): void => {
@@ -90,7 +95,11 @@ export const connect = (entryPath = binPath): Client => {
           ...parameters,
           capabilities: {
             ...capabilities,
-            workspace: { ...workspace, diagnostics: { refreshSupport: true } },
+            workspace: {
+              ...workspace,
+              diagnostics: { refreshSupport: true },
+              inlayHint: { refreshSupport: true },
+            },
             textDocument: {
               ...textDocument,
               diagnostic: { dynamicRegistration: false, relatedDocumentSupport: false },
@@ -118,7 +127,10 @@ export const connect = (entryPath = binPath): Client => {
       pull(parameters.textDocument.uri)
     }
   }
-  const waitFor = <A>(select: (message: Record<string, unknown>) => A | undefined): Promise<A> =>
+  const waitFor = <A>(
+    select: (message: Record<string, unknown>) => A | undefined,
+    timeoutMilliseconds = 25_000,
+  ): Promise<A> =>
     new Promise((resolve, reject) => {
       const startedAt = Date.now()
       const poll = (): void => {
@@ -131,7 +143,7 @@ export const connect = (entryPath = binPath): Client => {
         }
         // Kept under the 30s per-test budget: this inner poll must not be the thing that fires
         // first, or a slow runner reports a timeout instead of the test's own limit.
-        if (Date.now() - startedAt > 25_000) {
+        if (Date.now() - startedAt > timeoutMilliseconds) {
           reject(new Error(`Timed out waiting; saw ${JSON.stringify(messages)}`))
           return
         }


### PR DESCRIPTION
## Summary
- refresh VS Code inlay hints after committed LSP analysis generations
- use the built-in `$tsc-watch` problem matcher correctly for both watch tasks
- cover inlay refresh at the stdio protocol seam and in the extension-host acceptance harness

## Verification
- `pnpm exec biome check .`
- `pnpm --filter @silklang/lsp --filter silk-language run typecheck`
- `pnpm --filter @silklang/lsp --filter silk-language run test`
- watch-task matcher structural check