### PR TITLE
docs: describe receiver method calls in the STYLE-002 boundary

### DIFF
--- a/apps/docs/content/reference/style-guide.md
+++ b/apps/docs/content/reference/style-guide.md
@@ -133,16 +133,14 @@ them. Silk does not select by import order or form an overload set.
 
 **Boundary:** This is an API convention, not a validity rule. A member may place another argument
 first when its domain meaning calls for that order, and a valid inline conformance is not rejected
-for lacking a mapped member. An inherent member is called through its owner; the language does not
-currently reinterpret a member as an instance method:
-
-```silk,ignore
-counter.increment(1)
-```
-
-Use `Counter.increment(counter, 1)` or `counter |> Counter.increment(1)`. Receiver-position
-method-call syntax is defined by a separate later change; the receiver-first contract described here
-is what lets that spelling reuse the same member without a second calling convention.
+for lacking a mapped member. A receiver method is also callable as `counter.increment(1)`; that
+spelling resolves to the same member as `Counter.increment(counter, 1)` and
+`counter |> Counter.increment(1)`, with the receiver's ownership taken from the declared `self`
+parameter (`Self` consumes, `&Self` borrows, `&mut Self` borrows exclusively). Only a member whose
+first parameter is `self` is callable through a value; an associated function such as
+`Counter.zero()` is not, and `counter.increment` without a call is not a callable value. The
+receiver-first contract described here is what lets all three spellings share one member without a
+second calling convention.
 
 Extension functions do not retroactively make an external type conform to an interface or service;
 a third-party type/interface combination requires an owned adapter type. This coherence boundary is


### PR DESCRIPTION
## Summary

The STYLE-002 boundary paragraph still said the language does not reinterpret a member as an instance method and deferred receiver syntax to a later change, while the section's own example already calls `Counter { value: 40 }.increment(1)`. This rewrites the paragraph to state the rule that shipped with #322: a receiver method is callable through a value, resolves to the same member as the direct and pipeline forms, takes the receiver's ownership from the declared `self` parameter, and neither an associated function nor an uncalled member is reachable through a value.

## Verification

- `oxfmt --check` on the page passes.
- Full gate not run locally; the change removes one `silk,ignore` fence and edits prose only. CI covers the docs snippet tests.