### PR TITLE
test(compiler): make temporary-directory fixtures cacheable and give gate-flaky tests headroom

### DIFF
--- a/packages/compiler/test/IntrinsicCatalog.test.ts
+++ b/packages/compiler/test/IntrinsicCatalog.test.ts
@@ -404,7 +404,9 @@ it.effect(
       )
       assert.deepEqual([...observed].sort(), [...catalog].sort())
     }),
-  60_000,
+  // Measured near the 60s floor while the full parallel gate saturates the host; the timeout
+  // is headroom for contention, not a performance assertion.
+  180_000,
 )
 
 it.effect('keeps every intrinsic identifiable and presentable in rejected calls', () =>

--- a/packages/compiler/test/LexerPressure.test.ts
+++ b/packages/compiler/test/LexerPressure.test.ts
@@ -410,7 +410,9 @@ it.effect(
       }
       assert.deepEqual([...covered].sort(), [...tokenKinds].sort())
     }),
-  60_000,
+  // Measured near the 60s floor while the full parallel gate saturates the host; the timeout
+  // is headroom for contention, not a performance assertion.
+  180_000,
 )
 
 it.effect('publishes only general MIR operations for the pressure program', () =>

--- a/packages/compiler/test/LocalSharedPressure.test.ts
+++ b/packages/compiler/test/LocalSharedPressure.test.ts
@@ -979,7 +979,9 @@ it.effect(
         }
       }
     }),
-  60_000,
+  // Measured near the 60s floor while the full parallel gate saturates the host; the timeout
+  // is headroom for contention, not a performance assertion.
+  180_000,
 )
 
 const actorNeutralFixtures = [

--- a/packages/compiler/test/OwnedAllocationAcceptance.test.ts
+++ b/packages/compiler/test/OwnedAllocationAcceptance.test.ts
@@ -1396,6 +1396,9 @@ pub fn main() -> i32 { return 0 }`,
         assert.throws(() => Analysis.loweredMir(snapshot), /MIR is unavailable/)
     }
   }),
+  // Measured near the 60s floor while the full parallel gate saturates the host; the timeout
+  // is headroom for contention, not a performance assertion.
+  180_000,
 )
 
 /**

--- a/packages/compiler/test/OwnedAllocationAcceptance.test.ts
+++ b/packages/compiler/test/OwnedAllocationAcceptance.test.ts
@@ -1141,12 +1141,14 @@ pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`
  * otherwise surface as a trap — or as undefined behaviour in a released backend — rather than
  * as a compile error.
  */
-it.effect('rejects every prohibited allocation shape before lowering', () =>
-  Effect.gen(function* () {
-    const cases: ReadonlyArray<readonly [string, string, string]> = [
-      [
-        'local-shared-layout-provenance-mismatch',
-        `import silk.allocator { OutOfMemoryError }
+it.effect(
+  'rejects every prohibited allocation shape before lowering',
+  () =>
+    Effect.gen(function* () {
+      const cases: ReadonlyArray<readonly [string, string, string]> = [
+        [
+          'local-shared-layout-provenance-mismatch',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 effect fn store() -> i32 ! OutOfMemoryError {
   let layout = Intrinsic.sharedLayout<i64>()
@@ -1159,11 +1161,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-ordinary-layout',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-ordinary-layout',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 import silk.layout { Layout }
 effect fn store() -> i32 ! OutOfMemoryError {
@@ -1177,11 +1179,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-helper-provenance-mismatch',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-helper-provenance-mismatch',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 fn forward(allocation: Allocation) -> Allocation { return move allocation }
 effect fn store() -> i32 ! OutOfMemoryError {
@@ -1196,11 +1198,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-conditional-helper-provenance-mismatch',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-conditional-helper-provenance-mismatch',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 fn choose(flag: bool, wrong: Allocation, right: Allocation) -> Allocation {
   if flag {
@@ -1224,11 +1226,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-provider-forges-provenance',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-provider-forges-provenance',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 import silk.layout { Layout }
 service Forge {
@@ -1253,11 +1255,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-same-spelling-layout',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-same-spelling-layout',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 import silk.layout { Layout }
 fn sharedLayout() -> Layout { return Layout.of<i32>() }
@@ -1272,11 +1274,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0138',
-      ],
-      [
-        'local-shared-outside-unsafe',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0138',
+        ],
+        [
+          'local-shared-outside-unsafe',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 effect fn store() -> i32 ! OutOfMemoryError {
   let layout = Intrinsic.sharedLayout<i32>()
@@ -1287,11 +1289,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0082',
-      ],
-      [
-        'local-shared-reuses-consumed-allocation',
-        `import silk.allocator { OutOfMemoryError }
+          'SEM0082',
+        ],
+        [
+          'local-shared-reuses-consumed-allocation',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 effect fn store() -> i32 ! OutOfMemoryError {
   let layout = Intrinsic.sharedLayout<i32>()
@@ -1305,11 +1307,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'OWN0001',
-      ],
-      [
-        'local-shared-reuses-consumed-payload',
-        `import silk.allocator { OutOfMemoryError }
+          'OWN0001',
+        ],
+        [
+          'local-shared-reuses-consumed-payload',
+          `import silk.allocator { OutOfMemoryError }
 import silk.effect as Effect
 effect fn store() -> i32 ! OutOfMemoryError {
   let blockLayout = Intrinsic.sharedLayout<Allocation>()
@@ -1325,11 +1327,11 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'OWN0001',
-      ],
-      [
-        'raw-storage-outside-unsafe',
-        `import silk.allocator { Allocator }
+          'OWN0001',
+        ],
+        [
+          'raw-storage-outside-unsafe',
+          `import silk.allocator { Allocator }
 import silk.allocator { OutOfMemoryError }
 import silk.allocator { SystemAllocator }
 import silk.effect as Effect
@@ -1345,57 +1347,57 @@ effect fn store() -> i32 ! OutOfMemoryError {
 }
 effect fn recover(error: OutOfMemoryError) -> i32 { return 0 }
 pub fn main() -> i32 { return run Effect.catchAll(store(), recover) }`,
-        'SEM0082',
-      ],
-      [
-        'slot-escapes-its-buffer',
-        guarded(`    let slot = RawBuffer.slot(&mut buffer, 0)
+          'SEM0082',
+        ],
+        [
+          'slot-escapes-its-buffer',
+          guarded(`    let slot = RawBuffer.slot(&mut buffer, 0)
     drop buffer
     let value = Slot.take(move slot)
     return value`),
-        'OWN0011',
-      ],
-      [
-        'buffer-moves-under-a-live-slot',
-        guarded(`    let slot = RawBuffer.slot(&mut buffer, 0)
+          'OWN0011',
+        ],
+        [
+          'buffer-moves-under-a-live-slot',
+          guarded(`    let slot = RawBuffer.slot(&mut buffer, 0)
     let moved = move buffer
     drop moved
     return 1`),
-        'OWN0011',
-      ],
-      [
-        'foreign-allocator-conformance',
-        `import silk.allocator { Allocator }
+          'OWN0011',
+        ],
+        [
+          'foreign-allocator-conformance',
+          `import silk.allocator { Allocator }
 struct TestAllocator { remaining: i32 }
 impl Allocator for TestAllocator { allocate: Foreign.allocate }
 pub fn main() -> i32 { return 0 }`,
-        'SEM0083',
-      ],
-      [
-        'drop-hook-on-a-copy-type',
-        `struct CopyValue { value: i32 }
+          'SEM0083',
+        ],
+        [
+          'drop-hook-on-a-copy-type',
+          `struct CopyValue { value: i32 }
 impl Copy for CopyValue {}
 impl Drop for CopyValue { fn drop(self: &mut CopyValue) -> () { return () } }
 pub fn main() -> i32 { return 0 }`,
-        'SEM0083',
-      ],
-    ]
+          'SEM0083',
+        ],
+      ]
 
-    for (const [name, source, code] of cases) {
-      const snapshot = yield* Analysis.ofSourceRealized(
-        `owned-allocation-negative/${name}`,
-        ascii(source),
-        'wasm32-unknown-unknown',
-      )
-      assert.include(
-        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-        code,
-        `${name}\n${Hir.encode(Analysis.rootAnalysis(snapshot).hir)}`,
-      )
-      if (code === 'SEM0138')
-        assert.throws(() => Analysis.loweredMir(snapshot), /MIR is unavailable/)
-    }
-  }),
+      for (const [name, source, code] of cases) {
+        const snapshot = yield* Analysis.ofSourceRealized(
+          `owned-allocation-negative/${name}`,
+          ascii(source),
+          'wasm32-unknown-unknown',
+        )
+        assert.include(
+          Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+          code,
+          `${name}\n${Hir.encode(Analysis.rootAnalysis(snapshot).hir)}`,
+        )
+        if (code === 'SEM0138')
+          assert.throws(() => Analysis.loweredMir(snapshot), /MIR is unavailable/)
+      }
+    }),
   // Measured near the 60s floor while the full parallel gate saturates the host; the timeout
   // is headroom for contention, not a performance assertion.
   180_000,

--- a/packages/compiler/test/TemporaryDirectoryAcceptance.test.ts
+++ b/packages/compiler/test/TemporaryDirectoryAcceptance.test.ts
@@ -62,6 +62,63 @@ pub fn main() -> i32 {
 }`
 
 /**
+ * The native programs read their confined root from SILK_TEST_ROOT at runtime instead of baking
+ * the test run's mkdtemp path into the source text. A per-run path in the source made every
+ * compilation byte-unique, so the content-addressed emission and executable caches could never
+ * hit; with a stable source they hit on every warm run.
+ */
+const nativeRootResolution = `import silk.bytes { Bytes, asSlice as rootSlice }
+import silk.host_input { HostInputError, inputFailure, variableNamed }
+import silk.option { Option }
+import silk.os_host_input as OsHostInput
+import silk.string { InvalidUtf8, String, copy as stringCopy, copyUtf8 as stringCopyUtf8, view as stringView }
+
+effect fn missingRoot() -> Bytes ! HostInputError {
+  fail inputFailure()
+}
+
+effect fn requiredRoot(found: Option<Bytes>) -> Bytes ! HostInputError {
+  return match move found {
+    Option<Bytes>.Some { value: bytes } => move bytes
+    Option<Bytes>.None => run missingRoot()
+  }
+}
+
+/// A root that is not valid UTF-8 is a harness defect, not a program outcome; trap like osMake
+/// does for its own malformed-root preconditions.
+effect fn invalidRoot() -> String ! OutOfMemoryError ? &mut Allocator {
+  let invalid = 1 / 0
+  return run stringCopy("/")
+}
+
+effect fn confinedRootString() -> String ! HostInputError | OutOfMemoryError ? &mut Allocator {
+  let mut hostInput = OsHostInput.make()
+  let found = run Effect.provideMut(variableNamed("SILK_TEST_ROOT"), &mut hostInput)
+  let rootBytes = run requiredRoot(move found)
+  let copied = run stringCopyUtf8(rootSlice(&rootBytes))
+  return match move copied {
+    Result<String, InvalidUtf8>.Success { value } => move value
+    Result<String, InvalidUtf8>.Failure { error } => run invalidRoot()
+  }
+}`
+
+const nativeEpilogue = `import silk.allocator { OutOfMemoryError }
+import silk.filesystem { FileError }
+import silk.host_input { HostInputError }
+import silk.result { Result }
+pub fn main() -> i32 {
+  let completed = run Effect.result(program())
+  return match move completed {
+      Result<i32, FileError | OutOfMemoryError | HostInputError>.Success { value } => value
+      Result<i32, FileError | OutOfMemoryError | HostInputError>.Failure { error } => match move error {
+        FileError failure => 100 + failure.reason.code
+        OutOfMemoryError exhausted => 99
+        HostInputError missing => 98
+      }
+  }
+}`
+
+/**
  * The whole lifecycle against a real confined root. Each numbered return is one acceptance
  * criterion, so a native exit status names which one failed rather than merely that one did.
  */
@@ -73,10 +130,12 @@ import silk.filesystem { FileError }
 import silk.filesystem { FileSystem }
 import silk.u8 as u8
 ${prelude}
+${nativeRootResolution}
 
-effect fn program() -> i32 ! FileError | OutOfMemoryError {
+effect fn program() -> i32 ! FileError | OutOfMemoryError | HostInputError {
   let mut allocator = Allocator.systemAllocatorProvider()
-  let mut fs = run osMake("${nativeRoot}") |> Effect.provideMut(&mut allocator)
+  let root = run confinedRootString() |> Effect.provideMut(&mut allocator)
+  let mut fs = run osMake(stringView(&root)) |> Effect.provideMut(&mut allocator)
   let parent = run pathMake("/scopes") |> Effect.provideMut(&mut allocator)
   let prepared = run Intrinsic.bindRequirementMut(
     Intrinsic.bindRequirementMut(createDirectoriesRecursively(&parent), &mut fs),
@@ -113,7 +172,7 @@ effect fn program() -> i32 ! FileError | OutOfMemoryError {
   return 42
 }
 
-${epilogue}`
+${nativeEpilogue}`
 
 /**
  * Recursive removal against a real populated tree. `release` removes contents, not just an empty
@@ -126,10 +185,12 @@ import silk.allocator { SystemAllocator }
 import silk.effect as Effect
 import silk.filesystem { FileError }
 ${prelude}
+${nativeRootResolution}
 
-effect fn program() -> i32 ! FileError | OutOfMemoryError {
+effect fn program() -> i32 ! FileError | OutOfMemoryError | HostInputError {
   let mut allocator = Allocator.systemAllocatorProvider()
-  let mut fs = run osMake("${nativeRoot}") |> Effect.provideMut(&mut allocator)
+  let root = run confinedRootString() |> Effect.provideMut(&mut allocator)
+  let mut fs = run osMake(stringView(&root)) |> Effect.provideMut(&mut allocator)
   let target = run pathMake("/tree") |> Effect.provideMut(&mut allocator)
   let removed = run Intrinsic.bindRequirementMut(
     Intrinsic.bindRequirementMut(removeDirectoryRecursively(&target), &mut fs),
@@ -138,7 +199,7 @@ effect fn program() -> i32 ! FileError | OutOfMemoryError {
   return 42
 }
 
-${epilogue}`
+${nativeEpilogue}`
 
 /**
  * Several populated scopes, each released while the others are still owned. This is the shape that
@@ -154,10 +215,12 @@ import silk.filesystem { FileError }
 import silk.filesystem { FileSystem }
 import silk.u8 as u8
 ${prelude}
+${nativeRootResolution}
 
-effect fn program() -> i32 ! FileError | OutOfMemoryError {
+effect fn program() -> i32 ! FileError | OutOfMemoryError | HostInputError {
   let mut allocator = Allocator.systemAllocatorProvider()
-  let mut fs = run osMake("${nativeRoot}") |> Effect.provideMut(&mut allocator)
+  let root = run confinedRootString() |> Effect.provideMut(&mut allocator)
+  let mut fs = run osMake(stringView(&root)) |> Effect.provideMut(&mut allocator)
   let parent = run pathMake("/many") |> Effect.provideMut(&mut allocator)
   let prepared = run Intrinsic.bindRequirementMut(
     Intrinsic.bindRequirementMut(createDirectoriesRecursively(&parent), &mut fs),
@@ -191,7 +254,7 @@ ${[0, 1, 2]
   return 42
 }
 
-${epilogue}`
+${nativeEpilogue}`
 
 /**
  * The provider protocol on the evaluator: the provider chooses the name, so the created name comes
@@ -254,7 +317,10 @@ it.effect(
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
       if (compiled._tag !== 'Compiled') return
-      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      const run = spawnSync(compiled.path, [], {
+        encoding: 'utf8',
+        env: { ...process.env, SILK_TEST_ROOT: nativeRoot },
+      })
       assert.strictEqual(
         run.status,
         42,
@@ -290,7 +356,10 @@ it.effect(
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
       if (compiled._tag !== 'Compiled') return
-      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      const run = spawnSync(compiled.path, [], {
+        encoding: 'utf8',
+        env: { ...process.env, SILK_TEST_ROOT: nativeRoot },
+      })
       assert.strictEqual(run.status, 42, JSON.stringify({ signal: run.signal, stderr: run.stderr }))
       // The file, the nested directory's file, the nested directory, and the directory itself.
       assert.isFalse(existsSync(join(nativeRoot, 'tree')))
@@ -317,7 +386,10 @@ it.effect(
       }).pipe(Effect.provide(SourceResolver.empty))
       assert.strictEqual(compiled._tag, 'Compiled', JSON.stringify(compiled).slice(0, 2500))
       if (compiled._tag !== 'Compiled') return
-      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      const run = spawnSync(compiled.path, [], {
+        encoding: 'utf8',
+        env: { ...process.env, SILK_TEST_ROOT: nativeRoot },
+      })
       // Before #130 was fixed this trapped (SIGILL) even at -O0: a cleanup arm's reloaded lanes
       // escaped into the arm's join block, so the join read an undefined union tag and fell
       // through to the invalid-tag trap. The status, not just the absence of a crash, is what


### PR DESCRIPTION
## Summary

**TemporaryDirectoryAcceptance** was the one heavy suite the backend emission cache could never help: its native fixtures interpolated the run's `mkdtemp` path into the source text, so every run compiled a byte-unique program — permanently cold for both the emission cache and the executable cache.

The three native programs now read their confined root from `SILK_TEST_ROOT` at runtime through `HostInput` (owned `String` copy of the environment value via `copyUtf8`; a non-UTF-8 root traps, the same stance `osMake` takes on its own malformed-root preconditions), and the tests pass the root in the spawn environment. The failure row gains `HostInputError` with a dedicated exit status (98) in the native epilogue.

With byte-stable sources, warm runs skip emission and Clang entirely:

| | before (every run) | after (warm) |
|---|---|---|
| whole file | ~57–67s | **~16s** |
| native-many test | ~30s | **3.9s** |

Under the full parallel gate this file measured ~4 minutes; that now happens only on the first run after a compiler change.

## Timeout headroom

Four tests measured within noise of the 60s default while the gate saturates the host and were reported as timeouts there (`[failed]` at exactly ~60s in the rank report): LexerPressure's canonical-lexer corpus, OwnedAllocationAcceptance's prohibited-shape sweep, LocalSharedPressure's pay-for-use tiers, and IntrinsicCatalog's presentation pairing. Each now carries an explicit 180s ceiling with the workspace's usual rationale comment — headroom for contention, not a performance assertion.

## Verification

TemporaryDirectoryAcceptance 6/6 (cold and warm), OwnedAllocationAcceptance + IntrinsicCatalog 33/33, biome + test typecheck clean.