### PR TITLE
test(docs,docgen): stop recompiling what another sweep already proves

### DIFF
--- a/apps/docs/app/labs/presets.test.ts
+++ b/apps/docs/app/labs/presets.test.ts
@@ -144,6 +144,8 @@ describe('preset catalog', () => {
     expect(new Set(labels).size).toBe(labels.length)
   })
 
+  // Also the file's wasm32 build gate: this is the only sweep compiling every preset for
+  // wasm32-unknown-unknown, so a preset that cannot build for it fails here.
   it('gives every projected MIR row a unique React key', () => {
     const mirView = viewById('mir')
     expect(mirView).toBeDefined()
@@ -183,11 +185,19 @@ describe('preset catalog', () => {
     expect(presets.some((preset) => preset.label.startsWith('trap · '))).toBe(true)
   })
 
+  // Presets exist to put the compiler in a specific state, including deliberately broken states.
+  // What must never happen is a preset that crashes the driver: a mistranscribed program would
+  // take down whichever pane rendered it. One pass builds every snapshot (so a throw names its
+  // preset) and checks the diagnostic polarity the label advertises.
   it(
-    'keeps fail-prefixed presets as the ones that surface diagnostics',
+    'builds every preset, damaged included, with diagnostics only on fail-prefixed ones',
     () => {
       for (const preset of presets) {
-        const snapshot = snapshotOf(preset)
+        let snapshot: Analysis.Snapshot | undefined
+        expect(() => {
+          snapshot = snapshotOf(preset)
+        }, preset.label).not.toThrow()
+        if (snapshot === undefined) continue
         const hasDiagnostics = Analysis.diagnostics(snapshot).length > 0
         if (preset.label.startsWith('fail · ')) {
           expect(hasDiagnostics, preset.label).toBe(true)
@@ -196,7 +206,7 @@ describe('preset catalog', () => {
         }
       }
     },
-    60_000,
+    120_000,
   )
 
   it('roots every preset at a module it actually defines', () => {
@@ -205,36 +215,22 @@ describe('preset catalog', () => {
     }
   })
 
-  // Presets exist to put the compiler in a specific state, including deliberately broken states.
-  // What must never happen is a preset that crashes the driver: a mistranscribed program would
-  // take down whichever pane rendered it.
-  it(
-    'builds a snapshot for every preset, damaged programs included',
-    () => {
-      for (const preset of presets) {
-        expect(() => snapshotOf(preset), preset.label).not.toThrow()
-      }
-    },
-    60_000,
-  )
-
   // Lowering is target-aware, so a preset that builds for one target is not evidence it builds
-  // for the rest — and the workbench lets any target be selected against any preset.
+  // for the rest — and the workbench lets any target be selected against any preset. Only the two
+  // targets no other test compiles are built here: every preset already builds for
+  // x86_64-unknown-linux-gnu (the compiler default the diagnostics sweep uses) and for
+  // wasm32-unknown-unknown (the MIR React-key sweep), so all four selectable targets stay covered
+  // across the file without any preset compiling twice for the same target.
   it(
     'builds a snapshot for every preset against every selectable target',
     () => {
-      for (const target of [
-        'aarch64-apple-darwin',
-        'x86_64-unknown-linux-gnu',
-        'aarch64-unknown-linux-gnu',
-        'wasm32-unknown-unknown',
-      ]) {
+      for (const target of ['aarch64-apple-darwin', 'aarch64-unknown-linux-gnu']) {
         for (const preset of presets) {
           expect(() => snapshotOf(preset, target), `${preset.label} · ${target}`).not.toThrow()
         }
       }
     },
-    360_000,
+    240_000,
   )
 
   it('keeps the phases the labs shipped presets for', () => {

--- a/packages/docgen/test/Stdlib.test.ts
+++ b/packages/docgen/test/Stdlib.test.ts
@@ -2,6 +2,7 @@ import { assert, it } from '@effect/vitest'
 import * as CompilerStdlib from '@silklang/compiler/Stdlib'
 import * as Effect from 'effect/Effect'
 import * as Doctest from '../src/Doctest.js'
+import * as Example from '../src/Example.js'
 import * as Json from '../src/Json.js'
 import * as Report from '../src/Report.js'
 import * as Stdlib from '../src/Stdlib.js'
@@ -88,25 +89,12 @@ it.effect(
     Effect.gen(function* () {
       const documentation = yield* stdlibDocumentation
       const parsed: unknown = JSON.parse(Json.encode(documentation))
-      const live = yield* liveReport
-      const roundTripped = yield* Doctest.run({
-        documentation: parsed,
-        sources: Stdlib.sources,
-      })
-      assert.deepStrictEqual(
-        {
-          collected: roundTripped.collected,
-          passed: roundTripped.passed,
-          skipped: roundTripped.skipped,
-          failed: roundTripped.failed,
-        },
-        {
-          collected: live.collected,
-          passed: live.passed,
-          skipped: live.skipped,
-          failed: live.failed,
-        },
-      )
+      // Compiling an example is a pure function of the collected example, and the live sweep
+      // above already compiled every one — the round trip has to prove only that collection reads
+      // the same examples out of what `silk doc` writes as out of the live value.
+      const roundTripped = Example.collect(parsed)
+      assert.isAbove(roundTripped.length, 0)
+      assert.deepStrictEqual(roundTripped, Example.collect(documentation))
     }),
   180_000,
 )


### PR DESCRIPTION
## Summary

Two of the slowest remaining non-compiler test files were re-doing full compilations another test in the same file had already performed.

## labs `presets.test.ts` — 373s (ranked, one sweep regularly timing out) → **137s isolated, 27/27 pass**

- The damaged-programs and diagnostics sweeps compiled every preset separately at the same default target; they're one pass now (a throw still names its preset).
- The selectable-target matrix builds only the two aarch64 targets: the diagnostics pass already builds every preset for the default `x86_64-unknown-linux-gnu`, and the MIR React-key sweep builds every preset for `wasm32-unknown-unknown` — so all four selectable targets stay covered per preset, with no preset compiling twice for the same target.
- A shared snapshot cache was tried first and OOM-killed the vitest worker: retaining 100 realized snapshots is heavier than recompiling. The final shape retains nothing.

## docgen `Stdlib.test.ts` — 88s → **29s isolated**

The JSON round-trip test re-ran the whole doctest sweep. Compiling an example is a pure function of the collected example, and the live sweep already compiled every one — so the round trip now compares `Example.collect(JSON.parse(Json.encode(docs)))` against `Example.collect(docs)`: the same guarantee about what `silk doc` writes, zero compiles, sub-40ms.

## Verification

labs 27/27, docgen 3/3, biome + both package typechecks clean.