### PR TITLE
Fix JUL-106: retain match-binding locals in native lowering

### DIFF
--- a/packages/compiler/src/NativeFunction.ts
+++ b/packages/compiler/src/NativeFunction.ts
@@ -104,6 +104,11 @@ export const discoverRoots = (
           : [],
       ),
     ),
+    ...blocks.flatMap((block) =>
+      block.operations.flatMap((operation) =>
+        operation._tag === 'BindMatch' ? [operation.destination.ordinal] : [],
+      ),
+    ),
     ...[...assignments].flatMap(([ordinal, count]) => (count > 1 ? [ordinal] : [])),
     ...continuationLocals,
     ...runtimeContinuationDestinations,

--- a/packages/compiler/test/support/corpus.ts
+++ b/packages/compiler/test/support/corpus.ts
@@ -246,6 +246,21 @@ pub fn main() -> i32 {
   return update(&mut buffer, usize.ONE)
 }`
 
+/** Statement-form `if let` keeps pattern bindings live on every native success branch. */
+export const retainedIfLetMatchAcceptance = `import silk.option { Option }
+
+fn inspect(taken: Option<i32>) -> i32 {
+  if let Option<i32>.Some { value: i } = move taken {
+    return i
+  } else {
+    return 0
+  }
+}
+
+pub fn main() -> i32 {
+  return inspect(Option<i32>.Some { value: 42 }) + inspect(Option<i32>.None)
+}`
+
 /** Two independent roots resume in reverse suspension order without sharing a frame stack. */
 export const independentExecutionNonLifo = `import silk.allocator { Allocator, OutOfMemoryError }
 import silk.allocator { Allocator, OutOfMemoryError }
@@ -1291,6 +1306,11 @@ pub fn main() -> i32 {
   {
     name: 'template-formatting',
     source: templateFormattingAcceptance,
+    expected: { _tag: 'Completes', result: 42 },
+  },
+  {
+    name: 'retained-if-let-match-binding',
+    source: retainedIfLetMatchAcceptance,
     expected: { _tag: 'Completes', result: 42 },
   },
   {


### PR DESCRIPTION
## Summary
- Preserve `BindMatch` destinations as native mutable roots so pattern match bindings remain available after control-flow joins.
- Add a native regression corpus entry for retained `if let` `Option` match bindings.

## Testing
- Not run in this step (per current workflow constraints).
