### PR TITLE
Fix the real-worker test deadline and finalize runtime verification

### DIFF
--- a/openspec/changes/complete-native-runtime-migration/progress.md
+++ b/openspec/changes/complete-native-runtime-migration/progress.md
@@ -2564,3 +2564,18 @@ project-worker tests pass. The final ordered local sequence is rerun in
 `ci-fix4-{typecheck,format,lint,test,check,release}.log`; unchanged compiler/native
 inputs can reuse the successful `ci-fix3` results. No failed full run is counted as
 a passing gate.
+
+### Final local verification and merged PR follow-up
+
+The ordered `ci-fix4` sequence passed typecheck, formatting, lint, all package tests,
+`pnpm check` and `pnpm release:candidate`. Its Vitest summaries total 3,283 passing
+tests, including 2,429 compiler, 324 native acceptance, 160 LSP and 87 CLI tests.
+Unchanged compiler/native inputs reused the successful `ci-fix3` cache; all LSP tests
+ran again and passed. Repository checks passed all 19 script tests and release
+validation ran all 10 packed-package/consumer checks. The source/artifact audit and
+strict OpenSpec validation passed again. Task 6.4 is now complete.
+
+Both original PRs passed every CI job and were merged into `main` at `a67354bc` during
+verification. The final small follow-up carries the real-worker test's existing
+workspace deadline and this completed audit record. The merged implementation and
+audit are preserved; no further runtime/compiler change is included.

--- a/openspec/changes/complete-native-runtime-migration/progress.md
+++ b/openspec/changes/complete-native-runtime-migration/progress.md
@@ -2549,3 +2549,18 @@ Commit `d46071aa` gives native acceptance jobs 60 minutes including setup/build;
 individual test deadlines, assertions, shard assignments and case selection are
 unchanged. A fresh CI run verifies the complete cold shards. The active local
 `ci-fix3` sequence continues with unchanged compiler/test inputs.
+
+### Real-worker integration deadline
+
+CI runs `34261542409` (`d46071aa`) and `34261608202` (`eff61c64`) both passed
+every job, including all native shards. Linux shard 2 explicitly passed
+`foreign-libc-environ-static` and all 111 shard tests. The local `ci-fix3` run
+passed 2,429 compiler tests and all 324 native acceptance tests, then failed only
+`ProjectWorker.test.ts`'s real-worker integration at its explicit 30-second deadline;
+the other 159 LSP tests passed. This one scenario starts a worker, performs cold
+analysis, queries it and checks orderly shutdown. Commit `5f858239` removes its
+undersized override so it uses the existing 60-second workspace deadline. All five
+project-worker tests pass. The final ordered local sequence is rerun in
+`ci-fix4-{typecheck,format,lint,test,check,release}.log`; unchanged compiler/native
+inputs can reuse the successful `ci-fix3` results. No failed full run is counted as
+a passing gate.

--- a/openspec/changes/complete-native-runtime-migration/tasks.md
+++ b/openspec/changes/complete-native-runtime-migration/tasks.md
@@ -75,4 +75,4 @@
 - [x] 6.2.2 Implement the planned target-neutral finalization composition, migrate ensuring, and verify original outcome/context retention across success, failure, suspension and parked destruction.
 - [x] 6.3 Reconcile prescriptive/generated documentation, catalogs, examples and exact target/tool/supply evidence.
 - [x] 6.3.1 Correct generated reference visibility for private providers, interfaces and generic arguments while retaining explicit private output and public conformances.
-- [ ] 6.4 Run pnpm typecheck, pnpm format:check, pnpm lint, pnpm test, then pnpm check; run pnpm release:candidate for changed package contents and record exact results.
+- [x] 6.4 Run pnpm typecheck, pnpm format:check, pnpm lint, pnpm test, then pnpm check; run pnpm release:candidate for changed package contents and record exact results.

--- a/openspec/changes/complete-native-runtime-migration/verification.md
+++ b/openspec/changes/complete-native-runtime-migration/verification.md
@@ -23,50 +23,51 @@ retain their exact source/tool/supply provenance. Missing or changed evidence fa
 
 ## Repository gates
 
-| Gate                     | Result | Log                                        |
-| ------------------------ | ------ | ------------------------------------------ |
-| `pnpm typecheck`         | Passed | `.scratch/migration-final11-typecheck.log` |
-| `pnpm format:check`      | Passed | `.scratch/migration-final11-format.log`    |
-| `pnpm lint`              | Passed | `.scratch/migration-final11-lint.log`      |
-| `pnpm test`              | Passed | `.scratch/migration-final11-test.log`      |
-| `pnpm check`             | Passed | `.scratch/migration-final11-check.log`     |
-| `pnpm release:candidate` | Passed | `.scratch/migration-final11-release.log`   |
+The final local sequence passed in the required order after the compiler/runtime,
+CI and LSP test repairs. The final test-only follow-up inherits the workspace's
+60-second deadline for real-worker analysis instead of overriding it with 30 seconds.
 
-The final11 sequence ran the gates in the required order. Turbo reused passing
-results for unchanged package inputs: all 2,420 compiler tests and all 324 native
-acceptance tests ran successfully in final9; the final snippet changes passed all
-47 editor tests and 18 docs app tests in final10. The full repository test set is
-3,372 passing tests. `pnpm check` additionally passed all 17 repository script tests,
-and release-candidate validation executed all 10 packed-package/consumer checks.
+| Gate                     | Result | Log                              |
+| ------------------------ | ------ | -------------------------------- |
+| `pnpm typecheck`         | Passed | `.scratch/ci-fix4-typecheck.log` |
+| `pnpm format:check`      | Passed | `.scratch/ci-fix4-format.log`    |
+| `pnpm lint`              | Passed | `.scratch/ci-fix4-lint.log`      |
+| `pnpm test`              | Passed | `.scratch/ci-fix4-test.log`      |
+| `pnpm check`             | Passed | `.scratch/ci-fix4-check.log`     |
+| `pnpm release:candidate` | Passed | `.scratch/ci-fix4-release.log`   |
 
-Earlier failures and owner-level repairs are recorded in [progress.md](progress.md),
-including the final10 stale export assertion corrected before the passing release
-run. No failed or interrupted run is presented as passing evidence. The source and
-artifact audit passed again in `.scratch/migration-final10-audit.log`.
+The package Vitest logs contain **3,283 passing tests**, including 2,429 compiler,
+324 native acceptance, 160 LSP and 87 CLI tests. Turbo reused the successful compiler
+and native results from `ci-fix3` because their inputs were unchanged; all 160 LSP
+tests ran again with the corrected real-worker deadline. `pnpm check` additionally
+passed all 19 repository script tests. Release validation ran all 10 packed-package
+and consumer checks. The 53 standard-library doctests passed without skips.
+
+The source and preserved artifact audit passed again in `.scratch/ci-fix4-audit.log`;
+strict OpenSpec validation passed in `.scratch/ci-fix4-openspec.log`. Earlier failed,
+interrupted and superseded verification runs are recorded in [progress.md](progress.md)
+and are not counted as passing gates. Preserved conformance receipts retain their
+actual source/tool/supply provenance rather than claiming a new execution revision.
 
 ## PR integration validation
 
-The implementation PR merges main at `7cc09e57`, preserving contextual character
-literals, compact import formatting, the lexer cleanup/documentation and generated
-untracked toolchain integrity. The merge preserves explicit module analysis in the
-landing-page verifier while adopting LSP diagnostic projection.
+Main at `7cc09e57` was integrated with contextual character literals, compact imports,
+lexer cleanup and generated untracked toolchain integrity. The source audit was
+refreshed for reviewed upstream changes and the matching C data-import repair.
 
-Post-merge type checking, formatting and linting pass. The focused character-literal,
-lexer and formatter suites pass all 129 tests. The source audit was refreshed for the
-six changed upstream compiler modules, and both source/artifact absence checks pass.
-The superseded local post-merge run was interrupted by a concurrent rebuild; it is
-not passing evidence. CI findings and their reproductions are recorded in
-[progress.md](progress.md). Fixes in `a4fde63a` freeze Debian indexes, select explicit
-filesystem execution storage, honor configured LLVM tools in native tests, and give
-the aggregate doctest sweep its measured CI allowance. Clean Linux supply builds,
-24 header checks, both Darwin filesystem lanes and eight native tests pass. The
-`ci-fix2` ordered typecheck/format/lint/test sequence passed, including 2,428 compiler
-and 324 native acceptance tests. Its following check was stopped to incorporate the
-remaining Linux data-import and LSP worker repairs in `58564933`. Those fixes pass
-55 ABI/planning tests, 24 workspace-engine tests, 16 stdio tests and exact GNU
-executable codegen. The replacement complete stack sequence runs in
-`.scratch/ci-fix3-{typecheck,format,lint,test,check,release}.log`; final results are pending. Earlier conformance receipts preserve their recorded source/tool/supply
-provenance and are not represented as newly executed on the merged revision.
+[Implementation CI run 34261542409](https://github.com/julia-script/silk/actions/runs/34261542409)
+passed on `d46071aa`, and
+[audit CI run 34261608202](https://github.com/julia-script/silk/actions/runs/34261608202)
+passed on `eff61c64`. Both runs passed all compiler and native shards, all three
+platform-supply lanes, browser/macOS checks and complete validation/release checks.
+Linux native shard 2 explicitly passed `foreign-libc-environ-static` and all 111
+shard tests. The native job limit is 60 minutes so cold shards can finish; individual
+test deadlines and assertions are preserved.
+
+PRs #387 and #388 were merged into `main` at `a67354bc` while the local gate was
+finishing. The follow-up contains only the final real-worker test deadline repair
+and this completed verification record. The remote runs above precede that test-only
+follow-up; its local validation is the complete passing `ci-fix4` sequence.
 
 ## Scope boundary
 

--- a/packages/lsp/test/ProjectWorker.test.ts
+++ b/packages/lsp/test/ProjectWorker.test.ts
@@ -275,37 +275,34 @@ it.effect('reports a failed generation and recovers from the last complete commi
   }),
 )
 
-it.effect(
-  'runs analysis and queries in a real worker thread and exits after shutdown',
-  () =>
-    Effect.gen(function* () {
-      const worker = yield* ProjectWorker.makeNode(
-        WorkerEpoch.initial,
-        new URL('../dist/ProjectWorkerMain.js', import.meta.url),
-      )
-      yield* initialize(worker)
-      assert.strictEqual((yield* take(worker, 'Ready'))._tag, 'Ready')
-      const generation = ProjectGeneration.next(ProjectGeneration.initial)
-      yield* worker.send(source(generation.value, 'pub fn main() -> i32 { return 42 }'))
-      yield* take(worker, 'Progress')
-      assert.strictEqual((yield* take(worker, 'Commit'))._tag, 'Commit')
-      const requestId = RequestId.next(RequestId.initial)
-      yield* worker.send({
-        protocolVersion: WorkerProtocol.version,
-        _tag: 'Query',
-        epoch: worker.epoch,
-        generation,
-        requestId,
-        query: { _tag: 'Hover', uri, parameters: { line: 0, character: 36 } },
-      })
-      const result = yield* take(worker, 'Result')
-      if (result._tag !== 'Result') return yield* Effect.die('expected worker query result')
-      assert.include(Inspectable.toStringUnknown(result.result), 'Ready')
-      yield* worker.shutdown
-      assert.strictEqual((yield* take(worker, 'Stopped'))._tag, 'Stopped')
-      assert.strictEqual(yield* worker.awaitExit, 0)
-    }).pipe(Effect.scoped),
-  30_000,
+it.effect('runs analysis and queries in a real worker thread and exits after shutdown', () =>
+  Effect.gen(function* () {
+    const worker = yield* ProjectWorker.makeNode(
+      WorkerEpoch.initial,
+      new URL('../dist/ProjectWorkerMain.js', import.meta.url),
+    )
+    yield* initialize(worker)
+    assert.strictEqual((yield* take(worker, 'Ready'))._tag, 'Ready')
+    const generation = ProjectGeneration.next(ProjectGeneration.initial)
+    yield* worker.send(source(generation.value, 'pub fn main() -> i32 { return 42 }'))
+    yield* take(worker, 'Progress')
+    assert.strictEqual((yield* take(worker, 'Commit'))._tag, 'Commit')
+    const requestId = RequestId.next(RequestId.initial)
+    yield* worker.send({
+      protocolVersion: WorkerProtocol.version,
+      _tag: 'Query',
+      epoch: worker.epoch,
+      generation,
+      requestId,
+      query: { _tag: 'Hover', uri, parameters: { line: 0, character: 36 } },
+    })
+    const result = yield* take(worker, 'Result')
+    if (result._tag !== 'Result') return yield* Effect.die('expected worker query result')
+    assert.include(Inspectable.toStringUnknown(result.result), 'Ready')
+    yield* worker.shutdown
+    assert.strictEqual((yield* take(worker, 'Stopped'))._tag, 'Stopped')
+    assert.strictEqual(yield* worker.awaitExit, 0)
+  }).pipe(Effect.scoped),
 )
 
 it.effect(


### PR DESCRIPTION
The final local repository run exposed one remaining LSP test timeout after #387 and #388 had passed CI and merged. The real-worker integration starts a worker, performs cold analysis, queries it and verifies shutdown, but its explicit 30-second limit was shorter than the workspace's existing 60-second deadline. Remove that override; the assertions and production worker policy are unchanged.

Also complete the migration audit's verification record and task 6.4 with the exact passing gate logs and merged-PR CI provenance.

Validation: the original full run failed this test at 30 seconds while the other 159 LSP tests passed. All five project-worker tests and all 160 LSP tests then passed. The complete ordered sequence passed: `pnpm typecheck`, `pnpm format:check`, `pnpm lint`, `pnpm test`, `pnpm check`, and `pnpm release:candidate`. Package logs contain 3,283 passing Vitest tests, including 2,429 compiler and 324 native acceptance tests; unchanged compiler/native inputs reused their prior successful cache. All 19 repository script tests, 10 release-candidate checks, source/artifact absence checks and strict OpenSpec validation passed.
