### PR TITLE
fix(llvm): resolve duplicate data-layout specifications last-wins

### DIFF
--- a/packages/llvm/src/DataLayout.ts
+++ b/packages/llvm/src/DataLayout.ts
@@ -221,7 +221,7 @@ const pointer = (component: string): PointerSpec => {
 }
 
 /** @internal */
-const sorted = <A>(values: ReadonlyArray<A>, key: (value: A) => number): ReadonlyArray<A> =>
+const sorted = <A>(values: Iterable<A>, key: (value: A) => number): ReadonlyArray<A> =>
   Object.freeze([...values].sort((left, right) => key(left) - key(right)))
 
 /** @internal */
@@ -235,10 +235,10 @@ const parseUnsafe = (original: ByteString.ByteString): DataLayout => {
   let allocaAddressSpace = AddrSpace.defaultAddrSpace
   let functionPointerAlignment: string | undefined
   let aggregateSpec = empty.aggregate
-  const integers: Array<PrimitiveSpec> = []
-  const floats: Array<PrimitiveSpec> = []
-  const vectors: Array<PrimitiveSpec> = []
-  const pointers: Array<PointerSpec> = []
+  const integers = new Map<number, PrimitiveSpec>()
+  const floats = new Map<number, PrimitiveSpec>()
+  const vectors = new Map<number, PrimitiveSpec>()
+  const pointers = new Map<number, PointerSpec>()
   const nativeIntegerWidths: Array<number> = []
   const nonIntegralAddressSpaces: Array<AddrSpace.AddrSpace> = []
 
@@ -246,13 +246,17 @@ const parseUnsafe = (original: ByteString.ByteString): DataLayout => {
     if (component === 'e' || component === 'E') {
       endian = component === 'e' ? 'little' : 'big'
     } else if (/^i\d+:/.test(component)) {
-      integers.push(primitive(component))
+      const spec = primitive(component)
+      integers.set(spec.bitWidth, spec)
     } else if (/^f\d+:/.test(component)) {
-      floats.push(primitive(component))
+      const spec = primitive(component)
+      floats.set(spec.bitWidth, spec)
     } else if (/^v\d+:/.test(component)) {
-      vectors.push(primitive(component))
+      const spec = primitive(component)
+      vectors.set(spec.bitWidth, spec)
     } else if (/^p\d*:/.test(component)) {
-      pointers.push(pointer(component))
+      const spec = pointer(component)
+      pointers.set(spec.addressSpace.value, spec)
     } else if (/^n\d+(?::\d+)*$/.test(component)) {
       nativeIntegerWidths.push(
         ...component
@@ -290,10 +294,10 @@ const parseUnsafe = (original: ByteString.ByteString): DataLayout => {
     _tag: 'DataLayout',
     original,
     endian,
-    integers: sorted(integers, (value) => value.bitWidth),
-    floats: sorted(floats, (value) => value.bitWidth),
-    vectors: sorted(vectors, (value) => value.bitWidth),
-    pointers: sorted(pointers, (value) => value.addressSpace.value),
+    integers: sorted(integers.values(), (value) => value.bitWidth),
+    floats: sorted(floats.values(), (value) => value.bitWidth),
+    vectors: sorted(vectors.values(), (value) => value.bitWidth),
+    pointers: sorted(pointers.values(), (value) => value.addressSpace.value),
     aggregate: aggregateSpec,
     nativeIntegerWidths: Object.freeze(
       [...nativeIntegerWidths].sort((left, right) => left - right),

--- a/packages/llvm/test/DataLayout.test.ts
+++ b/packages/llvm/test/DataLayout.test.ts
@@ -7,6 +7,26 @@ import * as ByteString from '../src/ByteString.js'
 import * as DataLayout from '../src/DataLayout.js'
 import { LlvmError } from '../src/LlvmError.js'
 
+const primitivePayload = (spec: DataLayout.PrimitiveSpec | undefined) =>
+  spec === undefined
+    ? undefined
+    : {
+        bitWidth: spec.bitWidth,
+        abiAlignment: spec.abiAlignment.byteUnits,
+        preferredAlignment: spec.preferredAlignment.byteUnits,
+      }
+
+const pointerPayload = (spec: DataLayout.PointerSpec | undefined) =>
+  spec === undefined
+    ? undefined
+    : {
+        addressSpace: spec.addressSpace.value,
+        bitWidth: spec.bitWidth,
+        abiAlignment: spec.abiAlignment.byteUnits,
+        preferredAlignment: spec.preferredAlignment.byteUnits,
+        indexBitWidth: spec.indexBitWidth,
+      }
+
 it.effect('parses explicit primitive, pointer, native-width, stack, and non-integral fields', () =>
   Effect.gen(function* () {
     const layout = yield* DataLayout.parse(
@@ -25,6 +45,121 @@ it.effect('parses explicit primitive, pointer, native-width, stack, and non-inte
       layout.nonIntegralAddressSpaces.map((address) => address.value),
       [1, 3],
     )
+  }),
+)
+
+it.effect('matches LLVM 22.1.8 last-wins precedence for repeated keyed specifications', () =>
+  Effect.gen(function* () {
+    const addressOne = yield* AddrSpace.make(1)
+    const cases = [
+      {
+        input:
+          'i32:32:64-i32:64:128-f64:64:128-f64:32:64-v128:128:256-v128:64:128-p:64:64:128:32-p0:32:32:64:16-p1:64:64:128:32-p1:32:32:64:16',
+        primitive: {
+          integer: { bitWidth: 32, abiAlignment: 8n, preferredAlignment: 16n },
+          float: { bitWidth: 64, abiAlignment: 4n, preferredAlignment: 8n },
+          vector: { bitWidth: 128, abiAlignment: 8n, preferredAlignment: 16n },
+        },
+        pointerZero: {
+          addressSpace: 0,
+          bitWidth: 32,
+          abiAlignment: 4n,
+          preferredAlignment: 8n,
+          indexBitWidth: 16,
+        },
+        pointerOne: {
+          addressSpace: 1,
+          bitWidth: 32,
+          abiAlignment: 4n,
+          preferredAlignment: 8n,
+          indexBitWidth: 16,
+        },
+      },
+      {
+        input:
+          'i32:64:128-i32:32:64-f64:32:64-f64:64:128-v128:64:128-v128:128:256-p0:32:32:64:16-p:64:64:128:32-p1:32:32:64:16-p1:64:64:128:32',
+        primitive: {
+          integer: { bitWidth: 32, abiAlignment: 4n, preferredAlignment: 8n },
+          float: { bitWidth: 64, abiAlignment: 8n, preferredAlignment: 16n },
+          vector: { bitWidth: 128, abiAlignment: 16n, preferredAlignment: 32n },
+        },
+        pointerZero: {
+          addressSpace: 0,
+          bitWidth: 64,
+          abiAlignment: 8n,
+          preferredAlignment: 16n,
+          indexBitWidth: 32,
+        },
+        pointerOne: {
+          addressSpace: 1,
+          bitWidth: 64,
+          abiAlignment: 8n,
+          preferredAlignment: 16n,
+          indexBitWidth: 32,
+        },
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      const layout = yield* DataLayout.parse(testCase.input)
+
+      assert.deepEqual(
+        primitivePayload(DataLayout.integerSpec(layout, 32)),
+        testCase.primitive.integer,
+      )
+      assert.deepEqual(primitivePayload(DataLayout.floatSpec(layout, 64)), testCase.primitive.float)
+      assert.deepEqual(
+        primitivePayload(DataLayout.vectorSpec(layout, 128)),
+        testCase.primitive.vector,
+      )
+      assert.deepEqual(pointerPayload(DataLayout.pointerSpec(layout)), testCase.pointerZero)
+      assert.deepEqual(
+        pointerPayload(DataLayout.pointerSpec(layout, addressOne)),
+        testCase.pointerOne,
+      )
+    }
+  }),
+)
+
+it.effect('keeps semantic collections canonical without rewriting the source layout', () =>
+  Effect.gen(function* () {
+    const input =
+      'E-e-m:e-m:o-S64-S128-P1-P2-G3-G4-A5-A6-Fi32-Fn64-n32:64-n8:16-ni:3-ni:1-i64:64-i8:8-i64:128-f64:64-f32:32-f64:128-v128:128-v64:64-v128:256-p2:32:32-p:64:64-p2:64:64'
+    const layout = yield* DataLayout.parse(input)
+
+    assert.strictEqual(layout.endian, 'little')
+    assert.strictEqual(layout.mangling, 'o')
+    assert.strictEqual(layout.stackAlignment.byteUnits, 16n)
+    assert.strictEqual(layout.programAddressSpace.value, 2)
+    assert.strictEqual(layout.globalAddressSpace.value, 4)
+    assert.strictEqual(layout.allocaAddressSpace.value, 6)
+    assert.strictEqual(layout.functionPointerAlignment, 'Fn64')
+    assert.deepEqual(layout.nativeIntegerWidths, [8, 16, 32, 64])
+    assert.deepEqual(
+      layout.nonIntegralAddressSpaces.map((address) => address.value),
+      [1, 3],
+    )
+    assert.deepEqual(
+      layout.integers.map((spec) => spec.bitWidth),
+      [8, 64],
+    )
+    assert.deepEqual(
+      layout.floats.map((spec) => spec.bitWidth),
+      [32, 64],
+    )
+    assert.deepEqual(
+      layout.vectors.map((spec) => spec.bitWidth),
+      [64, 128],
+    )
+    assert.deepEqual(
+      layout.pointers.map((spec) => spec.addressSpace.value),
+      [0, 2],
+    )
+    assert.strictEqual(DataLayout.integerSpec(layout, 64)?.abiAlignment.byteUnits, 16n)
+    assert.strictEqual(DataLayout.floatSpec(layout, 64)?.abiAlignment.byteUnits, 16n)
+    assert.strictEqual(DataLayout.vectorSpec(layout, 128)?.abiAlignment.byteUnits, 32n)
+    assert.strictEqual(DataLayout.pointerSpec(layout, yield* AddrSpace.make(2))?.bitWidth, 64)
+    assert.isTrue(ByteString.equals(DataLayout.render(layout), ByteString.fromString(input)))
   }),
 )
 


### PR DESCRIPTION
## Summary

- replace duplicate integer, float, vector, and pointer data-layout rules by semantic key so the final textual occurrence is authoritative
- keep the public semantic collections immutable and deterministically key-sorted while preserving the original byte-exact layout spelling
- add pinned LLVM 22.1.8 coverage for both source orders, `p` versus `p0`, nonzero address spaces, singleton precedence, and cumulative `n` / `ni` fields
- preserve the aggregate-alignment behavior merged in #291 while rebasing onto current `main`

## Verification

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm check`
- `pnpm release:candidate`

Linear: [JUL-27](https://linear.app/juliaortiz/issue/JUL-27/resolve-duplicate-llvm-primitive-and-pointer-layout-specifications)