### PR TITLE
fix(llvm): match integer alignment and allocation layout

### DIFF
--- a/.changeset/bright-integers-align.md
+++ b/.changeset/bright-integers-align.md
@@ -1,0 +1,7 @@
+---
+'@silklang/llvm': minor
+---
+
+Match LLVM 22.1.8 integer data-layout defaults, explicit overrides, width fallback, and allocation
+padding. Expose source-exact and effective integer specifications separately, and propagate the
+corrected layout through arrays, fixed vectors, and structures.

--- a/openspec/specs/llvm-module-declarations/spec.md
+++ b/openspec/specs/llvm-module-declarations/spec.md
@@ -7,11 +7,19 @@ Allow callers to describe LLVM module types, constants, attributes, and global d
 ## Requirements
 
 ### Requirement: Explicit target and data layout
-The system SHALL accept an explicit target triple and LLVM data-layout string, SHALL parse supported layout components exactly, and SHALL expose layout queries for integer, floating-point, vector, pointer, aggregate, size, and alignment properties. Aggregate alignment SHALL follow the pinned LLVM semantics: an absent rule behaves as `a:0:64`; `a:0` has one-byte ABI and preferred alignment; each encoded alignment MUST fit LLVM's unsigned 16-bit field; an explicit preferred alignment MUST be nonzero, power-of-two, and at least the ABI alignment; and the final repeated aggregate rule is authoritative.
+The system SHALL accept an explicit target triple and LLVM data-layout string, SHALL parse supported layout components exactly, and SHALL expose layout queries for integer, floating-point, vector, pointer, aggregate, size, and alignment properties. Integer alignment SHALL follow the pinned LLVM semantics: effective lookup starts from the default `i8:8:8`, `i16:16:16`, `i32:32:32`, and `i64:32:64` rules; an explicit same-width rule overrides its default; repeated rules use the final entry; lookup selects an exact width, the smallest larger width, or the largest width; and the parsed source entries remain distinguishable from the effective rules. Aggregate alignment SHALL follow the pinned LLVM semantics: an absent rule behaves as `a:0:64`; `a:0` has one-byte ABI and preferred alignment; each encoded alignment MUST fit LLVM's unsigned 16-bit field; an explicit preferred alignment MUST be nonzero, power-of-two, and at least the ABI alignment; and the final repeated aggregate rule is authoritative.
 
 #### Scenario: Parse a valid data layout
 - **WHEN** a caller supplies a supported LLVM data-layout string
 - **THEN** layout queries return the widths, address spaces, ABI alignments, and preferred alignments described by that string
+
+#### Scenario: Resolve effective integer alignment
+- **WHEN** a caller queries an integer width under an empty, endian-only, or sparse-override data layout
+- **THEN** the effective query applies default and final explicit rules before selecting the exact, next-larger, or largest specification, while source-entry queries and rendering remain exact
+
+#### Scenario: Compute arbitrary-width integer allocation layout
+- **WHEN** a caller queries the size or alignment of an arbitrary-width integer, or an array, fixed vector, or structure containing one
+- **THEN** its store size is rounded up to the effective ABI alignment; arrays use that allocation stride, fixed vectors pack element bits and apply exact or natural vector alignment, and structures use the resulting field layout
 
 #### Scenario: Preserve an aggregate rule
 - **WHEN** a caller supplies `a:<abi>[:<preferred>]`

--- a/packages/llvm/src/DataLayout.ts
+++ b/packages/llvm/src/DataLayout.ts
@@ -58,7 +58,10 @@ export interface DataLayout {
   readonly _tag: 'DataLayout'
   readonly original: ByteString.ByteString
   readonly endian: 'little' | 'big' | undefined
+  /** The integer specifications that occur explicitly in the source layout. */
   readonly integers: ReadonlyArray<PrimitiveSpec>
+  /** The effective LLVM integer specifications after explicit same-width overrides. */
+  readonly effectiveIntegers: ReadonlyArray<PrimitiveSpec>
   readonly floats: ReadonlyArray<PrimitiveSpec>
   readonly vectors: ReadonlyArray<PrimitiveSpec>
   readonly pointers: ReadonlyArray<PointerSpec>
@@ -86,6 +89,32 @@ const defaultAggregateSpec: AggregateSpec = Object.freeze({
 })
 
 /** @internal */
+const fixedPrimitiveSpec = (
+  bitWidth: number,
+  abiByteUnits: bigint,
+  preferredByteUnits: bigint,
+): PrimitiveSpec =>
+  Object.freeze({
+    bitWidth,
+    abiAlignment: Object.freeze({ _tag: 'Alignment', byteUnits: abiByteUnits }),
+    preferredAlignment: Object.freeze({
+      _tag: 'Alignment',
+      byteUnits: preferredByteUnits,
+    }),
+  })
+
+/** @internal */
+const defaultLargestIntegerSpec = fixedPrimitiveSpec(64, 4n, 8n)
+
+/** @internal */
+const defaultIntegerSpecs: ReadonlyArray<PrimitiveSpec> = Object.freeze([
+  fixedPrimitiveSpec(8, 1n, 1n),
+  fixedPrimitiveSpec(16, 2n, 2n),
+  fixedPrimitiveSpec(32, 4n, 4n),
+  defaultLargestIntegerSpec,
+])
+
+/** @internal */
 class DataLayoutParseFailure extends Error {
   readonly input: unknown
 
@@ -111,6 +140,7 @@ export const empty: DataLayout = Object.freeze({
   original: ByteString.empty,
   endian: undefined,
   integers: Object.freeze([]),
+  effectiveIntegers: defaultIntegerSpecs,
   floats: Object.freeze([]),
   vectors: Object.freeze([]),
   pointers: Object.freeze([]),
@@ -225,6 +255,15 @@ const sorted = <A>(values: Iterable<A>, key: (value: A) => number): ReadonlyArra
   Object.freeze([...values].sort((left, right) => key(left) - key(right)))
 
 /** @internal */
+const effectiveIntegerSpecs = (
+  explicit: ReadonlyArray<PrimitiveSpec>,
+): ReadonlyArray<PrimitiveSpec> => {
+  const byWidth = new Map(defaultIntegerSpecs.map((spec) => [spec.bitWidth, spec]))
+  for (const spec of explicit) byWidth.set(spec.bitWidth, spec)
+  return sorted(byWidth.values(), (spec) => spec.bitWidth)
+}
+
+/** @internal */
 const parseUnsafe = (original: ByteString.ByteString): DataLayout => {
   if (ByteString.isEmpty(original)) return empty
   let endian: DataLayout['endian']
@@ -290,11 +329,13 @@ const parseUnsafe = (original: ByteString.ByteString): DataLayout => {
     }
   }
 
+  const integerEntries = sorted(integers.values(), (value) => value.bitWidth)
   return Object.freeze({
     _tag: 'DataLayout',
     original,
     endian,
-    integers: sorted(integers.values(), (value) => value.bitWidth),
+    integers: integerEntries,
+    effectiveIntegers: effectiveIntegerSpecs(integerEntries),
     floats: sorted(floats.values(), (value) => value.bitWidth),
     vectors: sorted(vectors.values(), (value) => value.bitWidth),
     pointers: sorted(pointers.values(), (value) => value.addressSpace.value),
@@ -366,13 +407,29 @@ export const parse = Effect.fn('DataLayout.parse')(function* (
 })
 
 /**
- * Finds the exact integer-width rule, without synthesizing a fallback.
+ * Returns the source layout's exact integer-width rule, or `undefined` if the rule is absent.
  *
  * @category data layouts
  * @since 0.0.0
  */
 export const integerSpec = (self: DataLayout, bitWidth: number): PrimitiveSpec | undefined =>
   self.integers.find((spec) => spec.bitWidth === bitWidth)
+
+/**
+ * Returns LLVM's effective integer-width rule after it applies defaults and explicit overrides.
+ *
+ * **Details**
+ *
+ * Exact widths win. Otherwise the smallest larger width is selected, or the largest width when no
+ * larger rule exists.
+ *
+ * @category data layouts
+ * @since 0.0.0
+ */
+export const effectiveIntegerSpec = (self: DataLayout, bitWidth: number): PrimitiveSpec =>
+  self.effectiveIntegers.find((spec) => spec.bitWidth >= bitWidth) ??
+  self.effectiveIntegers.at(-1) ??
+  defaultLargestIntegerSpec
 
 /**
  * Finds the exact floating-point-width rule, without synthesizing a fallback.

--- a/packages/llvm/src/Type.ts
+++ b/packages/llvm/src/Type.ts
@@ -789,22 +789,37 @@ const simpleBitWidth = (tag: TypeDescription.SimpleTag): number | undefined => {
 }
 
 /** @internal */
+const powerOfTwoCeiling = (value: bigint): bigint => {
+  let power = 1n
+  while (power < value) power *= 2n
+  return power
+}
+
+/** @internal */
 const layoutOf = (
   index: number,
   state: BuilderState.MutableState,
   visiting: Set<number>,
-): { readonly size: bigint; readonly alignment: Alignment.Alignment } => {
+): {
+  readonly bitSize: bigint
+  readonly size: bigint
+  readonly alignment: Alignment.Alignment
+} => {
   if (visiting.has(index)) throw new Error('recursive type has no finite inline size')
   visiting.add(index)
   const description = state.types.descriptions[index]
   if (description === undefined) throw new Error('missing type table entry')
   try {
     if (description._tag === 'Integer') {
-      const spec = DataLayout.integerSpec(state.layout, description.bitWidth)
-      const size = BigInt(Math.ceil(description.bitWidth / 8))
+      const spec = DataLayout.effectiveIntegerSpec(state.layout, description.bitWidth)
+      const storeSize = BigInt(Math.ceil(description.bitWidth / 8))
+      const alignment = spec.abiAlignment.byteUnits
+      if (alignment === undefined) throw new Error('effective integer alignment is unspecified')
+      const remainder = storeSize % alignment
       return {
-        size,
-        alignment: spec?.abiAlignment ?? { _tag: 'Alignment', byteUnits: size === 0n ? 1n : size },
+        bitSize: BigInt(description.bitWidth),
+        size: remainder === 0n ? storeSize : storeSize + alignment - remainder,
+        alignment: spec.abiAlignment,
       }
     }
     if (description._tag === 'Simple') {
@@ -812,20 +827,44 @@ const layoutOf = (
       if (bits === undefined) throw new Error(`${description.tag} has no allocatable size`)
       const size = BigInt(Math.ceil(bits / 8))
       const spec = DataLayout.floatSpec(state.layout, bits)
-      return { size, alignment: spec?.abiAlignment ?? { _tag: 'Alignment', byteUnits: size } }
+      return {
+        bitSize: BigInt(bits),
+        size,
+        alignment: spec?.abiAlignment ?? { _tag: 'Alignment', byteUnits: size },
+      }
     }
     if (description._tag === 'Pointer') {
       const spec = DataLayout.pointerSpec(state.layout, description.addressSpace)
       if (spec === undefined) throw new Error('data layout has no pointer specification')
-      return { size: BigInt(Math.ceil(spec.bitWidth / 8)), alignment: spec.abiAlignment }
-    }
-    if (description._tag === 'Array' || description._tag === 'Vector') {
-      if (description._tag === 'Vector' && description.scalable) {
-        throw new Error('scalable vector has no fixed allocation size')
+      return {
+        bitSize: BigInt(spec.bitWidth),
+        size: BigInt(Math.ceil(spec.bitWidth / 8)),
+        alignment: spec.abiAlignment,
       }
+    }
+    if (description._tag === 'Array') {
       const child = layoutOf(description.child, state, visiting)
-      const length = description._tag === 'Array' ? description.length : BigInt(description.length)
-      return { size: child.size * length, alignment: child.alignment }
+      const size = child.size * description.length
+      return { bitSize: size * 8n, size, alignment: child.alignment }
+    }
+    if (description._tag === 'Vector') {
+      if (description.scalable) throw new Error('scalable vector has no fixed allocation size')
+      const child = layoutOf(description.child, state, visiting)
+      const bitSize = child.bitSize * BigInt(description.length)
+      const storeSize = (bitSize + 7n) / 8n
+      const bitWidth = bitSize <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(bitSize) : undefined
+      const vectorSpec =
+        bitWidth === undefined ? undefined : DataLayout.vectorSpec(state.layout, bitWidth)
+      const vectorAlignment: Alignment.Alignment =
+        vectorSpec?.abiAlignment ??
+        Object.freeze({ _tag: 'Alignment', byteUnits: powerOfTwoCeiling(storeSize) })
+      const alignment = vectorAlignment.byteUnits ?? 1n
+      const remainder = storeSize % alignment
+      return {
+        bitSize,
+        size: remainder === 0n ? storeSize : storeSize + alignment - remainder,
+        alignment: vectorAlignment,
+      }
     }
     let body: { readonly fields: ReadonlyArray<number>; readonly packed: boolean } | undefined
     if (description._tag === 'Structure') body = description
@@ -846,6 +885,7 @@ const layoutOf = (
       const remainder = offset % maximumAlignment
       if (remainder !== 0n) offset += maximumAlignment - remainder
       return {
+        bitSize: offset * 8n,
         size: offset,
         alignment: { _tag: 'Alignment', byteUnits: maximumAlignment },
       }

--- a/packages/llvm/test/DataLayout.test.ts
+++ b/packages/llvm/test/DataLayout.test.ts
@@ -121,6 +121,76 @@ it.effect('matches LLVM 22.1.8 last-wins precedence for repeated keyed specifica
   }),
 )
 
+it.effect('matches pinned LLVM 22.1.8 effective integer specifications', () =>
+  Effect.gen(function* () {
+    const completeEmpty = DataLayout.empty
+    const endianOnly = yield* DataLayout.parse('e')
+    const sparseSource = 'e-i16:16:16-i16:32:32-i32:64:64'
+    const sparseOverride = yield* DataLayout.parse(sparseSource)
+
+    assert.deepEqual(completeEmpty.integers, [])
+    assert.deepEqual(endianOnly.integers, [])
+    assert.deepEqual(sparseOverride.integers.map(primitivePayload), [
+      { bitWidth: 16, abiAlignment: 4n, preferredAlignment: 4n },
+      { bitWidth: 32, abiAlignment: 8n, preferredAlignment: 8n },
+    ])
+    assert.isTrue(ByteString.equals(DataLayout.render(completeEmpty), ByteString.empty))
+    assert.isTrue(ByteString.equals(DataLayout.render(endianOnly), ByteString.fromString('e')))
+    assert.isTrue(
+      ByteString.equals(DataLayout.render(sparseOverride), ByteString.fromString(sparseSource)),
+    )
+
+    for (const layout of [completeEmpty, endianOnly]) {
+      assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(layout, 8)), {
+        bitWidth: 8,
+        abiAlignment: 1n,
+        preferredAlignment: 1n,
+      })
+      assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(layout, 9)), {
+        bitWidth: 16,
+        abiAlignment: 2n,
+        preferredAlignment: 2n,
+      })
+      assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(layout, 65)), {
+        bitWidth: 64,
+        abiAlignment: 4n,
+        preferredAlignment: 8n,
+      })
+    }
+
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 8)), {
+      bitWidth: 8,
+      abiAlignment: 1n,
+      preferredAlignment: 1n,
+    })
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 16)), {
+      bitWidth: 16,
+      abiAlignment: 4n,
+      preferredAlignment: 4n,
+    })
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 9)), {
+      bitWidth: 16,
+      abiAlignment: 4n,
+      preferredAlignment: 4n,
+    })
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 24)), {
+      bitWidth: 32,
+      abiAlignment: 8n,
+      preferredAlignment: 8n,
+    })
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 40)), {
+      bitWidth: 64,
+      abiAlignment: 4n,
+      preferredAlignment: 8n,
+    })
+    assert.deepEqual(primitivePayload(DataLayout.effectiveIntegerSpec(sparseOverride, 128)), {
+      bitWidth: 64,
+      abiAlignment: 4n,
+      preferredAlignment: 8n,
+    })
+  }),
+)
+
 it.effect('keeps semantic collections canonical without rewriting the source layout', () =>
   Effect.gen(function* () {
     const input =

--- a/packages/llvm/test/Type.test.ts
+++ b/packages/llvm/test/Type.test.ts
@@ -97,6 +97,83 @@ it.effect('matches pinned LLVM aggregate alignment for structures and arrays', (
   }),
 )
 
+it.effect('matches pinned LLVM 22.1.8 integer allocation size and aggregate propagation', () =>
+  Effect.gen(function* () {
+    const cases = [
+      { name: 'complete empty', dataLayout: '' },
+      { name: 'endian only', dataLayout: 'e' },
+      { name: 'sparse override', dataLayout: 'e-i16:32-i32:64' },
+    ] as const
+
+    for (const testCase of cases) {
+      const builder = yield* Builder.make({ dataLayout: testCase.dataLayout })
+      const i9 = yield* Type.integer(builder, 9)
+      const i24 = yield* Type.integer(builder, 24)
+      const i40 = yield* Type.integer(builder, 40)
+      const i65 = yield* Type.integer(builder, 65)
+
+      const expected =
+        testCase.name === 'sparse override'
+          ? [
+              [4n, 4n],
+              [8n, 8n],
+              [8n, 4n],
+              [12n, 4n],
+            ]
+          : [
+              [2n, 2n],
+              [4n, 4n],
+              [8n, 4n],
+              [12n, 4n],
+            ]
+
+      const types = [i9, i24, i40, i65]
+      for (const [index, type] of types.entries()) {
+        const result = expected[index]
+        assert.isDefined(result, `${testCase.name}: missing expected layout for type ${index}`)
+        assert.strictEqual(yield* Type.sizeOf(builder, type), result[0], testCase.name)
+        assert.strictEqual(
+          (yield* Type.alignmentOf(builder, type)).byteUnits,
+          result[1],
+          testCase.name,
+        )
+      }
+
+      if (testCase.name === 'sparse override') {
+        const array = yield* Type.array(builder, i9, 3)
+        const vector = yield* Type.vector(builder, i9, 3)
+        const naturallyAlignedVector = yield* Type.vector(builder, i9, 8)
+        const explicitVectorBuilder = yield* Builder.make({
+          dataLayout: 'e-i16:32-i32:64-v27:64',
+        })
+        const explicitVectorElement = yield* Type.integer(explicitVectorBuilder, 9)
+        const explicitlyAlignedVector = yield* Type.vector(
+          explicitVectorBuilder,
+          explicitVectorElement,
+          3,
+        )
+        const structure = yield* Type.structure(builder, [i9, i40])
+        assert.strictEqual(yield* Type.sizeOf(builder, array), 12n)
+        assert.strictEqual((yield* Type.alignmentOf(builder, array)).byteUnits, 4n)
+        assert.strictEqual(yield* Type.sizeOf(builder, vector), 4n)
+        assert.strictEqual((yield* Type.alignmentOf(builder, vector)).byteUnits, 4n)
+        assert.strictEqual(yield* Type.sizeOf(builder, naturallyAlignedVector), 16n)
+        assert.strictEqual(
+          (yield* Type.alignmentOf(builder, naturallyAlignedVector)).byteUnits,
+          16n,
+        )
+        assert.strictEqual(yield* Type.sizeOf(explicitVectorBuilder, explicitlyAlignedVector), 8n)
+        assert.strictEqual(
+          (yield* Type.alignmentOf(explicitVectorBuilder, explicitlyAlignedVector)).byteUnits,
+          8n,
+        )
+        assert.strictEqual(yield* Type.sizeOf(builder, structure), 12n)
+        assert.strictEqual((yield* Type.alignmentOf(builder, structure)).byteUnits, 4n)
+      }
+    }
+  }),
+)
+
 it.effect('accepts boundary widths and rejects invalid widths before mutation', () =>
   Effect.gen(function* () {
     const builder = yield* Builder.make()


### PR DESCRIPTION
## Summary

- model LLVM 22.1.8 default and effective integer alignment specifications while preserving source-exact data-layout entries
- round arbitrary-width integer allocation sizes to ABI alignment and propagate corrected layouts through arrays, structures, and fixed vectors
- add pinned oracle coverage, OpenSpec requirements, public documentation, and an `@silklang/llvm` minor changeset

## Verification

- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm check`
- `pnpm release:candidate`
- `openspec validate llvm-module-declarations --type spec --strict --no-interactive`
- `git diff --check`

Linear: [JUL-28](https://linear.app/juliaortiz/issue/JUL-28/match-llvm-integer-alignment-lookup-defaults-and-allocation-size)