### PR TITLE
Reject unsafe HoverContent link destinations

### DIFF
--- a/.changeset/safe-hovers-render.md
+++ b/.changeset/safe-hovers-render.md
@@ -1,0 +1,6 @@
+---
+'@silklang/editor-support': patch
+---
+
+Restrict hover links to normalized HTTP, HTTPS, and mailto destinations and document the DOM-backed
+HoverContent actor.

--- a/openspec/specs/snippet-element/spec.md
+++ b/openspec/specs/snippet-element/spec.md
@@ -66,8 +66,12 @@ failures.
 ### Requirement: Hover presents language-server content safely
 
 When hover is enabled, pointing at source SHALL show the language server's hover content for that
-position, rendered from its CommonMark payload. Links in hover content SHALL only be emitted for
-http, https, and mailto destinations; other schemes SHALL render as plain text.
+position, rendered from its CommonMark payload into a detached DOM node. Links in hover content
+SHALL only be emitted for explicit `http:`, `https:`, and `mailto:` destinations after CommonMark
+entity decoding and ASCII control-character removal. Relative, fragment, protocol-relative, and
+all other destinations SHALL render as plain text. Raw HTML SHALL render literally rather than
+creating authored elements. The renderer SHALL highlight fenced Silk code with the editor's
+classes and SHALL NOT inject standalone CSS.
 
 #### Scenario: Hovering a declaration
 
@@ -77,8 +81,14 @@ http, https, and mailto destinations; other schemes SHALL render as plain text.
 
 #### Scenario: Unsafe link scheme
 
-- **WHEN** hover content contains a link with a non-http(s), non-mailto scheme
+- **WHEN** hover content contains a relative, fragment, protocol-relative, unknown-scheme, or
+  encoded-control destination that does not normalize to an explicit allowed scheme
 - **THEN** the tooltip shows the link text without a hyperlink
+
+#### Scenario: Raw HTML
+
+- **WHEN** hover content contains authored raw HTML
+- **THEN** the tooltip shows that HTML literally and creates no authored element
 
 ### Requirement: Inlay hints render inline
 

--- a/packages/editor-support/README.md
+++ b/packages/editor-support/README.md
@@ -8,6 +8,10 @@ support that can be reused independently of any one application:
   configuration.
 - `@silklang/editor-support/Editor` provides the framework-free CodeMirror editor with diagnostics,
   hover, inlay hints, and UTF-8/UTF-16 position mapping.
+- `@silklang/editor-support` exposes `HoverContent` as a namespace, while
+  `@silklang/editor-support/HoverContent` provides the same actor as a deep import. Its `render`
+  operation converts CommonMark hover payloads into detached DOM, requires a browser-compatible
+  `document`, and leaves tooltip and highlight CSS to the host.
 - `@silklang/editor-support/Element` and `/register` provide the `<silk-snippet>` custom element.
 - `@silklang/editor-support/bundle` resolves to the self-registering browser bundle built for
   generated documentation sites.

--- a/packages/editor-support/src/HoverContent.ts
+++ b/packages/editor-support/src/HoverContent.ts
@@ -1,23 +1,42 @@
-/**
- * Renders one language-server hover's CommonMark payload as plain DOM.
- *
- * Hover content is compiler-authored but flows through Markdown, so links are restricted to
- * http(s) and mailto and every other scheme renders as plain text. Nested `silk` code blocks are
- * highlighted with the same lexer-driven classification the editor uses, so hover code and editor
- * code never disagree.
- */
-
-import type { BlockContent, PhrasingContent, RootContent } from 'mdast'
+import type { BlockContent, Definition, PhrasingContent, RootContent } from 'mdast'
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import * as SilkCodeMirror from './CodeMirror.js'
 
 const safeLink = (destination: string): string | undefined => {
-  const normalized = destination.trim()
-  if (normalized.startsWith('//')) return undefined
-  const scheme = /^([a-z][a-z\d+.-]*):/i.exec(normalized)?.[1]?.toLowerCase()
-  return scheme === undefined || scheme === 'http' || scheme === 'https' || scheme === 'mailto'
-    ? destination
-    : undefined
+  const normalized = Array.from(destination, (character) => {
+    const code = character.charCodeAt(0)
+    return code <= 0x1f || code === 0x7f ? '' : character
+  }).join('')
+  return /^(?:https?|mailto):/i.test(normalized) ? normalized : undefined
+}
+
+interface RenderContext {
+  readonly definitions: ReadonlyMap<string, Definition>
+}
+
+const collectDefinitions = (
+  nodes: ReadonlyArray<RootContent | BlockContent>,
+  definitions: Map<string, Definition>,
+): void => {
+  for (const node of nodes) {
+    switch (node.type) {
+      case 'definition':
+        if (!definitions.has(node.identifier)) definitions.set(node.identifier, node)
+        break
+      case 'blockquote':
+        collectDefinitions(node.children, definitions)
+        break
+      case 'list':
+        for (const item of node.children) collectDefinitions(item.children, definitions)
+        break
+    }
+  }
+}
+
+const context = (nodes: ReadonlyArray<RootContent>): RenderContext => {
+  const definitions = new Map<string, Definition>()
+  collectDefinitions(nodes, definitions)
+  return { definitions }
 }
 
 const element = (tag: string, children: Iterable<Node | string>): HTMLElement => {
@@ -26,45 +45,61 @@ const element = (tag: string, children: Iterable<Node | string>): HTMLElement =>
   return node
 }
 
-const inlines = (children: ReadonlyArray<PhrasingContent>): ReadonlyArray<Node | string> =>
-  children.flatMap((child) => inline(child))
+const anchor = (
+  href: string,
+  title: string | null | undefined,
+  children: Iterable<Node | string>,
+): HTMLAnchorElement => {
+  const node = document.createElement('a')
+  node.href = href
+  if (title !== null && title !== undefined) node.title = title
+  node.rel = 'noreferrer'
+  node.append(...children)
+  return node
+}
 
-const inline = (node: PhrasingContent): ReadonlyArray<Node | string> => {
+const inlines = (
+  context: RenderContext,
+  children: ReadonlyArray<PhrasingContent>,
+): ReadonlyArray<Node | string> => children.flatMap((child) => inline(context, child))
+
+const inline = (context: RenderContext, node: PhrasingContent): ReadonlyArray<Node | string> => {
   switch (node.type) {
     case 'text':
       return [node.value]
     case 'inlineCode':
       return [element('code', [node.value])]
     case 'emphasis':
-      return [element('em', inlines(node.children))]
+      return [element('em', inlines(context, node.children))]
     case 'strong':
-      return [element('strong', inlines(node.children))]
+      return [element('strong', inlines(context, node.children))]
     case 'link': {
       const href = safeLink(node.url)
-      if (href === undefined) return inlines(node.children)
-      const anchor = document.createElement('a')
-      anchor.href = href
-      if (node.title !== null && node.title !== undefined) anchor.title = node.title
-      anchor.rel = 'noreferrer'
-      anchor.append(...inlines(node.children))
-      return [anchor]
+      return href === undefined
+        ? inlines(context, node.children)
+        : [anchor(href, node.title, inlines(context, node.children))]
     }
-    case 'linkReference':
-      return inlines(node.children)
+    case 'linkReference': {
+      const definition = context.definitions.get(node.identifier)
+      const href = definition === undefined ? undefined : safeLink(definition.url)
+      return href === undefined
+        ? inlines(context, node.children)
+        : [anchor(href, definition?.title, inlines(context, node.children))]
+    }
     case 'break':
       return [document.createElement('br')]
     case 'image': {
       const href = safeLink(node.url)
       if (href === undefined) return [node.alt ?? '']
-      const anchor = document.createElement('a')
-      anchor.href = href
-      if (node.title !== null && node.title !== undefined) anchor.title = node.title
-      anchor.rel = 'noreferrer'
-      anchor.append(node.alt ?? '')
-      return [anchor]
+      return [anchor(href, node.title, [node.alt ?? ''])]
     }
-    case 'imageReference':
-      return [node.alt ?? '']
+    case 'imageReference': {
+      const definition = context.definitions.get(node.identifier)
+      const href = definition === undefined ? undefined : safeLink(definition.url)
+      return href === undefined
+        ? [node.alt ?? '']
+        : [anchor(href, definition?.title, [node.alt ?? ''])]
+    }
     case 'html':
       return [node.value]
     default:
@@ -88,12 +123,12 @@ const silk = (value: string): ReadonlyArray<Node | string> => {
   return result
 }
 
-const block = (node: RootContent | BlockContent): Node | undefined => {
+const block = (context: RenderContext, node: RootContent | BlockContent): Node | undefined => {
   switch (node.type) {
     case 'paragraph':
-      return element('p', inlines(node.children))
+      return element('p', inlines(context, node.children))
     case 'heading':
-      return element(`h${node.depth}`, inlines(node.children))
+      return element(`h${node.depth}`, inlines(context, node.children))
     case 'code': {
       const pre = document.createElement('pre')
       if (node.lang !== null && node.lang !== undefined) pre.dataset.language = node.lang
@@ -103,12 +138,12 @@ const block = (node: RootContent | BlockContent): Node | undefined => {
       return pre
     }
     case 'blockquote':
-      return element('blockquote', blocks(node.children))
+      return element('blockquote', blocks(context, node.children))
     case 'list': {
       const list = document.createElement(node.ordered === true ? 'ol' : 'ul')
       if (node.ordered === true && node.start !== null && node.start !== undefined)
         list.setAttribute('start', String(node.start))
-      for (const item of node.children) list.append(element('li', blocks(item.children)))
+      for (const item of node.children) list.append(element('li', blocks(context, item.children)))
       return list
     }
     case 'thematicBreak':
@@ -122,16 +157,40 @@ const block = (node: RootContent | BlockContent): Node | undefined => {
   }
 }
 
-const blocks = (nodes: ReadonlyArray<RootContent | BlockContent>): ReadonlyArray<Node> =>
+const blocks = (
+  context: RenderContext,
+  nodes: ReadonlyArray<RootContent | BlockContent>,
+): ReadonlyArray<Node> =>
   nodes.flatMap((node) => {
-    const rendered = block(node)
+    const rendered = block(context, node)
     return rendered === undefined ? [] : [rendered]
   })
 
-/** Renders the CommonMark payload of one language-server hover into a detached tooltip node. */
+/**
+ * Renders a language-server hover's CommonMark payload into a detached DOM node.
+ *
+ * **When to use**
+ *
+ * Use when a browser host needs the editor's canonical, framework-free hover rendering.
+ *
+ * **Details**
+ *
+ * Links are emitted only for explicit `http:`, `https:`, and `mailto:` destinations after
+ * CommonMark entity decoding and ASCII control-character removal. Other destinations and raw HTML
+ * render as text. Fenced `silk` code receives the same lexer-driven classes as the editor.
+ *
+ * **Gotchas**
+ *
+ * Rendering requires a DOM `document` global. The returned node is detached, and this module does
+ * not inject CSS; the host owns styles for `cm-silk-type-tooltip` and the emitted highlight classes.
+ *
+ * @category converting
+ * @since 0.0.0
+ */
 export const render = (markdown: string): HTMLElement => {
+  const rootContent = fromMarkdown(markdown).children
   const root = document.createElement('div')
   root.className = 'cm-silk-type-tooltip'
-  root.append(...blocks(fromMarkdown(markdown).children))
+  root.append(...blocks(context(rootContent), rootContent))
   return root
 }

--- a/packages/editor-support/src/index.ts
+++ b/packages/editor-support/src/index.ts
@@ -1,5 +1,16 @@
 export * as CodeMirror from './CodeMirror.js'
 export * as Editor from './Editor.js'
 export * as Element from './Element.js'
+/**
+ * DOM-backed CommonMark rendering for language-server hover content.
+ *
+ * **Gotchas**
+ *
+ * Requires a browser-compatible `document` global. The renderer returns detached nodes and does
+ * not bundle or inject tooltip CSS.
+ *
+ * @category converting
+ * @since 0.0.0
+ */
 export * as HoverContent from './HoverContent.js'
 export * as TextMate from './TextMate.js'

--- a/packages/editor-support/test/HoverContent.test.ts
+++ b/packages/editor-support/test/HoverContent.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from 'vitest'
+import { assert, describe, it } from '@effect/vitest'
 import * as HoverContent from '../src/HoverContent.js'
 
 describe('render', () => {
@@ -12,22 +12,58 @@ describe('render', () => {
     assert.include(root.innerHTML, '<p>Allocates <strong>owned storage</strong>')
   })
 
-  it('keeps http links and strips their formatting risks', () => {
-    const root = HoverContent.render('See [the docs](https://example.com "Docs").')
-    const anchor = root.querySelector('a')
-    assert.isNotNull(anchor)
-    assert.strictEqual(anchor?.getAttribute('href'), 'https://example.com')
-    assert.strictEqual(anchor?.getAttribute('rel'), 'noreferrer')
+  it('keeps explicit http, https, and mailto links with safe attributes', () => {
+    const root = HoverContent.render(
+      '[http](http://example.com) [https](https://example.com "Docs") [mail](mailto:hello@example.com) [normalized](h&#10;ttps://normalized.example)',
+    )
+    const anchors = [...root.querySelectorAll('a')]
+    assert.deepEqual(
+      anchors.map((anchor) => anchor.getAttribute('href')),
+      [
+        'http://example.com',
+        'https://example.com',
+        'mailto:hello@example.com',
+        'https://normalized.example',
+      ],
+    )
+    assert.deepEqual(
+      anchors.map((anchor) => anchor.getAttribute('rel')),
+      ['noreferrer', 'noreferrer', 'noreferrer', 'noreferrer'],
+    )
+    assert.strictEqual(anchors[1]?.getAttribute('title'), 'Docs')
   })
 
-  it('renders unsafe link schemes as plain text', () => {
+  it('renders every non-allowlisted destination as plain text after normalization', () => {
     const root = HoverContent.render(
-      'Do not [click](javascript:alert(1)) or [peek](vscode://open) or [drift](//evil.example).',
+      '[relative](guide) [fragment](#topic) [protocol-relative](//evil.example) [unknown](vscode://open) [encoded-control](java&#10;script:alert(1)) [encoded-space](&#32;https://space.example) [non-ASCII-space](&nbsp;https://space.example).',
     )
     assert.isNull(root.querySelector('a'))
-    assert.include(root.textContent ?? '', 'click')
-    assert.include(root.textContent ?? '', 'peek')
-    assert.include(root.textContent ?? '', 'drift')
+    assert.strictEqual(
+      root.textContent,
+      'relative fragment protocol-relative unknown encoded-control encoded-space non-ASCII-space.',
+    )
+  })
+
+  it('applies the same allowlist to CommonMark reference links and images', () => {
+    const root = HoverContent.render(
+      '[docs][safe] [blocked][unsafe] ![diagram][safe-image] ![blocked image][unsafe-image]\n\n[safe]: https://reference.example "Reference"\n[unsafe]: javascript:alert(1)\n[safe-image]: mailto:diagram@example.com\n[unsafe-image]: #fragment',
+    )
+    const anchors = [...root.querySelectorAll('a')]
+    assert.deepEqual(
+      anchors.map((item) => [item.textContent, item.getAttribute('href')]),
+      [
+        ['docs', 'https://reference.example'],
+        ['diagram', 'mailto:diagram@example.com'],
+      ],
+    )
+    assert.strictEqual(anchors[0]?.getAttribute('title'), 'Reference')
+    assert.strictEqual(root.textContent, 'docs blocked diagram blocked image')
+  })
+
+  it('renders authored HTML literally without admitting authored elements', () => {
+    const root = HoverContent.render('<button onclick="alert(1)">press</button>')
+    assert.isNull(root.querySelector('button'))
+    assert.strictEqual(root.textContent, '<button onclick="alert(1)">press</button>')
   })
 
   it('renders lists, quotes, and headings structurally', () => {
@@ -36,5 +72,15 @@ describe('render', () => {
     assert.isNotNull(root.querySelector('blockquote'))
     assert.strictEqual(root.querySelectorAll('li').length, 2)
     assert.isNotNull(root.querySelector('hr'))
+  })
+
+  it('returns detached DOM and leaves styling to the host', () => {
+    const headBefore = document.head.innerHTML
+    const root = HoverContent.render('```silk\npub struct Item\n```')
+    assert.isFalse(root.isConnected)
+    assert.strictEqual(root.className, 'cm-silk-type-tooltip')
+    assert.isNotNull(root.querySelector('.cm-silk-keyword'))
+    assert.isNull(root.querySelector('style, link[rel="stylesheet"]'))
+    assert.strictEqual(document.head.innerHTML, headBefore)
   })
 })


### PR DESCRIPTION
## Outcome

- allow only explicit `http:`, `https:`, and `mailto:` hover destinations after CommonMark entity decoding and ASCII control removal
- resolve CommonMark link and image references through the same first-definition-wins allowlist
- document the DOM-backed root and deep HoverContent API, including detached nodes and host-owned CSS
- align the canonical snippet-element OpenSpec and add a patch changeset

## Acceptance evidence

- relative, fragment, protocol-relative, unknown-scheme, encoded-control, encoded-space, and non-ASCII-whitespace prefixes render as plain text
- allowed inline, autolink-path, reference-link, and reference-image destinations retain safe anchors and attributes
- raw HTML remains literal, Silk fences remain highlighted, returned DOM is detached, and no document-level CSS is injected
- built root and deep exports expose the same renderer and preserve the public JSDoc in declarations
- independent security/contract re-review completed with no remaining findings

## Verification

- `pnpm --filter @silklang/editor-support exec vitest run test/HoverContent.test.ts`
- `pnpm --filter @silklang/editor-support test`
- `pnpm --filter @silklang/lsp test`
- `pnpm exec openspec validate snippet-element --type spec --strict --no-interactive`
- `pnpm typecheck`
- `pnpm exec biome check .`
- `pnpm test`
- `pnpm check`
- `pnpm release:candidate`

No deferred checks. Residual risk is limited to browser URL/DOM differences beyond jsdom; no concrete bypass was found.

Linear: [JUL-60](https://linear.app/juliaortiz/issue/JUL-60/reject-unsafe-hovercontent-link-schemes-and-document-the-public-actor)