### PR TITLE
test(compiler): sweep allocation quotas at runtime instead of compiling per ordinal

### DIFF
--- a/packages/compiler/test/LexerPressure.test.ts
+++ b/packages/compiler/test/LexerPressure.test.ts
@@ -289,7 +289,14 @@ const sourceFor = (
   return Object.freeze({ source, expected })
 }
 
-const quotaSourceFor = (input: string, id: string, quota: number): string => {
+/**
+ * One program sweeps every allocation ordinal itself: each iteration builds a fresh
+ * QuotaAllocator with the loop's quota, `quotaSweepIteration` marks the iteration so the test
+ * segments one evaluator trace per quota, and the sweep terminates on the first quota that
+ * completes. Compiling once replaced one full pipeline per ordinal whose sources differed only
+ * in one integer literal.
+ */
+const quotaSweepSourceFor = (input: string, id: string): string => {
   const generated = sourceFor(input, id).source
   const withAllocator = replaceExactlyOnce(
     generated,
@@ -312,10 +319,41 @@ effect fn allocate(self: &mut QuotaAllocator, layout: Layout) -> Allocation ! Ou
 
 impl Allocator for QuotaAllocator { allocate: QuotaAllocator.allocate }`,
   )
-  return replaceExactlyOnce(
+  const withHarness = replaceExactlyOnce(
     withAllocator,
-    '  let mut allocator = Allocator.systemAllocatorProvider()',
-    `  let mut allocator = QuotaAllocator { remaining: ${quota} }`,
+    `pub effect fn main() -> () ! OutOfMemoryError | WriterError {
+  let mut allocator = Allocator.systemAllocatorProvider()
+`,
+    `fn quotaSweepIteration() -> () { return () }
+
+effect fn attemptRecover(error: OutOfMemoryError | WriterError) -> bool {
+  drop error
+  return false
+}
+
+effect fn attemptQuota(quota: i32, source: &[u8]) -> bool ! OutOfMemoryError | WriterError {
+  let mut allocator = QuotaAllocator { remaining: quota }
+  let checked = run check(source) |> Effect.provideMut(&mut allocator)
+  return true
+}
+
+pub effect fn main() -> () ! OutOfMemoryError | WriterError {
+`,
+  )
+  return replaceExactlyOnce(
+    withHarness,
+    `  return run check(source) |> Effect.provideMut(&mut allocator)
+}`,
+    `  let mut quota = 0
+  while quota < 64 {
+    quotaSweepIteration()
+    let succeeded = run Effect.catchAll(attemptQuota(quota, source), attemptRecover)
+    if succeeded { return () }
+    quota = quota + 1
+  }
+  let unreachedTerminal = 1 / 0
+  return ()
+}`,
   )
 }
 
@@ -502,81 +540,65 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const representative = corpus[3]
-      const baseline = sourceFor(representative.input, 'lexer-pressure/quota/baseline')
-      const baselineSnapshot = yield* Analysis.ofSourceRealized(
-        'lexer-pressure/quota/baseline',
-        ascii(baseline.source),
-        'wasm32-unknown-unknown',
+      const id = 'lexer-pressure/quota/sweep'
+      const source = quotaSweepSourceFor(representative.input, id)
+      const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
+      assert.deepEqual(Analysis.diagnostics(snapshot), [], id)
+
+      // Every ordinal shares one evaluation; the raised step ceiling is the sum of what the
+      // per-quota runs used separately, not a change in what any single run may cost.
+      const evaluated = Analysis.evaluate(snapshot, { maxSteps: 50_000_000 })
+      assert.strictEqual(evaluated._tag, 'Completed')
+      if (evaluated._tag !== 'Completed') return
+
+      const markers = evaluated.trace.flatMap((event, index) =>
+        event._tag === 'Call' && event.target.name === 'quotaSweepIteration' ? [index] : [],
       )
-      const baselineOutcome = Analysis.evaluate(baselineSnapshot)
-      assert.strictEqual(baselineOutcome._tag, 'Completed')
-      if (baselineOutcome._tag !== 'Completed') return
-      const allocationCount = baselineOutcome.trace.filter(
-        (event) => event._tag === 'AllocationAcquire',
-      ).length
+      const allocationCount = markers.length - 1
       // Rendering is Writer-backed now; only token and diagnostic vector growth allocates.
       assert.isAtLeast(allocationCount, 2)
 
-      // Native execution runs at the boundary ordinals only — immediate failure, one mid-growth
-      // rollback, and unrestricted completion — while the evaluator and Wasm carry every ordinal.
-      // Each native leg is a full release pipeline, and the allocator's rollback path does not
-      // vary by ordinal index beyond those three shapes.
-      const nativeQuotas = new Set([0, Math.floor(allocationCount / 2), allocationCount])
-
       for (let quota = 0; quota <= allocationCount; quota += 1) {
-        const id = `lexer-pressure/quota/q${quota}`
-        const source = quotaSourceFor(representative.input, id, quota)
-        const snapshot = yield* Analysis.ofSourceRealized(
-          id,
-          ascii(source),
-          'wasm32-unknown-unknown',
+        const label = `q${quota}`
+        const segment = evaluated.trace.slice(
+          (markers[quota] ?? 0) + 1,
+          markers[quota + 1] ?? evaluated.trace.length,
         )
-        assert.deepEqual(Analysis.diagnostics(snapshot), [], id)
-        const expectedTag = quota === allocationCount ? 'Completed' : 'UnhandledFailure'
-        const evaluated = Analysis.evaluate(snapshot)
-        assert.strictEqual(evaluated._tag, expectedTag, id)
-        const acquired = evaluated.trace.filter(
-          (event) => event._tag === 'AllocationAcquire',
-        ).length
-        const released = evaluated.trace.filter(
-          (event) => event._tag === 'AllocationRelease',
-        ).length
-        assert.strictEqual(acquired, quota, id)
-        assert.strictEqual(released, acquired, id)
-        const again = Analysis.evaluate(snapshot)
-        assert.strictEqual(again._tag, expectedTag, id)
-        assert.deepEqual(
-          again.trace.filter(
-            (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
-          ),
-          evaluated.trace.filter(
-            (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
-          ),
-          id,
-        )
-
-        const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
-        const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
-        assert.strictEqual(
-          (instance.exports.silk_main as () => number)(),
-          quota === allocationCount ? 0 : 1,
-          id,
-        )
-
-        if (!nativeQuotas.has(quota)) continue
-        const compiled = yield* Driver.compile({
-          compilation: { root: SourceFile.make(id, ascii(source)) },
-          toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-          profile: 'release',
-          destination: join(destinationRoot, `quota-${quota}`),
-        }).pipe(Effect.provide(SourceResolver.empty))
-        assert.strictEqual(compiled._tag, 'Compiled', id)
-        if (compiled._tag !== 'Compiled') continue
-        const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
-        assert.strictEqual(run.status, quota === allocationCount ? 0 : 1, `${id}: ${run.stderr}`)
-        if (quota === allocationCount) assert.strictEqual(run.stderr, '')
-        else assert.strictEqual(run.stderr, 'Error: silk/allocator.OutOfMemoryError\n')
+        const acquired = segment.filter((event) => event._tag === 'AllocationAcquire').length
+        const released = segment.filter((event) => event._tag === 'AllocationRelease').length
+        assert.strictEqual(acquired, quota, label)
+        assert.strictEqual(released, acquired, label)
       }
+
+      const again = Analysis.evaluate(snapshot, { maxSteps: 50_000_000 })
+      assert.strictEqual(again._tag, 'Completed')
+      if (again._tag !== 'Completed') return
+      assert.deepEqual(
+        again.trace.filter(
+          (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
+        ),
+        evaluated.trace.filter(
+          (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
+        ),
+      )
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 0)
+
+      // One native execution now carries every ordinal: the sweep only completes if each earlier
+      // quota rolled back cleanly enough for the next attempt to run.
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make(id, ascii(source)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'quota-sweep'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled', id)
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 0, `${id}: ${run.stderr}`)
+      assert.strictEqual(run.stderr, '')
     }),
   180_000,
 )

--- a/packages/compiler/test/SchedulerFiber.test.ts
+++ b/packages/compiler/test/SchedulerFiber.test.ts
@@ -299,7 +299,13 @@ effect fn rejectPrepared(
   return ()
 }`
 
-const allocationOrdinalSource = (quota: number): string => {
+/**
+ * One program sweeps every allocation ordinal itself: `scenario` takes the quota at runtime and
+ * `sweep` drives quotas 0..19, marking each iteration with `sweepIterationStarted` so the test
+ * can segment a single evaluator trace per quota. Compiling once replaced twenty full pipelines
+ * whose sources differed only in one integer literal.
+ */
+const allocationOrdinalSweepSource: string = (() => {
   const base = forkChild.toString()
   return base
     .replace(
@@ -402,7 +408,7 @@ const allocationOrdinalSource = (quota: number): string => {
       `effect fn scenario() -> i32 ! Allocator.OutOfMemoryError {
   let mut allocator = Allocator.systemAllocatorProvider()
   let audit =`,
-      `effect fn scenario() -> i32 ! Allocator.OutOfMemoryError {
+      `effect fn scenario(quota: i32) -> i32 ! Allocator.OutOfMemoryError {
   let mut bootstrap = Allocator.systemAllocatorProvider()
   let audit =`,
     )
@@ -410,7 +416,7 @@ const allocationOrdinalSource = (quota: number): string => {
       `  let audit = run Shared.make<Audit>(Audit {
     rootPreparations: 0,`,
       `  let audit = run Shared.make<Audit>(Audit {
-    remaining: ${quota},
+    remaining: quota,
     requests: 0,
     refusals: 0,
     rootPreparations: 0,`,
@@ -508,7 +514,33 @@ const allocationOrdinalSource = (quota: number): string => {
   return 7
 }`,
     )
+    .replace(
+      `pub fn main() -> i32 {
+  return run Effect.catchAll(scenario(), recover)
+}`,
+      `fn sweepIterationStarted() -> () { return () }
+
+fn expectedOutcome(quota: i32) -> i32 {
+  if quota < 10 { return 7 }
+  return 42
 }
+
+effect fn sweep() -> i32 {
+  let mut quota = 0
+  while quota < 20 {
+    sweepIterationStarted()
+    let outcome = run Effect.catchAll(scenario(quota), recover)
+    if outcome != expectedOutcome(quota) { return 0 - (quota + 1) }
+    quota = quota + 1
+  }
+  return 42
+}
+
+pub fn main() -> i32 {
+  return run sweep()
+}`,
+    )
+})()
 
 it.effect('dispatches Scheduler.prepare to a renamed ordinary-source provider', () =>
   Effect.gen(function* () {
@@ -1417,33 +1449,44 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const terminalQuota = 19
+      const snapshot = yield* Analysis.ofSourceRealized(
+        'scheduler-fiber/allocation-ordinals',
+        ascii(allocationOrdinalSweepSource),
+        'wasm32-unknown-unknown',
+      )
+      assert.deepEqual(
+        Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
+        [],
+        describe(Analysis.diagnostics(snapshot)),
+      )
+      assert.deepEqual(MirVerification.verify(Analysis.loweredMir(snapshot)), [])
+
+      // Twenty ordinals share one evaluation; the raised step ceiling is the sum of what the
+      // per-quota runs used separately, not a change in what any single run may cost.
+      const evaluated = Analysis.evaluate(snapshot, { maxSteps: 50_000_000 })
+      assert.strictEqual(evaluated._tag, 'Completed', describe(evaluated))
+      if (evaluated._tag !== 'Completed') return
+      assert.strictEqual(evaluated.result.value, 42n)
+
+      const markers = evaluated.trace.flatMap((event, index) =>
+        event._tag === 'Call' && event.target.name === 'sweepIterationStarted' ? [index] : [],
+      )
+      assert.lengthOf(markers, terminalQuota + 1)
+
       for (let quota = 0; quota <= terminalQuota; quota++) {
         const label = `q${quota}`
-        const source = allocationOrdinalSource(quota)
-        const snapshot = yield* Analysis.ofSourceRealized(
-          `scheduler-fiber/allocation-ordinals/${label}`,
-          ascii(source),
-          'wasm32-unknown-unknown',
+        const from = markers[quota] ?? 0
+        const segment = evaluated.trace.slice(
+          from + 1,
+          markers[quota + 1] ?? evaluated.trace.length,
         )
-        assert.deepEqual(
-          Analysis.diagnostics(snapshot).map((diagnostic) => diagnostic.code),
-          [],
-          `${label}: ${describe(Analysis.diagnostics(snapshot))}`,
-        )
-
-        const evaluated = Analysis.evaluate(snapshot)
-        assert.strictEqual(evaluated._tag, 'Completed', `${label}: ${describe(evaluated)}`)
-        if (evaluated._tag !== 'Completed') continue
 
         const publicationReached = 17 <= quota
         const rejectedLifetimeReached = 15 <= quota
         const childPreparationReached = 10 <= quota
-        const expected = childPreparationReached ? 42 : 7
-        assert.strictEqual(evaluated.result.value, BigInt(expected), label)
 
         const callCount = (name: string): number =>
-          evaluated.trace.filter((event) => event._tag === 'Call' && event.target.name === name)
-            .length
+          segment.filter((event) => event._tag === 'Call' && event.target.name === name).length
         assert.strictEqual(callCount('taskIdentityRefusalObserved'), 0, label)
         assert.strictEqual(callCount('wrongRejectionFailure'), 0, label)
         assert.strictEqual(callCount('rejectedBodyActivated'), 0, label)
@@ -1466,30 +1509,22 @@ it.effect(
           label,
         )
         assert.strictEqual(callCount('rejectionObserved'), childPreparationReached ? 1 : 0, label)
+        const callIndex = (name: string): number =>
+          segment.findIndex((event) => event._tag === 'Call' && event.target.name === name)
         if (rejectedLifetimeReached) {
-          const releasedTask = evaluated.trace.findIndex(
-            (event) => event._tag === 'Call' && event.target.name === 'rejectedTaskReleased',
-          )
-          const observed = evaluated.trace.findIndex(
-            (event) => event._tag === 'Call' && event.target.name === 'rejectionObserved',
-          )
-          assert.isBelow(releasedTask, observed, label)
+          assert.isBelow(callIndex('rejectedTaskReleased'), callIndex('rejectionObserved'), label)
         }
         if (publicationReached) {
-          const callIndex = (name: string): number =>
-            evaluated.trace.findIndex(
-              (event) => event._tag === 'Call' && event.target.name === name,
-            )
           const releasedTask = callIndex('rejectedTaskReleased')
           if (quota < terminalQuota)
             assert.isBelow(releasedTask, callIndex('publicationInsertionRefused'), label)
           else assert.isBelow(callIndex('publicationInsertionAccepted'), releasedTask, label)
         }
 
-        const acquired = evaluated.trace.flatMap((event) =>
+        const acquired = segment.flatMap((event) =>
           event._tag === 'AllocationAcquire' ? [event.ticket] : [],
         )
-        const released = evaluated.trace.flatMap((event) =>
+        const released = segment.flatMap((event) =>
           event._tag === 'AllocationRelease' ? [event.ticket] : [],
         )
         assert.strictEqual(acquired.length, quota < terminalQuota ? quota + 1 : 20, label)
@@ -1498,14 +1533,11 @@ it.effect(
           acquired.toSorted((left, right) => left - right),
           `${label}: ${describe({ acquired, released })}`,
         )
-
-        if (quota === terminalQuota)
-          assert.deepEqual(MirVerification.verify(Analysis.loweredMir(snapshot)), [])
-
-        const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
-        const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
-        assert.strictEqual((instance.exports.silk_main as () => number)(), expected, label)
       }
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 42)
     }),
   600_000,
 )

--- a/packages/compiler/test/StackVmPressure.test.ts
+++ b/packages/compiler/test/StackVmPressure.test.ts
@@ -205,7 +205,14 @@ const sourceFor = (
   return Object.freeze({ source, expected })
 }
 
-const quotaSourceFor = (bytecode: ReadonlyArray<number>, quota: number): string => {
+/**
+ * One program sweeps every allocation ordinal itself: each iteration builds a fresh
+ * QuotaAllocator with the loop's quota, `quotaSweepIteration` marks the iteration so the test
+ * segments one evaluator trace per quota, and the sweep terminates on the first quota that
+ * completes. Compiling once replaced one full pipeline per ordinal whose sources differed only
+ * in one integer literal.
+ */
+const quotaSweepSourceFor = (bytecode: ReadonlyArray<number>): string => {
   const generated = sourceFor(bytecode).source
   const withAllocator = replaceExactlyOnce(
     generated,
@@ -228,10 +235,56 @@ effect fn allocate(self: &mut QuotaAllocator, layout: Layout) -> Allocation ! Ou
 
 impl Allocator for QuotaAllocator { allocate: QuotaAllocator.allocate }`,
   )
-  return replaceExactlyOnce(
+  const withHarness = replaceExactlyOnce(
     withAllocator,
-    '  let mut allocator = Allocator.systemAllocatorProvider()',
-    `  let mut allocator = QuotaAllocator { remaining: ${quota} }`,
+    `pub effect fn main() -> () ! OutOfMemoryError | LogError {
+  let mut allocator = Allocator.systemAllocatorProvider()
+  let mut logger = Logger.inMemoryProvider()
+`,
+    `fn quotaSweepIteration() -> () { return () }
+
+effect fn attemptRecover(error: OutOfMemoryError | LogError) -> bool {
+  drop error
+  return false
+}
+
+effect fn attemptQuota(quota: i32, bytecode: &[u8]) -> bool ! OutOfMemoryError | LogError {
+  let mut allocator = QuotaAllocator { remaining: quota }
+  let mut logger = Logger.inMemoryProvider()
+  let completed = run execute(bytecode)
+    |> Effect.map(fingerprint)
+    |> Effect.map(verify)
+    |> Effect.tap(logVerified)
+    |> Effect.provideMut(&mut allocator)
+    |> Effect.provideMut(&mut logger)
+  if logLength(&logger) != 1 { let mismatch = 1 / 0 }
+  return true
+}
+
+pub effect fn main() -> () ! OutOfMemoryError | LogError {
+`,
+  )
+  return replaceExactlyOnce(
+    withHarness,
+    `  let completed = run execute(bytecode)
+    |> Effect.map(fingerprint)
+    |> Effect.map(verify)
+    |> Effect.tap(logVerified)
+    |> Effect.provideMut(&mut allocator)
+    |> Effect.provideMut(&mut logger)
+  if logLength(&logger) != 1 { let mismatch = 1 / 0 }
+  return ()
+}`,
+    `  let mut quota = 0
+  while quota < 64 {
+    quotaSweepIteration()
+    let succeeded = run Effect.catchAll(attemptQuota(quota, bytecode), attemptRecover)
+    if succeeded { return () }
+    quota = quota + 1
+  }
+  let unreachedTerminal = 1 / 0
+  return ()
+}`,
   )
 }
 
@@ -414,85 +467,64 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const representative = corpus[9]
-      const baseline = sourceFor(representative.bytecode)
-      const baselineSnapshot = yield* Analysis.ofSourceRealized(
-        'stack-vm-pressure/quota/baseline',
-        ascii(baseline.source),
-        'wasm32-unknown-unknown',
+      const id = 'stack-vm-pressure/quota/sweep'
+      const source = quotaSweepSourceFor(representative.bytecode)
+      const snapshot = yield* Analysis.ofSourceRealized(id, ascii(source), 'wasm32-unknown-unknown')
+      assert.deepEqual(Analysis.diagnostics(snapshot), [], id)
+
+      // Every ordinal shares one evaluation; the raised step ceiling is the sum of what the
+      // per-quota runs used separately, not a change in what any single run may cost.
+      const evaluated = Analysis.evaluate(snapshot, { maxSteps: 50_000_000 })
+      assert.strictEqual(evaluated._tag, 'Completed')
+      if (evaluated._tag !== 'Completed') return
+
+      const markers = evaluated.trace.flatMap((event, index) =>
+        event._tag === 'Call' && event.target.name === 'quotaSweepIteration' ? [index] : [],
       )
-      assert.deepEqual(Analysis.diagnostics(baselineSnapshot), [])
-      const baselineOutcome = Analysis.evaluate(baselineSnapshot)
-      assert.strictEqual(baselineOutcome._tag, 'Completed')
-      if (baselineOutcome._tag !== 'Completed') return
-      const allocationCount = baselineOutcome.trace.filter(
-        (event) => event._tag === 'AllocationAcquire',
-      ).length
+      const allocationCount = markers.length - 1
       assert.isAtLeast(allocationCount, 4)
 
-      // Native execution runs at the boundary ordinals only — immediate failure, one mid-growth
-      // rollback, and unrestricted completion — while the evaluator and Wasm carry every ordinal.
-      // Each native leg is a full release pipeline, and the allocator's rollback path does not
-      // vary by ordinal index beyond those three shapes.
-      const nativeQuotas = new Set([0, Math.floor(allocationCount / 2), allocationCount])
-
       for (let quota = 0; quota <= allocationCount; quota += 1) {
-        const id = `stack-vm-pressure/quota/q${quota}`
-        const source = quotaSourceFor(representative.bytecode, quota)
-        const snapshot = yield* Analysis.ofSourceRealized(
-          id,
-          ascii(source),
-          'wasm32-unknown-unknown',
+        const label = `q${quota}`
+        const segment = evaluated.trace.slice(
+          (markers[quota] ?? 0) + 1,
+          markers[quota + 1] ?? evaluated.trace.length,
         )
-        assert.deepEqual(Analysis.diagnostics(snapshot), [], id)
-        const expectedTag = quota === allocationCount ? 'Completed' : 'UnhandledFailure'
-        const evaluated = Analysis.evaluate(snapshot)
-        assert.strictEqual(evaluated._tag, expectedTag, id)
-        const acquired = evaluated.trace.filter(
-          (event) => event._tag === 'AllocationAcquire',
-        ).length
-        const released = evaluated.trace.filter(
-          (event) => event._tag === 'AllocationRelease',
-        ).length
-        assert.strictEqual(acquired, quota, id)
-        assert.strictEqual(released, acquired, id)
-        const again = Analysis.evaluate(snapshot)
-        assert.strictEqual(again._tag, expectedTag, id)
-        assert.deepEqual(
-          again.trace.filter(
-            (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
-          ),
-          evaluated.trace.filter(
-            (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
-          ),
-          id,
-        )
-
-        const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
-        const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
-        assert.strictEqual(
-          (instance.exports.silk_main as () => number)(),
-          quota === allocationCount ? 0 : 1,
-          id,
-        )
-
-        if (!nativeQuotas.has(quota)) continue
-        const compiled = yield* Driver.compile({
-          compilation: { root: SourceFile.make(id, ascii(source)) },
-          toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
-          profile: 'release',
-          destination: join(destinationRoot, `quota-${quota}`),
-        }).pipe(Effect.provide(SourceResolver.empty))
-        assert.strictEqual(compiled._tag, 'Compiled', id)
-        if (compiled._tag !== 'Compiled') continue
-        const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
-        assert.strictEqual(
-          run.status,
-          quota === allocationCount ? 0 : 1,
-          `${id}: ${JSON.stringify({ stderr: run.stderr, signal: run.signal, error: run.error?.message })}`,
-        )
-        if (quota === allocationCount) assert.strictEqual(run.stderr, '')
-        else assert.strictEqual(run.stderr, 'Error: silk/allocator.OutOfMemoryError\n')
+        const acquired = segment.filter((event) => event._tag === 'AllocationAcquire').length
+        const released = segment.filter((event) => event._tag === 'AllocationRelease').length
+        assert.strictEqual(acquired, quota, label)
+        assert.strictEqual(released, acquired, label)
       }
+
+      const again = Analysis.evaluate(snapshot, { maxSteps: 50_000_000 })
+      assert.strictEqual(again._tag, 'Completed')
+      if (again._tag !== 'Completed') return
+      assert.deepEqual(
+        again.trace.filter(
+          (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
+        ),
+        evaluated.trace.filter(
+          (event) => event._tag === 'AllocationAcquire' || event._tag === 'AllocationRelease',
+        ),
+      )
+
+      const wasm = yield* Analysis.codegenWasm(snapshot, { mode: 'release' })
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(wasm.bytes.slice()), {})
+      assert.strictEqual((instance.exports.silk_main as () => number)(), 0)
+
+      // One native execution now carries every ordinal: the sweep only completes if each earlier
+      // quota rolled back cleanly enough for the next attempt to run.
+      const compiled = yield* Driver.compile({
+        compilation: { root: SourceFile.make(id, ascii(source)) },
+        toolchain: Object.freeze({ _tag: 'Toolchain', clang: '/usr/bin/clang' }),
+        profile: 'release',
+        destination: join(destinationRoot, 'quota-sweep'),
+      }).pipe(Effect.provide(SourceResolver.empty))
+      assert.strictEqual(compiled._tag, 'Compiled', id)
+      if (compiled._tag !== 'Compiled') return
+      const run = spawnSync(compiled.path, [], { encoding: 'utf8' })
+      assert.strictEqual(run.status, 0, `${id}: ${run.stderr}`)
+      assert.strictEqual(run.stderr, '')
     }),
   180_000,
 )


### PR DESCRIPTION
## Summary

The three quota-rollback suites compiled one full pipeline per allocation ordinal — twenty-ish builds each, differing only in one integer literal baked into a QuotaAllocator/Audit initializer. They were the gate's #3 (SchedulerFiber ordinal sweep, 2m46) plus StackVmPressure (1m20) and LexerPressure (1m0) rollback tests.

Each program now sweeps its own quotas at runtime: the quota is a parameter, an in-program loop drives every ordinal (terminating on the first quota that completes), and a `sweepIterationStarted`/`quotaSweepIteration` marker call bounds each iteration so the test segments **one** evaluator trace per quota and applies the unchanged per-quota assertions to each segment — acquired==quota, released==acquired, and (for the scheduler sweep) the full per-quota call-count and ordering matrix.

One compilation, one evaluation (step ceiling raised to the sum the per-quota runs used separately), one MIR verification, one Wasm execution — and for the pressure suites, one **native** execution that now carries *every* ordinal instead of three sampled ones: the sweep only completes if each earlier quota rolled back cleanly enough for the next attempt to run.

| test | before (isolated) | after |
|---|---|---|
| SchedulerFiber ordinal sweep | ~43s | **~4s** |
| LexerPressure rollback | ~35s | **~7.6s** |
| StackVmPressure rollback | ~19s | **~8.4s** |

Deliberately out of scope: the native uncaught-OutOfMemoryError stderr pin the pressure tests carried — the sweep catches failures in-program by design, and EffectEntry pins that mechanism (`Error: <module>.<error>` + exit 1) already.

## Verification

SchedulerFiber 14/14, LexerPressure 6/6, StackVmPressure 5/5; biome (CI config) + test typecheck clean.