### PR TITLE
Update default init project logging example

### DIFF
--- a/packages/cli/src/ProjectInitializer.ts
+++ b/packages/cli/src/ProjectInitializer.ts
@@ -167,8 +167,14 @@ const ignoreBytes = (previous: Uint8Array | undefined): Uint8Array => {
 const manifest = (name: string): string =>
   `[package]\nname = "${name}"\nversion = "0.1.0"\nroot = "src/main.silk"\n`
 
-const entry = `pub effect fn main() -> () {
-  return ()
+const entry = `import silk.effect { Effect }
+import silk.logger { Logger }
+
+pub effect fn main() -> () ! Logger.LogError {
+  let mut logger = Logger.stdoutProvider()
+
+  run Effect.log("Hello, world!")
+    |> Effect.provideMut(&mut logger)
 }
 `
 

--- a/packages/cli/test/Cli.test.ts
+++ b/packages/cli/test/Cli.test.ts
@@ -41,7 +41,7 @@ it.effect(
       assert.strictEqual(Result.isSuccess(initialized), true)
       assert.strictEqual(
         yield* fileSystem.readFileString(`${projectRoot}/src/main.silk`),
-        'pub effect fn main() -> () {\n  return ()\n}\n',
+        'import silk.effect { Effect }\nimport silk.logger { Logger }\n\npub effect fn main() -> () ! Logger.LogError {\n  let mut logger = Logger.stdoutProvider()\n\n  run Effect.log("Hello, world!")\n    |> Effect.provideMut(&mut logger)\n}\n',
       )
       const loaded = yield* execute(['check', '--manifest-path', `${projectRoot}/silk.toml`])
       assert.strictEqual(Result.isSuccess(loaded), true)

--- a/packages/cli/test/ProjectInitializer.test.ts
+++ b/packages/cli/test/ProjectInitializer.test.ts
@@ -25,7 +25,7 @@ it.effect('creates the canonical sparse executable project in a missing child di
     assert.strictEqual(yield* fileSystem.readFileString(`${root}/hello/.gitignore`), '/build/\n')
     assert.strictEqual(
       yield* fileSystem.readFileString(`${root}/hello/src/main.silk`),
-      'pub effect fn main() -> () {\n  return ()\n}\n',
+      'import silk.effect { Effect }\nimport silk.logger { Logger }\n\npub effect fn main() -> () ! Logger.LogError {\n  let mut logger = Logger.stdoutProvider()\n\n  run Effect.log("Hello, world!")\n    |> Effect.provideMut(&mut logger)\n}\n',
     )
     const project = yield* Project.load({ workingDirectory: `${root}/hello` })
     assert.strictEqual(project.entry.module, 'main')


### PR DESCRIPTION
## Summary

- generate new Silk projects with the Effect and Logger imports
- log `Hello, world!` through a mutable stdout logger provider
- update initializer and end-to-end CLI expectations

## Verification

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test` (one scheduler test timed out under full-suite contention; it passed alone)
- `pnpm --dir packages/cli exec vitest run test/ProjectInitializer.test.ts test/Cli.test.ts`
- `pnpm check`