### PR TITLE
Fix missing native StandardStreams spec scenario

### DIFF
--- a/openspec/specs/bootstrap-standard-streams/spec.md
+++ b/openspec/specs/bootstrap-standard-streams/spec.md
@@ -34,6 +34,11 @@ Define the smallest explicit process-output service needed to observe real Silk 
 Native execution SHALL connect an explicit provider to process destinations and preserve bytes,
 ordering, destinations, and typed failures.
 
+#### Scenario: Write to the selected native process destination
+
+- **WHEN** a native program supplies a `StandardStreams` provider and writes bytes to stdout or stderr
+- **THEN** the selected process destination receives the supplied bytes in call order, or the operation returns its typed stream failure
+
 ### Requirement: Logging remains separate
 
 This capability SHALL NOT define `Effect.log` as stdout writing. A separate Logger SHALL receive


### PR DESCRIPTION
Strict OpenSpec validation failed because “Native process destinations are explicit” had no scenario. Add a scenario covering explicit provider selection, destination and byte-order preservation, and typed write failures under the existing requirement.

Validation: the affected spec and all 132 main specs pass strict OpenSpec validation; the changed Markdown file passes Oxfmt; `git diff --check` passes. The full compiler suite was not rerun for this five-line specification-only correction, following the preference for focused checks on small changes.
