### PR TITLE
docs: update enum and match guidance

### DIFF
--- a/apps/docs/content/language/glossary.md
+++ b/apps/docs/content/language/glossary.md
@@ -631,10 +631,17 @@ success type is the normalized union of the protected expression and reachable r
 _Avoid_: catch-all exception handler, resumption point
 
 **Type union**:
-A normalized, unordered set of nominal alternatives such as `A | B`; order, nesting, and duplicate
-members do not affect its identity. A value has one active member and an implicit discriminant,
-allowing exhaustive matching without user-defined tag-field names.
+A normalized, unordered set of detached concrete value types such as `Full | Empty` or
+`i32 | string`; order, nesting, and duplicate members do not affect its identity. A value has one
+active member and an implicit discriminant, allowing exhaustive matching without user-defined
+tag-field names.
 _Avoid_: tagged record, variant map
+
+**Scalar enum**:
+A closed nominal type whose qualified, fieldless members have fixed-width integer discriminants.
+It is Copy, supports exhaustive matching by member name, and does not implicitly convert to or from
+its backing integer. Alternatives that carry data use a type union of nominal structs instead.
+_Avoid_: data-carrying enum, open enum, integer alias
 
 **Finite type-set constraint**:
 A compile-time generic bound restricting a type parameter to a closed set of nominal types while

--- a/apps/docs/content/language/index.md
+++ b/apps/docs/content/language/index.md
@@ -7,7 +7,8 @@ the language that the current alpha compiler implements.
 ## Start here
 
 - **[Getting started](./tutorial.md)** — create a project and learn the core language by writing
-  functions, loops, owned values, borrows, unions, Effects, typed failures, and a service provider.
+  functions, loops, owned values, borrows, scalar enums, unions, Effects, typed failures, and a
+  service provider.
 - **[Language reference](../reference/)** — look up the exact lexical, type, ownership, Effect,
   declaration, and control-flow rules.
 - **[Alpha status](./alpha-status.md)** — see what is implemented, which targets are supported, and

--- a/apps/docs/content/language/tutorial.md
+++ b/apps/docs/content/language/tutorial.md
@@ -106,7 +106,8 @@ Notes on what is *not* here:
   and `continue`.
 - `if` is a statement, not an expression. There is no `let x = if ...`. Declare the binding `mut`
   and assign it in each branch, or `return` from the branches. (`match` *is* an expression, but its
-  scrutinee must be a struct or union — it cannot branch on a scalar comparison.)
+  scrutinee must be a struct, structural union, or scalar enum — it does not replace a scalar
+  comparison.)
 - Conditions take no parentheses and the braces are mandatory.
 
 Arithmetic is homogeneous: both operands must already be the *same* integer type. Silk performs no
@@ -206,10 +207,38 @@ bind that returned view while its source remains live. This deliberately narrow 
 operations such as collection access without named lifetime annotations; a returned view cannot be
 placed inside owned data or an Effect result.
 
-## Unions and match
+## Enums, unions, and match
 
-Silk has no `enum`. Instead, a value can have a *union* type written `A | B`, and `match`
-takes it apart. `match` is an expression, so it can produce a value:
+Silk has two ways to model a closed set of alternatives. A scalar `enum` is a nominal set of named,
+fieldless members. Qualify each member with its enum name, including in a `match`:
+
+```silk
+enum Status {
+  Pending,
+  Ready,
+  Done,
+}
+
+fn statusCode(status: Status) -> i32 {
+  return match status {
+    Status.Pending => 0
+    Status.Ready => 1
+    Status.Done => 2
+  }
+}
+
+pub fn main() -> i32 {
+  return statusCode(Status.Ready)
+}
+```
+
+Scalar enums are copyable and use `u8` as their backing representation by default. You can select
+another fixed-width integer with a declaration such as `enum(i16) Status`, assign explicit integer
+discriminants to members, and read a member's backing value with `Status.value(status)`. Enums do
+not carry payloads or convert implicitly to or from integers.
+
+When alternatives need data, use a *structural union* written `A | B`. A union value has one active
+member, and `match` takes it apart. `match` is an expression, so it can produce a value:
 
 ```silk
 pub struct Empty {}
@@ -239,8 +268,8 @@ Points worth noting:
 - `Empty nothing` binds the whole member rather than its fields.
 - `match move state` states the access mode. The alternatives are `match value` (only for copyable
   values), `match &value`, and `match &mut value`.
-- Matches are checked for exhaustiveness. Leaving out `Empty` is a compile error naming the
-  member you missed, so adding a member to a union tells you every place that must change.
+- Matches are checked for exhaustiveness. Leaving out `Empty` or `Status.Done` is a compile error
+  naming the member you missed, so changing an enum or union tells you every match that must change.
 
 ## Effects: failure in the type
 

--- a/apps/docs/content/reference/functions-callables-and-control-flow.md
+++ b/apps/docs/content/reference/functions-callables-and-control-flow.md
@@ -24,7 +24,8 @@ defined by [ownership and borrowing](ownership-and-borrowing.md).
 - A **reachable path** is a possible route through the body that has not already returned, failed,
   diverged, broken, or continued.
 - A **guard** is the optional boolean expression between a match pattern and `=>`.
-- **Coverage** is the set of possible nominal alternatives handled by a match's arms.
+- **Coverage** is the set of possible structural-union members or scalar-enum members handled by a
+  match's arms.
 - **Narrowing** gives a value a more precise type within one proven branch without changing its
   declared type outside that branch.
 


### PR DESCRIPTION
## Summary

- replace the outdated tutorial claim that Silk has no enum support with a scalar enum example
- document the distinction between payload-free scalar enums and payload-carrying structural unions
- correct stale match coverage and union-member terminology in the tutorial, glossary, and reference
- include scalar enums in the language documentation overview

## Verification

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm --filter @silklang/compiler exec vitest run test/DocumentationExamples.test.ts`
- `pnpm check`