### PR TITLE
fix(docs): resolve bare Markdown links

### DIFF
--- a/apps/docs/lib/remark-relative-doc-links.mjs
+++ b/apps/docs/lib/remark-relative-doc-links.mjs
@@ -1,0 +1,30 @@
+/**
+ * Make extension-bearing Markdown links explicit relative paths for Fumadocs.
+ *
+ * Bare links such as `values-and-types.md` are valid Markdown and work when the source is read on
+ * GitHub. Fumadocs resolves only links beginning with `./` or `../`, however, so it otherwise emits
+ * the source URL unchanged and the deployed site requests a nonexistent `.md` route.
+ */
+export function remarkRelativeDocLinks() {
+  return (tree) => {
+    visit(tree, (node) => {
+      if (node.type !== 'link' || typeof node.url !== 'string') return;
+      if (!isBareMarkdownPath(node.url)) return;
+
+      node.url = `./${node.url}`;
+    });
+  };
+}
+
+function isBareMarkdownPath(url) {
+  if (url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) return false;
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(url)) return false;
+
+  const path = url.split(/[?#]/, 1)[0];
+  return path.endsWith('.md') || path.endsWith('.mdx');
+}
+
+function visit(node, callback) {
+  callback(node);
+  for (const child of node.children ?? []) visit(child, callback);
+}

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -3,6 +3,7 @@ import { applyMdxPreset, frontmatterSchema } from 'fumadocs-mdx/config';
 import { defineDocs } from 'fumadocs-mdx/macro';
 import * as TextMate from '@silklang/editor-support/TextMate';
 import { remarkH1Title } from './remark-h1-title.mjs';
+import { remarkRelativeDocLinks } from './remark-relative-doc-links.mjs';
 
 /**
  * The language and compiler docs are plain Markdown with no frontmatter, so they remain useful
@@ -33,7 +34,7 @@ const docs = defineDocs({
     schema,
     // Collection-level mdxOptions replace the defaults outright, so extend the preset.
     mdxOptions: applyMdxPreset({
-      remarkPlugins: (v) => [remarkH1Title, ...v],
+      remarkPlugins: (v) => [remarkH1Title, remarkRelativeDocLinks, ...v],
       rehypeCodeOptions: {
         // Bundled languages lazy-load regardless of `langs`, so this only adds Silk on top.
         // The grammar's own types are readonly; Shiki's registration type is not.

--- a/apps/docs/test/remark-relative-doc-links.test.mjs
+++ b/apps/docs/test/remark-relative-doc-links.test.mjs
@@ -1,0 +1,46 @@
+import { assert, it } from '@effect/vitest';
+import { remarkRelativeDocLinks } from '../lib/remark-relative-doc-links.mjs';
+
+it('marks bare Markdown document links as relative for Fumadocs resolution', () => {
+  const tree = {
+    type: 'root',
+    children: [
+      { type: 'link', url: 'values-and-types.md', children: [] },
+      { type: 'link', url: 'typed-failures.md#fatal-traps', children: [] },
+      { type: 'link', url: 'guides/start.mdx?mode=full#intro', children: [] },
+    ],
+  };
+
+  remarkRelativeDocLinks()(tree);
+
+  assert.deepStrictEqual(
+    tree.children.map(({ url }) => url),
+    [
+      './values-and-types.md',
+      './typed-failures.md#fatal-traps',
+      './guides/start.mdx?mode=full#intro',
+    ],
+  );
+});
+
+it('leaves explicit relative, absolute, fragment, and external links unchanged', () => {
+  const urls = [
+    './values-and-types.md',
+    '../language/tutorial.md',
+    '/docs/reference',
+    '#values',
+    'https://example.com/guide.md',
+    'mailto:docs@example.com',
+  ];
+  const tree = {
+    type: 'root',
+    children: urls.map((url) => ({ type: 'link', url, children: [] })),
+  };
+
+  remarkRelativeDocLinks()(tree);
+
+  assert.deepStrictEqual(
+    tree.children.map(({ url }) => url),
+    urls,
+  );
+});


### PR DESCRIPTION
## Summary

- normalize bare `.md` and `.mdx` document links before Fumadocs resolves them
- preserve GitHub-friendly source Markdown while emitting extension-free site routes
- cover anchors, query strings, explicit relative paths, and external URLs

## Verification

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm check`
- inspected the production HTML for `/docs/reference` and confirmed links such as `/docs/reference/values-and-types` no longer include `.md`