### PR TITLE
fix(compiler): harden self-hosted parser recovery

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -50,6 +50,13 @@ its first syntax diagnostic. A future compilation driver can stop on that diagno
 CST construction remains postponed. The token vector retains source information, but there is no
 second concrete-syntax tree to maintain.
 
+Recursive rules share a budget of 32 active grammar operations. This counts parser operations,
+not just parentheses: nested blocks, types, patterns, and expressions share the same budget.
+Siblings restore their parent's depth. Exceeding the budget reports `NestingLimit` and skips the
+damaged branch without recursive recovery. The budget is an implementation resource limit, not
+a Silk grammar restriction or a limit on file size. The previous value of 256 exceeded the
+available stack in the bootstrap-generated debug executable before recovery could run.
+
 ## Grammar modules
 
 | Module                                         | Responsibility                                                                                                                              |
@@ -90,6 +97,26 @@ parser across grammar fixtures, the self-hosted sources, and the standard librar
 postorder IDs, source spans, reachability, unique token ownership, and preservation of following
 declarations after malformed syntax. Extra file paths after the executable select a smaller corpus.
 The JavaScript harness imports the bootstrap package's built `dist` modules.
+
+The default run also executes the behavioral cases in `scripts/parser-cases.mjs`, adapted from
+the bootstrap parser tests. These compare acceptance and require specific valid constructs to
+survive damage in both parsers. They do not compare diagnostic wording, diagnostic counts, error
+tree shapes, or the two implementations' numerical resource budgets. Every native tree must
+still satisfy the flat-tree invariants, and every diagnostic must address a valid source span.
+The existing valid-file corpus retains its significant-tree comparison as a separate regression
+check; a representation change can update that check without changing the behavioral cases.
+
+Run only the behavioral cases, or select individual cases by name:
+
+```sh
+node compiler/scripts/test-parser.mjs compiler/build/llvm/aarch64-apple-darwin/debug/silk-compiler --cases
+node compiler/scripts/test-parser.mjs compiler/build/llvm/aarch64-apple-darwin/debug/silk-compiler --cases missing-parameter-comma overdeep-call
+```
+
+Each case uses a temporary source file beneath `compiler/fixtures/`, which the harness removes
+after success or failure. The native executable is built once, not once per test. The nesting
+cases exercise both accepted inputs and diagnostic recovery, including depth-budget reuse by
+sibling expressions and a following declaration after unclosed delimiters.
 
 `fixtures/parser/` contains syntax-only programs: names need not resolve and operations need not
 typecheck. `recovery.silk` deliberately contains syntax errors. The other files directly under

--- a/compiler/scripts/parser-cases.mjs
+++ b/compiler/scripts/parser-cases.mjs
@@ -1,0 +1,199 @@
+// Behavioral cases adapted from packages/compiler/test/Parser.test.ts and its fixtures.
+// Each witness names valid syntax that must survive; error-tree shape and diagnostic wording
+// deliberately remain implementation choices. Generated nesting inputs keep fixtures readable.
+const later = 'fn later() -> i32 { return 7 }'
+const recovered = 'let recovered = 2'
+const witness = (kind, text) => ({ kind, text })
+const recovery = (name, source, witnesses = []) => ({
+  name,
+  source: `${source}\n${later}`,
+  invalid: true,
+  witnesses: [...witnesses, witness('FunctionDeclaration', later)],
+})
+
+export const cases = [
+  {
+    name: 'nested-call-siblings',
+    source: 'fn main() -> i32 { return combine(identity(1), identity(2)) }',
+    witnesses: [witness('CallExpression', 'identity(1)'), witness('CallExpression', 'identity(2)')],
+  },
+  {
+    name: 'precedence',
+    source: 'fn main() -> i32 { return 1 + 2 * 3 }',
+    witnesses: [witness('InfixExpression', '2 * 3')],
+  },
+  {
+    name: 'lifetime-callable',
+    source:
+      "fn apply<'a>(f: for<'b> fn(&'b i32) -> &'b i32, value: &'a i32) -> &'a i32 { return f(value) }",
+    witnesses: [witness('ReferenceType', "&'a i32")],
+  },
+  {
+    name: 'prefix-precedence',
+    source: 'fn main() -> i32 { return -value.field * 2 + 1 }',
+    witnesses: [
+      witness('PrefixExpression', '-value.field'),
+      witness('InfixExpression', '-value.field * 2'),
+    ],
+  },
+  {
+    name: 'anonymous-callables',
+    source: `fn make() -> () {
+      let ordinary = fn(value: i32) -> i32 { return value }
+      let effectful = effect fn(error: Failure) -> i32 ! Failure ? &Logger { return 42 }
+      let pending = effect { return 1 }
+    }`,
+    witnesses: [
+      witness('AnonymousCallableExpression', 'fn(value: i32) -> i32 { return value }'),
+      witness(
+        'AnonymousCallableExpression',
+        'effect fn(error: Failure) -> i32 ! Failure ? &Logger { return 42 }',
+      ),
+      witness('EffectExpression', 'effect { return 1 }'),
+    ],
+  },
+  {
+    ...recovery('missing-parameter-type', 'fn damaged(value:, next: i32) -> () {}', [
+      witness('ParameterDeclaration', 'next: i32'),
+    ]),
+    missing: { token: 'Identifier', before: ', next' },
+  },
+  {
+    ...recovery('missing-parameter-comma', 'fn damaged(value: i32 next: i32) -> () {}', [
+      witness('ParameterDeclaration', 'next: i32'),
+    ]),
+    missing: { token: 'Comma', before: 'next:' },
+  },
+  {
+    ...recovery('missing-call-close', 'fn damaged() -> i32 { return identity(42 }'),
+    missing: { token: 'RightParenthesis', before: '}' },
+  },
+  recovery(
+    'damaged-argument-sibling',
+    'fn damaged() -> i32 { return combine(identity(:), identity(2)) }',
+    [witness('CallExpression', 'identity(2)')],
+  ),
+  recovery('missing-function-brace', 'fn damaged() -> i32 { return identity(42'),
+  recovery('missing-lifetime-referent', "fn damaged<'a>(value: &'a, next: i32) -> () {}", [
+    witness('ParameterDeclaration', 'next: i32'),
+  ]),
+  recovery('empty-effect-environment', 'fn damaged(value: Effect<; i32>) -> () {}'),
+  recovery('empty-callable-binder', 'fn damaged(value: fn<>(i32) -> i32) -> () {}'),
+  recovery('noncallable-lifetime-binder', "fn damaged(value: for<'a> i32) -> () {}"),
+  recovery(
+    'missing-lifetime-binder-close',
+    "fn damaged(value: for<'a fn(&'a i32) -> &'a i32) -> () {}",
+  ),
+  recovery('lifetime-value-borrow', "fn damaged(value: i32) -> () { drop &'a value }"),
+  recovery(
+    'service-operation-close',
+    `service Logger {
+  effect fn broken(message: &[u8] -> ()
+  fn enabled() -> bool
+}`,
+    [witness('ServiceOperation', 'fn enabled() -> bool')],
+  ),
+  recovery(
+    'invalid-service-storage',
+    `service Broken {
+  state: i32
+  fn enabled() -> bool
+}`,
+    [witness('ServiceOperation', 'fn enabled() -> bool')],
+  ),
+  recovery('missing-failure-member', 'effect fn damaged() -> i32 ! { return 1 }', [
+    witness('ReturnStatement', 'return 1'),
+  ]),
+  recovery(
+    'missing-impl-parameter-close',
+    'impl<T Drop for Vector<T> { fn drop(self: &mut Vector<T>) -> () { return () } }',
+  ),
+  recovery(
+    'missing-bounded-impl-close',
+    'impl<S: Decoder<S> Decoder<MappedSchema<S>> for MappedSchema<S> { decode: MappedSchema.mappedDecode }',
+  ),
+  recovery('missing-impl-body', 'impl Allocator for Broken'),
+  recovery(
+    'damaged-effect-block',
+    'fn make() -> i32 { let pending = effect { return broken( } return 0 }',
+    [witness('ReturnStatement', 'return 0')],
+  ),
+  recovery(
+    'damaged-anonymous-parameter',
+    'fn make() -> i32 { return accept(fn(value:) -> i32 { return 1 }, 42) }',
+    [witness('IntegerLiteralExpression', '42')],
+  ),
+  {
+    ...recovery(
+      'unsafe-call-statement-boundary',
+      'fn damaged() -> i32 { unsafe { let value = Slot.take( return 42 } }',
+      [witness('ReturnStatement', 'return 42')],
+    ),
+    // The bootstrap preserves the following function but consumes this return into recovery.
+    bootstrapWitnesses: [witness('FunctionDeclaration', later)],
+  },
+  ...[
+    { name: 'group', expression: (depth) => `${'('.repeat(depth)}1${')'.repeat(depth)}` },
+    { name: 'array', expression: (depth) => `${'['.repeat(depth)}1${']'.repeat(depth)}` },
+    { name: 'call', expression: (depth) => `${'f('.repeat(depth)}1${')'.repeat(depth)}` },
+    { name: 'prefix', expression: (depth) => `${'!'.repeat(depth)}true` },
+  ].flatMap(({ name, expression }) => [
+    {
+      name: `nested-${name}`,
+      source: `fn main() -> i32 { return ${expression(16)} }`,
+      witnesses: [witness('ReturnStatement', `return ${expression(16)}`)],
+    },
+    {
+      ...recovery(
+        `overdeep-${name}`,
+        `fn damaged() -> i32 { return ${expression(2000)} ${recovered} return recovered }`,
+        [witness('BindingStatement', recovered)],
+      ),
+      diagnostic: 'NestingLimit',
+    },
+  ]),
+  {
+    name: 'budget-sibling-reset',
+    source: `fn main() -> i32 { let left = ${'('.repeat(30)}1${')'.repeat(30)} let right = ${'('.repeat(30)}2${')'.repeat(30)} return right }`,
+    witnesses: [witness('ReturnStatement', 'return right')],
+  },
+  {
+    ...recovery(
+      'budget-boundary',
+      `fn damaged() -> i32 { return ${'('.repeat(31)}1${')'.repeat(31)} }`,
+    ),
+    // Resource budgets need not match the bootstrap's 256-expression-depth policy.
+    bootstrapInvalid: false,
+    diagnostic: 'NestingLimit',
+  },
+  {
+    ...recovery('overdeep-missing-delimiters', `fn damaged() -> i32 { return ${'('.repeat(2000)}1`),
+    // The bootstrap currently swallows the following declaration in this unclosed region.
+    // Keep the stronger native recovery contract rather than reproducing that behavior.
+    bootstrapWitnesses: [],
+    diagnostic: 'NestingLimit',
+  },
+  ...[
+    { name: 'type', source: `fn damaged(value: ${'('.repeat(80)}i32${')'.repeat(80)}) -> () {}` },
+    {
+      name: 'pattern',
+      source: `fn damaged(value: Pair) -> () { let ${'Pair { first: '.repeat(80)}leaf${' }'.repeat(80)} = value }`,
+    },
+    {
+      name: 'block',
+      source: `fn damaged() -> () { ${'if true { '.repeat(80)}return ()${' }'.repeat(80)} }`,
+    },
+    {
+      name: 'static-declaration',
+      source: `${'static if true { '.repeat(80)}const VALUE: i32 = 1${' }'.repeat(80)}`,
+    },
+    {
+      name: 'record',
+      source: `fn damaged() -> Pair { return ${'Pair { first: '.repeat(80)}1${' }'.repeat(80)} }`,
+    },
+  ].map(({ name, source }) => ({
+    ...recovery(`overdeep-${name}`, source),
+    bootstrapInvalid: false,
+    diagnostic: 'NestingLimit',
+  })),
+]

--- a/compiler/scripts/test-parser.mjs
+++ b/compiler/scripts/test-parser.mjs
@@ -1,16 +1,17 @@
 // One prebuilt native parser, many syntax-only inputs. No per-fixture compiler invocations.
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFileSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { resolve, relative } from 'node:path'
 import * as Lexer from '../../packages/compiler/dist/Lexer.js'
 import * as Parser from '../../packages/compiler/dist/Parser.js'
 import * as SourceFile from '../../packages/compiler/dist/SourceFile.js'
 import * as SyntaxTree from '../../packages/compiler/dist/SyntaxTree.js'
+import { cases } from './parser-cases.mjs'
 
 assert.ok(
   process.argv[2],
-  'Usage: node compiler/scripts/test-parser.mjs <built-executable> [source-files...]',
+  'Usage: node compiler/scripts/test-parser.mjs <built-executable> [source-files... | --cases [names...]]',
 )
 const executable = resolve(process.argv[2])
 const trivia = new Set(['Whitespace', 'LineComment', 'DocComment', 'ModuleDocComment'])
@@ -26,11 +27,24 @@ function decode(output, sourceLength) {
   let root
   let diagnosticCount
   let current
+  const diagnostics = []
   for (const line of output.split('\n')) {
     let match
     if ((match = /^root #(\d+)$/.exec(line))) root = Number(match[1])
     else if ((match = /^diagnostics (\d+)$/.exec(line))) diagnosticCount = Number(match[1])
     else if (
+      diagnosticCount !== undefined &&
+      (match = /^#(\d+) (MissingToken|UnexpectedToken|NestingLimit) (\w+) (\d+)\.\.(\d+)$/.exec(
+        line,
+      ))
+    ) {
+      assert.equal(Number(match[1]), diagnostics.length)
+      const start = Number(match[4])
+      const end = Number(match[5])
+      assert.ok(start <= end && end <= sourceLength, 'diagnostic spans address source bytes')
+      if (match[2] === 'MissingToken') assert.equal(start, end)
+      diagnostics.push({ kind: match[2], detail: match[3], start, end })
+    } else if (
       diagnosticCount === undefined &&
       (match = /^#(\d+) (\w+) (\d+)\.\.(\d+)$/.exec(line))
     ) {
@@ -62,6 +76,7 @@ function decode(output, sourceLength) {
   assert.equal(nodes[root]?.start, 0)
   assert.equal(nodes[root]?.end, sourceLength)
   assert.notEqual(diagnosticCount, undefined)
+  assert.equal(diagnostics.length, diagnosticCount, 'decode every diagnostic')
   const reached = new Set()
   const tokens = new Set()
   const visit = (id) => {
@@ -90,7 +105,7 @@ function decode(output, sourceLength) {
       return element.kind
     }),
   })
-  return { nodes, diagnosticCount, shape: shape(root), tokens }
+  return { nodes, diagnosticCount, diagnostics, shape: shape(root), tokens }
 }
 
 function bootstrapShape(node) {
@@ -122,15 +137,17 @@ function shapeDifferences(actual, expected, path) {
 
 let checked = 0
 let failed = 0
-const files =
-  process.argv.length > 3
-    ? process.argv.slice(3)
-    : [
-        ...filesUnder('compiler/fixtures/parser'),
-        ...filesUnder('compiler/src'),
-        ...filesUnder('packages/compiler/stdlib/silk'),
-      ]
-function checkFile(file) {
+function sourceFiles() {
+  if (process.argv[3] === '--cases') return []
+  if (process.argv.length > 3) return process.argv.slice(3)
+  return [
+    ...filesUnder('compiler/fixtures/parser'),
+    ...filesUnder('compiler/src'),
+    ...filesUnder('packages/compiler/stdlib/silk'),
+  ]
+}
+const files = sourceFiles()
+function checkFile(file, testCase) {
   const bytes = readFileSync(file)
   const lexical = Lexer.lex(SourceFile.make(file, bytes))
   const bootstrap = Parser.parse(lexical)
@@ -143,7 +160,52 @@ function checkFile(file) {
   for (const [id, token] of lexical.tokens.entries()) {
     if (!trivia.has(token.kind)) assert.ok(actual.tokens.has(id), `${file}: missing token #${id}`)
   }
-  if (file.endsWith('/recovery.silk')) {
+  for (const node of actual.nodes) {
+    for (const element of node.elements) {
+      if (element.token === undefined) continue
+      const token = lexical.tokens[element.token]
+      assert.ok(token, 'token IDs address the lexer array')
+      assert.deepEqual(
+        { kind: element.kind, start: element.start, end: element.end },
+        { kind: token.kind, start: token.span.start, end: token.span.end },
+        'token identities retain their kind and source span',
+      )
+    }
+  }
+  if (testCase !== undefined) {
+    assert.equal(
+      bootstrap.parserDiagnostics.length > 0,
+      testCase.bootstrapInvalid ?? testCase.invalid ?? false,
+      'bootstrap acceptance',
+    )
+    assert.equal(actual.diagnosticCount > 0, testCase.invalid ?? false, 'self-hosted acceptance')
+    if (testCase.diagnostic !== undefined) {
+      assert.ok(
+        actual.diagnostics.some((d) => d.kind === testCase.diagnostic),
+        testCase.diagnostic,
+      )
+    }
+    if (testCase.missing !== undefined) {
+      const offset = bytes.indexOf(testCase.missing.before)
+      assert.ok(offset >= 0, 'diagnostic anchor occurs in source')
+      assert.ok(
+        actual.diagnostics.some(
+          (d) =>
+            d.kind === 'MissingToken' &&
+            d.detail === testCase.missing.token &&
+            d.start === offset &&
+            d.end === offset,
+        ),
+        `missing ${testCase.missing.token} at byte ${offset}`,
+      )
+    }
+    checkWitnesses(actual, bytes, testCase.witnesses)
+    checkBootstrapWitnesses(
+      bootstrap.root,
+      bytes,
+      testCase.bootstrapWitnesses ?? testCase.witnesses,
+    )
+  } else if (file.endsWith('/recovery.silk')) {
     assert.ok(actual.diagnosticCount > 0)
     assert.ok(
       actual.nodes.filter((node) => node.kind === 'FunctionDeclaration').length >= 2,
@@ -165,6 +227,86 @@ function checkFile(file) {
       [],
       `${file}: significant AST structure must agree`,
     )
+  }
+}
+
+function checkWitnesses(actual, bytes, witnesses) {
+  const intact = (node) =>
+    !node.kind.startsWith('Error') &&
+    node.elements.every((element) =>
+      element.node === undefined
+        ? element.missing === undefined
+        : intact(actual.nodes[element.node]),
+    )
+  for (const { kind, text } of witnesses) {
+    const candidates = actual.nodes.filter(
+      (node) =>
+        node.kind === kind && bytes.subarray(node.start, node.end).toString().trim() === text,
+    )
+    assert.ok(candidates.length > 0, `preserve ${kind}: ${text}`)
+    assert.ok(
+      candidates.some(
+        (node) =>
+          intact(node) &&
+          !actual.diagnostics.some((d) => d.start > node.start && d.start < node.end),
+      ),
+      `undamaged ${kind}: ${text}`,
+    )
+  }
+}
+
+function checkBootstrapWitnesses(root, bytes, witnesses) {
+  const nodes = []
+  const visit = (node) => {
+    const childrenIntact = node.children
+      .map((child) => {
+        if (SyntaxTree.isNode(child)) return visit(child)
+        return SyntaxTree.isToken(child)
+      })
+      .every(Boolean)
+    const intact = childrenIntact && !node.kind.startsWith('Error')
+    nodes.push({
+      kind: node.kind,
+      text: bytes.subarray(node.span.start, node.span.end).toString().trim(),
+      intact,
+    })
+    return intact
+  }
+  visit(root)
+  for (const { kind, text } of witnesses) {
+    assert.ok(
+      nodes.some((node) => node.kind === kind && node.text === text && node.intact),
+      `bootstrap preserves ${kind}: ${text}`,
+    )
+  }
+}
+if (process.argv.length === 3 || process.argv[3] === '--cases') {
+  const names = process.argv.slice(4)
+  for (const name of names)
+    assert.ok(
+      cases.some((testCase) => testCase.name === name),
+      `unknown case: ${name}`,
+    )
+  const directory = mkdtempSync('compiler/fixtures/.parser-cases-')
+  try {
+    for (const testCase of cases.filter(
+      (testCase) => names.length === 0 || names.includes(testCase.name),
+    )) {
+      const file = `${directory}/${testCase.name}.silk`
+      writeFileSync(file, testCase.source)
+      try {
+        checkFile(file, testCase)
+        checked++
+        process.stdout.write(`ok case:${testCase.name}\n`)
+      } catch (error) {
+        failed++
+        process.stderr.write(
+          `FAIL case:${testCase.name}: ${error.message}${error.signal ? ` (signal ${error.signal})` : ''}\n`,
+        )
+      }
+    }
+  } finally {
+    rmSync(directory, { recursive: true })
   }
 }
 for (const file of files) {

--- a/compiler/src/lexer/Lexer.silk
+++ b/compiler/src/lexer/Lexer.silk
@@ -746,7 +746,8 @@ fn amountExceeds(source: &[u8], start: usize, end: usize, maximum: usize) -> boo
       if value > maximum {
         return true
       }
-      value = value * 10 + u8.toUsize(byte - '0')
+      value = value * 10 + (byte - '0'
+        |> u8.toUsize)
     }
     index = index + 1
   }
@@ -824,7 +825,9 @@ fn parseDuration(source: &[u8], start: usize, end: usize) -> DurationResult {
       }
     }
     let amountEnd = index
-    if isAsciiLetter(byteAtOrZero(source, index)) == false {
+    if !(source
+      |> byteAtOrZero(index)
+      |> isAsciiLetter) {
       let span = tokenSpan(componentStart, invalidAmountEnd(source, componentStart, end))
       return DurationResult.Invalid {
         diagnostic: LexicalDiagnostic.InvalidDurationAmount {span: span},
@@ -931,8 +934,11 @@ fn scanNumber(source: &[u8], start: usize) -> Scanned {
   let base = baseAt(source, start)
   if base.radix != 10 {
     let digits = scanDigitRun(source, base.radix, start + base.width)
-    if isAsciiLetter(byteAtOrZero(source, digits.end)) {
-      return scanDuration(source, start, digits.end)
+    if (source
+      |> byteAtOrZero(digits.end)
+      |> isAsciiLetter) {
+      return source
+        |> scanDuration(start, digits.end)
     }
     let span = tokenSpan(start, digits.end)
     if !digits.digits {
@@ -973,8 +979,11 @@ fn scanNumber(source: &[u8], start: usize) -> Scanned {
     exponentDigits = exponentRun.digits
     separated = separated && exponentRun.separated
   }
-  if isAsciiLetter(byteAtOrZero(source, end)) {
-    return scanDuration(source, start, end)
+  if (source
+    |> byteAtOrZero(end)
+    |> isAsciiLetter) {
+    return source
+      |> scanDuration(start, end)
   }
   let span = tokenSpan(start, end)
   if !separated {
@@ -1020,15 +1029,19 @@ fn scanInvalid(source: &[u8], start: usize) -> Scanned {
 fn scanToken(source: &[u8], start: usize) -> Scanned {
   let byte = source[start]
   if isWhitespace(byte) {
-    return scanWhitespace(source, start)
+    return source
+      |> scanWhitespace(start)
   }
   if hasPair(source, start, '/', '/') {
-    return scanComment(source, start)
+    return source
+      |> scanComment(start)
   }
 
   // A closing apostrophe or backslash keeps this in character-literal recovery.
   // Otherwise the apostrophe and identifier form a lifetime token.
-  if byte == '\'' && isIdentifierStart(byteAtOrZero(source, start + 1)) {
+  if byte == '\'' && (source
+    |> byteAtOrZero(start + 1)
+    |> isIdentifierStart) {
     let lifetimeEnd = scanIdentifierEnd(source, start + 1)
     let boundary = byteAtOrZero(source, lifetimeEnd)
     if boundary != '\'' && boundary != '\\' {
@@ -1038,22 +1051,27 @@ fn scanToken(source: &[u8], start: usize) -> Scanned {
   }
 
   if isRecognizedLiteralStart(source, start) {
-    return scanRecognizedLiteral(source, start)
+    return source
+      |> scanRecognizedLiteral(start)
   }
   if isIdentifierStart(byte) {
     let end = scanIdentifierEnd(source, start)
     if byteAtOrZero(source, end) == '"' {
-      return scanUnknownLiteral(source, start, end)
+      return source
+        |> scanUnknownLiteral(start, end)
     }
     return Scanned {token: keywordToken(source, start, end), end: end}
   }
   if isDecimalDigit(byte) {
-    return scanNumber(source, start)
+    return source
+      |> scanNumber(start)
   }
   if isPunctuation(byte) {
-    return scanPunctuation(source, start)
+    return source
+      |> scanPunctuation(start)
   }
-  return scanInvalid(source, start)
+  return source
+    |> scanInvalid(start)
 }
 
 impl<'source> Stream<Token, never ? never> for Lexer<'source> {
@@ -1074,12 +1092,14 @@ impl<'source> Stream<Token, never ? never> for Lexer<'source> {
     if self.cursor < self.source.length {
       let Scanned {token, end} = move scanToken(self.source, self.cursor)
       self.cursor = end
-      return Option.some<Token>(move token)
+      return move token
+        |> Option.some
     }
     if !self.eofEmitted {
       self.eofEmitted = true
       let span = tokenSpan(self.source.length, self.source.length)
-      return Option.some<Token>(Token.EndOfFile {span: span})
+      return Token.EndOfFile {span: span}
+        |> Option.some
     }
     return Option.none<Token>()
   }

--- a/compiler/src/parser/Declaration.silk
+++ b/compiler/src/parser/Declaration.silk
@@ -19,24 +19,32 @@ import silk.usize as Usize
 effect fn nominalHeader(initial: State, keyword: TokenKind) -> ElementsResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.optional(P.begin(move initial), TokenKind.PubKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.PubKeyword)
   if keyword == TokenKind.StructKeyword && P.currentKind(&p.state) == TokenKind.ExternKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let afterTextLiteral = run P.expect(move p, TokenKind.TextLiteral)
+    let afterTextLiteral = run move p
+      |> P.expect(TokenKind.TextLiteral)
     p = move afterTextLiteral
   }
-  let advanced = run P.expect(move p, keyword)
+  let advanced = run move p
+    |> P.expect(keyword)
   p = move advanced
   if keyword == TokenKind.EnumKeyword && P.currentKind(&p.state) == TokenKind.LeftParenthesis {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
     let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
     p = move withTypesParse
-    let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+    let afterRightParenthesis = run move p
+      |> P.expect(TokenKind.RightParenthesis)
     p = move afterRightParenthesis
   }
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
   if P.currentKind(&p.state) == TokenKind.Less {
     let withTypesParameters = run P.attach(
@@ -49,10 +57,14 @@ effect fn nominalHeader(initial: State, keyword: TokenKind) -> ElementsResult
 }
 
 effect fn field(initial: State, kind: NodeKind) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.optional(P.begin(move initial), TokenKind.PubKeyword)
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.PubKeyword)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   if P.currentKind(&p.state) == TokenKind.Identifier && P.peek(&p.state, 1) == TokenKind.Colon {
     let missing = run P.complete(
@@ -65,12 +77,14 @@ effect fn field(initial: State, kind: NodeKind) -> NodeResult ! OutOfMemoryError
     let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
     p = move withTypesParse
   }
-  return run P.complete(move p, kind)
+  return run move p
+    |> P.complete(kind)
 }
 
 effect fn structDeclaration(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run nominalHeader(move initial, TokenKind.StructKeyword)
-  let afterLeftBrace = run P.expect(move p, TokenKind.LeftBrace)
+  let afterLeftBrace = run move p
+    |> P.expect(TokenKind.LeftBrace)
   p = move afterLeftBrace
   while !G.declarationStart(&p.state) && (P.currentKind(&p.state) == TokenKind.Identifier || P.currentKind(
     &p.state,
@@ -78,14 +92,17 @@ effect fn structDeclaration(initial: State) -> NodeResult ! OutOfMemoryError ? &
     let attached = run P.attach(move p.elements, run field(move p.state, NodeKind.StructField))
     p = move attached
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, NodeKind.StructDeclaration)
+  return run move p
+    |> P.complete(NodeKind.StructDeclaration)
 }
 
 effect fn tupleDeclaration(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run nominalHeader(move initial, TokenKind.TupleKeyword)
-  let afterLeftParenthesis = run P.expect(move p, TokenKind.LeftParenthesis)
+  let afterLeftParenthesis = run move p
+    |> P.expect(TokenKind.LeftParenthesis)
   p = move afterLeftParenthesis
   while G.typeStart(P.currentKind(&p.state)) {
     let before = p.state.index
@@ -94,21 +111,30 @@ effect fn tupleDeclaration(initial: State) -> NodeResult ! OutOfMemoryError ? &m
     if p.state.index == before || P.currentKind(&p.state) == TokenKind.RightParenthesis {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  return run P.complete(move p, NodeKind.TupleDeclaration)
+  return run move p
+    |> P.complete(NodeKind.TupleDeclaration)
 }
 
 effect fn enumMember(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
   if P.currentKind(&p.state) == TokenKind.Equals {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let mut literal = run P.optional(P.begin(move p.state), TokenKind.Minus)
-    let afterDecimalInteger = run P.expect(move literal, TokenKind.DecimalInteger)
+    let mut literal = run move p.state
+      |> P.begin
+      |> P.optional(TokenKind.Minus)
+    let afterDecimalInteger = run move literal
+      |> P.expect(TokenKind.DecimalInteger)
     literal = move afterDecimalInteger
     let attached = run P.attach(
       move p.elements,
@@ -116,13 +142,17 @@ effect fn enumMember(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
     )
     p = move attached
   }
-  return run P.complete(move p, NodeKind.EnumMember)
+  return run move p
+    |> P.complete(NodeKind.EnumMember)
 }
 
 effect fn variant(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
   if P.currentKind(&p.state) == TokenKind.LeftBrace {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     if P.currentKind(&p.state) == TokenKind.RightBrace {
       let attached = run P.attach(
@@ -142,14 +172,17 @@ effect fn variant(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
         if P.currentKind(&p.state) == TokenKind.RightBrace {
           break
         }
-        let afterComma = run P.expect(move p, TokenKind.Comma)
+        let afterComma = run move p
+          |> P.expect(TokenKind.Comma)
         p = move afterComma
       }
     }
-    let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+    let afterRightBrace = run move p
+      |> P.expect(TokenKind.RightBrace)
     p = move afterRightBrace
   }
-  return run P.complete(move p, NodeKind.UnionVariant)
+  return run move p
+    |> P.complete(NodeKind.UnionVariant)
 }
 
 effect fn sumDeclaration(initial: State, isUnion: bool) -> NodeResult
@@ -160,7 +193,8 @@ effect fn sumDeclaration(initial: State, isUnion: bool) -> NodeResult
     keyword = TokenKind.UnionKeyword
   }
   let mut p = run nominalHeader(move initial, keyword)
-  let afterLeftBrace = run P.expect(move p, TokenKind.LeftBrace)
+  let afterLeftBrace = run move p
+    |> P.expect(TokenKind.LeftBrace)
   p = move afterLeftBrace
   while P.currentKind(&p.state) == TokenKind.Identifier {
     if isUnion {
@@ -173,24 +207,30 @@ effect fn sumDeclaration(initial: State, isUnion: bool) -> NodeResult
     if P.currentKind(&p.state) == TokenKind.RightBrace {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
   if isUnion {
-    return run P.complete(move p, NodeKind.UnionDeclaration)
+    return run move p
+      |> P.complete(NodeKind.UnionDeclaration)
   }
-  return run P.complete(move p, NodeKind.EnumDeclaration)
+  return run move p
+    |> P.complete(NodeKind.EnumDeclaration)
 }
 
 effect fn alias(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run nominalHeader(move initial, TokenKind.TypeKeyword)
-  let afterEquals = run P.expect(move p, TokenKind.Equals)
+  let afterEquals = run move p
+    |> P.expect(TokenKind.Equals)
   p = move afterEquals
   let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
   p = move withTypesParse
-  return run P.complete(move p, NodeKind.TypeAliasDeclaration)
+  return run move p
+    |> P.complete(NodeKind.TypeAliasDeclaration)
 }
 
 effect fn constant(initial: State, parameter: bool) -> NodeResult
@@ -200,17 +240,23 @@ effect fn constant(initial: State, parameter: bool) -> NodeResult
   if parameter {
     keyword = TokenKind.ParamKeyword
   }
-  let mut p = run P.optional(P.begin(move initial), TokenKind.PubKeyword)
-  let advanced = run P.expect(move p, keyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.PubKeyword)
+  let advanced = run move p
+    |> P.expect(keyword)
   p = move advanced
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
   p = move withTypesParse
   if !parameter || P.currentKind(&p.state) == TokenKind.Equals {
-    let afterEquals = run P.expect(move p, TokenKind.Equals)
+    let afterEquals = run move p
+      |> P.expect(TokenKind.Equals)
     p = move afterEquals
     let withExpressionsParse = run P.attach(
       move p.elements,
@@ -219,7 +265,9 @@ effect fn constant(initial: State, parameter: bool) -> NodeResult
     p = move withExpressionsParse
   }
   if parameter && P.word(&p.state, "where") {
-    let mut validation = run P.consume(P.begin(move p.state))
+    let mut validation = run move p.state
+      |> P.begin
+      |> P.consume
     let attached = run P.attach(
       move validation.elements,
       run Expressions.parse(move validation.state, false),
@@ -232,22 +280,29 @@ effect fn constant(initial: State, parameter: bool) -> NodeResult
     p = move attached2
   }
   if parameter {
-    return run P.complete(move p, NodeKind.PackageParameterDeclaration)
+    return run move p
+      |> P.complete(NodeKind.PackageParameterDeclaration)
   }
-  return run P.complete(move p, NodeKind.ConstantDeclaration)
+  return run move p
+    |> P.complete(NodeKind.ConstantDeclaration)
 }
 
 effect fn operator(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let kind = P.currentKind(&p.state)
   if G.precedence(kind) > 0 || kind == TokenKind.Bang || kind == TokenKind.Tilde || kind == TokenKind.Equals || kind == TokenKind.RunKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   } else {
-    let afterStar = run P.missing(move p, TokenKind.Star)
+    let afterStar = run move p
+      |> P.missing(TokenKind.Star)
     p = move afterStar
   }
-  return run P.complete(move p, NodeKind.OperatorMarker)
+  return run move p
+    |> P.complete(NodeKind.OperatorMarker)
 }
 
 effect fn functionPrefix(initial: State, operation: bool) -> ElementsResult
@@ -258,11 +313,14 @@ effect fn functionPrefix(initial: State, operation: bool) -> ElementsResult
     let attached = run P.attach(move p.elements, run operator(move p.state))
     p = move attached
   }
-  let afterPubKeyword = run P.optional(move p, TokenKind.PubKeyword)
+  let afterPubKeyword = run move p
+    |> P.optional(TokenKind.PubKeyword)
   p = move afterPubKeyword
-  let afterStaticKeyword = run P.optional(move p, TokenKind.StaticKeyword)
+  let afterStaticKeyword = run move p
+    |> P.optional(TokenKind.StaticKeyword)
   p = move afterStaticKeyword
-  let afterUnsafeKeyword = run P.optional(move p, TokenKind.UnsafeKeyword)
+  let afterUnsafeKeyword = run move p
+    |> P.optional(TokenKind.UnsafeKeyword)
   p = move afterUnsafeKeyword
   return move p
 }
@@ -272,7 +330,8 @@ effect fn functionName(initial: ElementsResult, allowDrop: bool) -> ElementsResu
 ? &mut Allocator {
   let mut p = move initial
   if P.currentKind(&p.state) == TokenKind.EffectKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     if P.currentKind(&p.state) == TokenKind.Less {
       let withTypesEnvironment = run P.attach(
@@ -282,13 +341,16 @@ effect fn functionName(initial: ElementsResult, allowDrop: bool) -> ElementsResu
       p = move withTypesEnvironment
     }
   }
-  let afterFnKeyword = run P.expect(move p, TokenKind.FnKeyword)
+  let afterFnKeyword = run move p
+    |> P.expect(TokenKind.FnKeyword)
   p = move afterFnKeyword
   if allowDrop && P.currentKind(&p.state) == TokenKind.DropKeyword {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   } else {
-    let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier
   }
   return run Types.contract(move p)
@@ -297,9 +359,11 @@ effect fn functionName(initial: ElementsResult, allowDrop: bool) -> ElementsResu
 effect fn symbol(initial: ElementsResult) -> ElementsResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = move initial
   if P.currentKind(&p.state) == TokenKind.AsKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let afterTextLiteral = run P.expect(move p, TokenKind.TextLiteral)
+    let afterTextLiteral = run move p
+      |> P.expect(TokenKind.TextLiteral)
     p = move afterTextLiteral
   }
   return move p
@@ -313,9 +377,11 @@ effect fn functionDeclaration(initial: State, operation: bool, allowDrop: bool) 
   let foreign = marker == TokenKind.ExternKeyword
   let exported = marker == TokenKind.ExportKeyword
   if foreign || exported {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let afterTextLiteral = run P.expect(move p, TokenKind.TextLiteral)
+    let afterTextLiteral = run move p
+      |> P.expect(TokenKind.TextLiteral)
     p = move afterTextLiteral
   }
   let advanced = run functionName(move p, allowDrop)
@@ -334,12 +400,15 @@ effect fn functionDeclaration(initial: State, operation: bool, allowDrop: bool) 
     p = move attached
   }
   if operation {
-    return run P.complete(move p, NodeKind.ServiceOperation)
+    return run move p
+      |> P.complete(NodeKind.ServiceOperation)
   }
   if foreign {
-    return run P.complete(move p, NodeKind.ForeignFunctionDeclaration)
+    return run move p
+      |> P.complete(NodeKind.ForeignFunctionDeclaration)
   }
-  return run P.complete(move p, NodeKind.FunctionDeclaration)
+  return run move p
+    |> P.complete(NodeKind.FunctionDeclaration)
 }
 
 fn operationStart(state: &State) -> bool {
@@ -358,7 +427,8 @@ effect fn serviceDeclaration(initial: State, isInterface: bool) -> NodeResult
     keyword = TokenKind.InterfaceKeyword
   }
   let mut p = run nominalHeader(move initial, keyword)
-  let afterLeftBrace = run P.expect(move p, TokenKind.LeftBrace)
+  let afterLeftBrace = run move p
+    |> P.expect(TokenKind.LeftBrace)
   p = move afterLeftBrace
   while P.currentKind(&p.state) != TokenKind.RightBrace && P.currentKind(&p.state) != TokenKind.EndOfFile {
     if operationStart(&p.state) {
@@ -379,25 +449,34 @@ effect fn serviceDeclaration(initial: State, isInterface: bool) -> NodeResult
       p = move attached2
     }
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
   if isInterface {
-    return run P.complete(move p, NodeKind.InterfaceDeclaration)
+    return run move p
+      |> P.complete(NodeKind.InterfaceDeclaration)
   }
-  return run P.complete(move p, NodeKind.ServiceDeclaration)
+  return run move p
+    |> P.complete(NodeKind.ServiceDeclaration)
 }
 
 effect fn implOperation(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let withTypesPath = run P.attach(move p.elements, run Types.path(move p.state))
   p = move withTypesPath
-  return run P.complete(move p, NodeKind.ImplOperation)
+  return run move p
+    |> P.complete(NodeKind.ImplOperation)
 }
 
 effect fn implementation(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   if P.currentKind(&p.state) == TokenKind.Less {
     let withTypesParameters = run P.attach(
       move p.elements,
@@ -408,12 +487,14 @@ effect fn implementation(initial: State) -> NodeResult ! OutOfMemoryError ? &mut
   let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
   p = move withTypesParse
   if P.currentKind(&p.state) == TokenKind.ForKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let withTypesParse2 = run P.attach(move p.elements, run Types.parse(move p.state))
     p = move withTypesParse2
   }
-  let afterLeftBrace = run P.expect(move p, TokenKind.LeftBrace)
+  let afterLeftBrace = run move p
+    |> P.expect(TokenKind.LeftBrace)
   p = move afterLeftBrace
   while P.currentKind(&p.state) == TokenKind.Identifier || P.currentKind(&p.state) == TokenKind.PubKeyword || P.currentKind(
     &p.state,
@@ -433,28 +514,38 @@ effect fn implementation(initial: State) -> NodeResult ! OutOfMemoryError ? &mut
       }
     }
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, NodeKind.ImplDeclaration)
+  return run move p
+    |> P.complete(NodeKind.ImplDeclaration)
 }
 
 effect fn foreignStatic(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let imported = P.currentKind(&initial) == TokenKind.UnsafeKeyword
-  let mut p = run P.optional(P.begin(move initial), TokenKind.UnsafeKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.UnsafeKeyword)
   if imported {
-    let afterExternKeyword = run P.expect(move p, TokenKind.ExternKeyword)
+    let afterExternKeyword = run move p
+      |> P.expect(TokenKind.ExternKeyword)
     p = move afterExternKeyword
   } else {
-    let afterExportKeyword = run P.expect(move p, TokenKind.ExportKeyword)
+    let afterExportKeyword = run move p
+      |> P.expect(TokenKind.ExportKeyword)
     p = move afterExportKeyword
   }
-  let afterTextLiteral = run P.expect(move p, TokenKind.TextLiteral)
+  let afterTextLiteral = run move p
+    |> P.expect(TokenKind.TextLiteral)
   p = move afterTextLiteral
-  let afterStaticKeyword = run P.expect(move p, TokenKind.StaticKeyword)
+  let afterStaticKeyword = run move p
+    |> P.expect(TokenKind.StaticKeyword)
   p = move afterStaticKeyword
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
   p = move withTypesParse
@@ -463,21 +554,26 @@ effect fn foreignStatic(initial: State) -> NodeResult ! OutOfMemoryError ? &mut 
   if imported {
     let advanced2 = run Properties.list(move p)
     p = move advanced2
-    return run P.complete(move p, NodeKind.ForeignStaticDeclaration)
+    return run move p
+      |> P.complete(NodeKind.ForeignStaticDeclaration)
   }
-  let afterEquals = run P.expect(move p, TokenKind.Equals)
+  let afterEquals = run move p
+    |> P.expect(TokenKind.Equals)
   p = move afterEquals
   let withExpressionsParse = run P.attach(
     move p.elements,
     run Expressions.parse(move p.state, false),
   )
   p = move withExpressionsParse
-  return run P.complete(move p, NodeKind.ExportStaticDeclaration)
+  return run move p
+    |> P.complete(NodeKind.ExportStaticDeclaration)
 }
 
 effect fn group(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let opened = P.currentKind(&initial) == TokenKind.LeftBrace
-  let mut p = run P.expect(P.begin(move initial), TokenKind.LeftBrace)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.LeftBrace)
   if opened {
     while P.currentKind(&p.state) != TokenKind.RightBrace && P.currentKind(&p.state) != TokenKind.ElseKeyword && P.currentKind(
       &p.state,
@@ -486,19 +582,23 @@ effect fn group(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocato
       let attached = run P.attach(move p.elements, run parse(move p.state))
       p = move attached
       if p.state.index == before {
-        let advanced = run P.unexpected(move p)
+        let advanced = run move p
+          |> P.unexpected
         p = move advanced
       }
     }
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, NodeKind.DeclarationGroup)
+  return run move p
+    |> P.complete(NodeKind.DeclarationGroup)
 }
 
 effect fn staticConditional(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -509,8 +609,11 @@ effect fn staticConditional(initial: State) -> NodeResult ! OutOfMemoryError ? &
 }
 
 effect fn staticConditionalInner(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
-  let afterIfKeyword = run P.expect(move p, TokenKind.IfKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
+  let afterIfKeyword = run move p
+    |> P.expect(TokenKind.IfKeyword)
   p = move afterIfKeyword
   let withExpressionsParse = run P.attach(
     move p.elements,
@@ -520,7 +623,8 @@ effect fn staticConditionalInner(initial: State) -> NodeResult ! OutOfMemoryErro
   let attached = run P.attach(move p.elements, run group(move p.state))
   p = move attached
   if P.currentKind(&p.state) == TokenKind.ElseKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     if P.currentKind(&p.state) == TokenKind.StaticKeyword {
       let attached2 = run P.attach(move p.elements, run staticConditional(move p.state))
@@ -530,7 +634,8 @@ effect fn staticConditionalInner(initial: State) -> NodeResult ! OutOfMemoryErro
       p = move attached3
     }
   }
-  return run P.complete(move p, NodeKind.StaticConditionalDeclaration)
+  return run move p
+    |> P.complete(NodeKind.StaticConditionalDeclaration)
 }
 
 /// Parses a declaration selected from its significant-token prefix, preserving damaged regions.
@@ -597,10 +702,13 @@ pub effect fn parse(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
     return run implementation(move initial)
   }
   if P.word(&initial, "module") {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let withPropertiesClause = run P.attach(move p.elements, run Properties.clause(move p.state))
     p = move withPropertiesClause
-    return run P.complete(move p, NodeKind.ModulePropertyDeclaration)
+    return run move p
+      |> P.complete(NodeKind.ModulePropertyDeclaration)
   }
   if head == TokenKind.FnKeyword || head == TokenKind.EffectKeyword || head == TokenKind.UnsafeKeyword || head == TokenKind.ExternKeyword || head == TokenKind.ExportKeyword || head == TokenKind.StaticKeyword {
     return run functionDeclaration(move initial, false, false)

--- a/compiler/src/parser/Declaration.silk
+++ b/compiler/src/parser/Declaration.silk
@@ -497,7 +497,7 @@ effect fn group(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocato
 }
 
 effect fn staticConditional(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  if initial.depth >= 256 {
+  if initial.depth >= P.NESTING_LIMIT {
     return run P.nestingError(move initial)
   }
   let depth = initial.depth

--- a/compiler/src/parser/Expression.silk
+++ b/compiler/src/parser/Expression.silk
@@ -19,42 +19,55 @@ effect fn literal(initial: State, nodeKind: NodeKind) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
   let negative = P.currentKind(&initial) == TokenKind.Minus
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   if negative && nodeKind == NodeKind.IntegerLiteralExpression && P.currentKind(&p.state) == TokenKind.DecimalInteger {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   } else if negative && nodeKind == NodeKind.FloatingLiteralExpression && P.currentKind(&p.state) == TokenKind.DecimalFloat {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   }
-  return run P.complete(move p, nodeKind)
+  return run move p
+    |> P.complete(nodeKind)
 }
 
 effect fn field(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let attached = run P.attach(move p.elements, run parse(move p.state, true))
   p = move attached
-  return run P.complete(move p, NodeKind.StructFieldInitializer)
+  return run move p
+    |> P.complete(NodeKind.StructFieldInitializer)
 }
 
 effect fn recordFields(initial: ElementsResult, kind: NodeKind) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(move initial, TokenKind.LeftBrace)
+  let mut p = run move initial
+    |> P.expect(TokenKind.LeftBrace)
   while P.currentKind(&p.state) == TokenKind.Identifier {
     let attached = run P.attach(move p.elements, run field(move p.state))
     p = move attached
     if P.currentKind(&p.state) == TokenKind.RightBrace {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, kind)
+  return run move p
+    |> P.complete(kind)
 }
 
 effect fn identifier(initial: State, allowRecord: bool) -> NodeResult
@@ -65,7 +78,8 @@ effect fn identifier(initial: State, allowRecord: bool) -> NodeResult
     if allowRecord && P.currentKind(&p.state) == TokenKind.LeftBrace {
       return run recordFields(move p, NodeKind.AppliedMemberExpression)
     }
-    return run P.complete(move p, NodeKind.AppliedMemberExpression)
+    return run move p
+      |> P.complete(NodeKind.AppliedMemberExpression)
   }
   if allowRecord && Look.record(&initial) {
     return run recordFields(
@@ -73,14 +87,17 @@ effect fn identifier(initial: State, allowRecord: bool) -> NodeResult
       NodeKind.StructLiteralExpression,
     )
   }
-  return run P.complete(
-    run P.expect(P.begin(move initial), TokenKind.Identifier),
-    NodeKind.IdentifierExpression,
-  )
+  let identifier = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
+  return run move identifier
+    |> P.complete(NodeKind.IdentifierExpression)
 }
 
 effect fn grouped(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   if P.currentKind(&p.state) == TokenKind.RightParenthesis {
     return run P.complete(run P.consume(move p), NodeKind.UnitExpression)
   }
@@ -88,7 +105,8 @@ effect fn grouped(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
   p = move attached
   let isTuple = P.currentKind(&p.state) == TokenKind.Comma
   while P.currentKind(&p.state) == TokenKind.Comma {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     if P.currentKind(&p.state) == TokenKind.RightParenthesis {
       break
@@ -100,16 +118,21 @@ effect fn grouped(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
       break
     }
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
   if isTuple {
-    return run P.complete(move p, NodeKind.TupleLiteralExpression)
+    return run move p
+      |> P.complete(NodeKind.TupleLiteralExpression)
   }
-  return run P.complete(move p, NodeKind.GroupedExpression)
+  return run move p
+    |> P.complete(NodeKind.GroupedExpression)
 }
 
 effect fn array(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   while G.expressionStart(P.currentKind(&p.state)) && !G.blockEnd(&p.state) {
     let before = p.state.index
     let attached = run P.attach(move p.elements, run parse(move p.state, true))
@@ -117,16 +140,21 @@ effect fn array(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocato
     if p.state.index == before || P.currentKind(&p.state) == TokenKind.RightBracket {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightBracket = run P.expect(move p, TokenKind.RightBracket)
+  let afterRightBracket = run move p
+    |> P.expect(TokenKind.RightBracket)
   p = move afterRightBracket
-  return run P.complete(move p, NodeKind.ArrayLiteralExpression)
+  return run move p
+    |> P.complete(NodeKind.ArrayLiteralExpression)
 }
 
 effect fn arguments(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.LeftParenthesis)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.LeftParenthesis)
   while G.expressionStart(P.currentKind(&p.state)) && !G.blockEnd(&p.state) {
     let before = p.state.index
     let attached = run P.attach(move p.elements, run parse(move p.state, true))
@@ -134,12 +162,15 @@ effect fn arguments(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
     if p.state.index == before || P.currentKind(&p.state) == TokenKind.RightParenthesis {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  return run P.complete(move p, NodeKind.ArgumentList)
+  return run move p
+    |> P.complete(NodeKind.ArgumentList)
 }
 
 /// Extends a completed expression with calls and place projections without recursive left nesting.
@@ -151,7 +182,8 @@ pub effect fn postfix(initial: NodeResult) -> NodeResult ! OutOfMemoryError ? &m
   while true {
     let kind = P.currentKind(&result.state)
     if kind == TokenKind.Less && Look.afterAngles(&result.state, 0) == TokenKind.LeftParenthesis {
-      let mut p = run P.wrap(move result)
+      let mut p = run move result
+        |> P.wrap
       let withTypesArguments = run P.attach(
         move p.elements,
         run Types.arguments(move p.state, true),
@@ -159,42 +191,52 @@ pub effect fn postfix(initial: NodeResult) -> NodeResult ! OutOfMemoryError ? &m
       p = move withTypesArguments
       let attached = run P.attach(move p.elements, run arguments(move p.state))
       p = move attached
-      let completed = run P.complete(move p, NodeKind.CallExpression)
+      let completed = run move p
+        |> P.complete(NodeKind.CallExpression)
       result = move completed
     } else if kind == TokenKind.LeftParenthesis {
-      let mut p = run P.wrap(move result)
+      let mut p = run move result
+        |> P.wrap
       let attached2 = run P.attach(move p.elements, run arguments(move p.state))
       p = move attached2
-      let completed2 = run P.complete(move p, NodeKind.CallExpression)
+      let completed2 = run move p
+        |> P.complete(NodeKind.CallExpression)
       result = move completed2
     } else if kind == TokenKind.Dot {
       let mut p = run P.consume(run P.wrap(move result))
       let member = P.currentKind(&p.state)
       let mut nodeKind = NodeKind.FieldProjectionExpression
       if member == TokenKind.Star {
-        let consumed = run P.consume(move p)
+        let consumed = run move p
+          |> P.consume
         p = move consumed
         nodeKind = NodeKind.ReferentProjectionExpression
       } else if member == TokenKind.DecimalInteger {
-        let consumed2 = run P.consume(move p)
+        let consumed2 = run move p
+          |> P.consume
         p = move consumed2
         nodeKind = NodeKind.OrdinalProjectionExpression
       } else if member == TokenKind.DropKeyword {
-        let consumed3 = run P.consume(move p)
+        let consumed3 = run move p
+          |> P.consume
         p = move consumed3
       } else {
-        let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+        let afterIdentifier = run move p
+          |> P.expect(TokenKind.Identifier)
         p = move afterIdentifier
       }
-      let completed3 = run P.complete(move p, nodeKind)
+      let completed3 = run move p
+        |> P.complete(nodeKind)
       result = move completed3
     } else if kind == TokenKind.LeftBracket && !P.lineBreakBefore(&result.state) {
       let mut p = run P.consume(run P.wrap(move result))
       let attached3 = run P.attach(move p.elements, run parse(move p.state, true))
       p = move attached3
-      let afterRightBracket = run P.expect(move p, TokenKind.RightBracket)
+      let afterRightBracket = run move p
+        |> P.expect(TokenKind.RightBracket)
       p = move afterRightBracket
-      let completed4 = run P.complete(move p, NodeKind.IndexProjectionExpression)
+      let completed4 = run move p
+        |> P.complete(NodeKind.IndexProjectionExpression)
       result = move completed4
     } else {
       break
@@ -204,8 +246,11 @@ pub effect fn postfix(initial: NodeResult) -> NodeResult ! OutOfMemoryError ? &m
 }
 
 effect fn anonymous(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.optional(P.begin(move initial), TokenKind.EffectKeyword)
-  let afterFnKeyword = run P.expect(move p, TokenKind.FnKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.EffectKeyword)
+  let afterFnKeyword = run move p
+    |> P.expect(TokenKind.FnKeyword)
   p = move afterFnKeyword
   let withTypesParameterList = run P.attach(move p.elements, run Types.parameterList(move p.state))
   p = move withTypesParameterList
@@ -227,35 +272,43 @@ effect fn anonymous(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
     run Statements.block(move p.state, true, false),
   )
   p = move withStatementsBlock
-  return run P.complete(move p, NodeKind.AnonymousCallableExpression)
+  return run move p
+    |> P.complete(NodeKind.AnonymousCallableExpression)
 }
 
 effect fn matchAccess(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = P.begin(move initial)
   if P.word(&p.state, "place") && P.peek(&p.state, 1) == TokenKind.Identifier {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   } else if P.currentKind(&p.state) == TokenKind.MoveKeyword {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   } else if P.currentKind(&p.state) == TokenKind.Ampersand {
-    let consumed3 = run P.consume(move p)
+    let consumed3 = run move p
+      |> P.consume
     p = move consumed3
-    let afterMutKeyword = run P.optional(move p, TokenKind.MutKeyword)
+    let afterMutKeyword = run move p
+      |> P.optional(TokenKind.MutKeyword)
     p = move afterMutKeyword
   }
-  return run P.complete(move p, NodeKind.MatchAccess)
+  return run move p
+    |> P.complete(NodeKind.MatchAccess)
 }
 
 effect fn arm(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run P.wrap(run Patterns.parse(move initial))
   if P.currentKind(&p.state) == TokenKind.IfKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached = run P.attach(move p.elements, run parse(move p.state, false))
     p = move attached
   }
-  let afterFatArrow = run P.expect(move p, TokenKind.FatArrow)
+  let afterFatArrow = run move p
+    |> P.expect(TokenKind.FatArrow)
   p = move afterFatArrow
   if P.currentKind(&p.state) == TokenKind.LeftBrace {
     let withStatementsBlock = run P.attach(
@@ -267,40 +320,52 @@ effect fn arm(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator 
     let attached2 = run P.attach(move p.elements, run parse(move p.state, true))
     p = move attached2
   }
-  return run P.complete(move p, NodeKind.MatchArm)
+  return run move p
+    |> P.complete(NodeKind.MatchArm)
 }
 
 effect fn matchExpression(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let attached = run P.attach(move p.elements, run matchAccess(move p.state))
   p = move attached
   let attached2 = run P.attach(move p.elements, run parse(move p.state, false))
   p = move attached2
-  let afterLeftBrace = run P.expect(move p, TokenKind.LeftBrace)
+  let afterLeftBrace = run move p
+    |> P.expect(TokenKind.LeftBrace)
   p = move afterLeftBrace
   while !G.blockEnd(&p.state) {
     let before = p.state.index
     let attached3 = run P.attach(move p.elements, run arm(move p.state))
     p = move attached3
     if p.state.index == before {
-      let advanced = run P.unexpected(move p)
+      let advanced = run move p
+        |> P.unexpected
       p = move advanced
     }
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, NodeKind.MatchExpression)
+  return run move p
+    |> P.complete(NodeKind.MatchExpression)
 }
 
 effect fn compileErrorExpression(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
-  let afterLeftParenthesis = run P.expect(move p, TokenKind.LeftParenthesis)
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
+  let afterLeftParenthesis = run move p
+    |> P.expect(TokenKind.LeftParenthesis)
   p = move afterLeftParenthesis
   let attached = run P.attach(move p.elements, run parse(move p.state, true))
   p = move attached
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  return run P.complete(move p, NodeKind.CompileErrorExpression)
+  return run move p
+    |> P.complete(NodeKind.CompileErrorExpression)
 }
 
 effect fn primary(initial: State, allowRecord: bool) -> NodeResult
@@ -354,13 +419,16 @@ effect fn primary(initial: State, allowRecord: bool) -> NodeResult
     return run anonymous(move initial)
   }
   if kind == TokenKind.EffectKeyword {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let withStatementsBlock = run P.attach(
       move p.elements,
       run Statements.block(move p.state, true, false),
     )
     p = move withStatementsBlock
-    return run P.complete(move p, NodeKind.EffectExpression)
+    return run move p
+      |> P.complete(NodeKind.EffectExpression)
   }
   if kind == TokenKind.MatchKeyword {
     return run matchExpression(move initial)
@@ -369,16 +437,22 @@ effect fn primary(initial: State, allowRecord: bool) -> NodeResult
     return run compileErrorExpression(move initial)
   }
   if kind == TokenKind.RunKeyword {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let attached = run P.attach(move p.elements, run parse(move p.state, allowRecord))
     p = move attached
-    return run P.complete(move p, NodeKind.RunExpression)
+    return run move p
+      |> P.complete(NodeKind.RunExpression)
   }
   if kind == TokenKind.MoveKeyword || kind == TokenKind.Ampersand || kind == TokenKind.UnsafeKeyword {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let mut nodeKind = NodeKind.MoveExpression
     if kind == TokenKind.Ampersand {
-      let afterMutKeyword = run P.optional(move p, TokenKind.MutKeyword)
+      let afterMutKeyword = run move p
+        |> P.optional(TokenKind.MutKeyword)
       p = move afterMutKeyword
       nodeKind = NodeKind.BorrowExpression
     } else if kind == TokenKind.UnsafeKeyword {
@@ -386,30 +460,38 @@ effect fn primary(initial: State, allowRecord: bool) -> NodeResult
     }
     let attached2 = run P.attach(move p.elements, run infix(move p.state, 11, allowRecord))
     p = move attached2
-    return run P.complete(move p, nodeKind)
+    return run move p
+      |> P.complete(nodeKind)
   }
   if kind == TokenKind.Minus || kind == TokenKind.Bang || kind == TokenKind.Tilde {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let attached3 = run P.attach(move p.elements, run infix(move p.state, 11, allowRecord))
     p = move attached3
-    return run P.complete(move p, NodeKind.PrefixExpression)
+    return run move p
+      |> P.complete(NodeKind.PrefixExpression)
   }
   let mut p = P.begin(move initial)
   if kind == TokenKind.Invalid || kind == TokenKind.Less {
-    let advanced = run P.unexpected(move p)
+    let advanced = run move p
+      |> P.unexpected
     p = move advanced
   } else {
-    let afterIdentifier = run P.missing(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.missing(TokenKind.Identifier)
     p = move afterIdentifier
   }
-  return run P.complete(move p, NodeKind.Error)
+  return run move p
+    |> P.complete(NodeKind.Error)
 }
 
 effect fn infix(initial: State, minimum: usize, allowRecord: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -437,10 +519,12 @@ effect fn infixInner(initial: State, minimum: usize, allowRecord: bool) -> NodeR
     )
     p = move attached
     if kind == TokenKind.PipeGreater {
-      let completed = run P.complete(move p, NodeKind.PipelineExpression)
+      let completed = run move p
+        |> P.complete(NodeKind.PipelineExpression)
       left = move completed
     } else {
-      let completed2 = run P.complete(move p, NodeKind.InfixExpression)
+      let completed2 = run move p
+        |> P.complete(NodeKind.InfixExpression)
       left = move completed2
     }
     if precedence == 4 || precedence == 5 {

--- a/compiler/src/parser/Expression.silk
+++ b/compiler/src/parser/Expression.silk
@@ -306,20 +306,6 @@ effect fn compileErrorExpression(initial: State) -> NodeResult ! OutOfMemoryErro
 effect fn primary(initial: State, allowRecord: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  if initial.depth >= 256 {
-    return run P.nestingError(move initial)
-  }
-  let depth = initial.depth
-  let mut state = move initial
-  state.depth = Usize.add(depth, 1)
-  let mut result = run primaryInner(move state, allowRecord)
-  result.state.depth = depth
-  return move result
-}
-
-effect fn primaryInner(initial: State, allowRecord: bool) -> NodeResult
-! OutOfMemoryError
-? &mut Allocator {
   let kind = P.currentKind(&initial)
   if kind == TokenKind.Identifier {
     return run identifier(move initial, allowRecord)
@@ -398,19 +384,13 @@ effect fn primaryInner(initial: State, allowRecord: bool) -> NodeResult
     } else if kind == TokenKind.UnsafeKeyword {
       nodeKind = NodeKind.UnsafeExpression
     }
-    let attached2 = run P.attach(
-      move p.elements,
-      run postfix(run primary(move p.state, allowRecord)),
-    )
+    let attached2 = run P.attach(move p.elements, run infix(move p.state, 11, allowRecord))
     p = move attached2
     return run P.complete(move p, nodeKind)
   }
   if kind == TokenKind.Minus || kind == TokenKind.Bang || kind == TokenKind.Tilde {
     let mut p = run P.consume(P.begin(move initial))
-    let attached3 = run P.attach(
-      move p.elements,
-      run postfix(run primary(move p.state, allowRecord)),
-    )
+    let attached3 = run P.attach(move p.elements, run infix(move p.state, 11, allowRecord))
     p = move attached3
     return run P.complete(move p, NodeKind.PrefixExpression)
   }
@@ -426,6 +406,20 @@ effect fn primaryInner(initial: State, allowRecord: bool) -> NodeResult
 }
 
 effect fn infix(initial: State, minimum: usize, allowRecord: bool) -> NodeResult
+! OutOfMemoryError
+? &mut Allocator {
+  if initial.depth >= P.NESTING_LIMIT {
+    return run P.nestingError(move initial)
+  }
+  let depth = initial.depth
+  let mut state = move initial
+  state.depth = Usize.add(depth, 1)
+  let mut result = run infixInner(move state, minimum, allowRecord)
+  result.state.depth = depth
+  return move result
+}
+
+effect fn infixInner(initial: State, minimum: usize, allowRecord: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
   let mut left = run postfix(run primary(move initial, allowRecord))

--- a/compiler/src/parser/Import.silk
+++ b/compiler/src/parser/Import.silk
@@ -80,9 +80,13 @@ effect fn attach(elements: Vector<Element>, result: NodeResult) -> ElementsResul
 
 effect fn parseImportAlias(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let start = Parsing.insertionSpan(&initial)
-  let keyword = run Parsing.expect(Parsing.begin(move initial), TokenKind.AsKeyword)
-  let name = run Parsing.expect(move keyword, TokenKind.Identifier)
-  return run Parsing.finish(move name, NodeKind.ImportAlias, start)
+  let keyword = run move initial
+    |> Parsing.begin
+    |> Parsing.expect(TokenKind.AsKeyword)
+  let name = run move keyword
+    |> Parsing.expect(TokenKind.Identifier)
+  return run move name
+    |> Parsing.finish(NodeKind.ImportAlias, start)
 }
 
 effect fn parseImportPath(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
@@ -91,30 +95,38 @@ effect fn parseImportPath(initial: State) -> NodeResult ! OutOfMemoryError ? &mu
   let following = Parsing.peek(&path.state, 1)
   let startsNextDeclaration = G.declarationStart(&path.state) && following != TokenKind.Dot && following != TokenKind.AsKeyword && following != TokenKind.LeftBrace && following != TokenKind.EndOfFile
   if Parsing.hasCurrent(&path.state) && isImportSegment(Parsing.currentKind(&path.state)) && !startsNextDeclaration {
-    let consumed = run Parsing.consume(move path)
+    let consumed = run move path
+      |> Parsing.consume
     path = move consumed
   } else {
-    let missing = run Parsing.missing(move path, TokenKind.Identifier)
+    let missing = run move path
+      |> Parsing.missing(TokenKind.Identifier)
     path = move missing
   }
   while Parsing.currentKind(&path.state) == TokenKind.Dot {
-    let withDot = run Parsing.consume(move path)
+    let withDot = run move path
+      |> Parsing.consume
     path = move withDot
     if Parsing.hasCurrent(&path.state) && isImportSegment(Parsing.currentKind(&path.state)) {
-      let withSegment = run Parsing.consume(move path)
+      let withSegment = run move path
+        |> Parsing.consume
       path = move withSegment
     } else {
-      let missing = run Parsing.missing(move path, TokenKind.Identifier)
+      let missing = run move path
+        |> Parsing.missing(TokenKind.Identifier)
       path = move missing
       break
     }
   }
-  return run Parsing.finish(move path, NodeKind.ImportPath, start)
+  return run move path
+    |> Parsing.finish(NodeKind.ImportPath, start)
 }
 
 effect fn parseImportMember(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let start = Parsing.insertionSpan(&initial)
-  let named = run Parsing.expect(Parsing.begin(move initial), TokenKind.Identifier)
+  let named = run move initial
+    |> Parsing.begin
+    |> Parsing.expect(TokenKind.Identifier)
   let hasAlias = Parsing.currentKind(&named.state) == TokenKind.AsKeyword
   let mut member = move named
   if hasAlias {
@@ -123,12 +135,15 @@ effect fn parseImportMember(initial: State) -> NodeResult ! OutOfMemoryError ? &
     let attached = run attach(move elements, move alias)
     member = move attached
   }
-  return run Parsing.finish(move member, NodeKind.ImportMember, start)
+  return run move member
+    |> Parsing.finish(NodeKind.ImportMember, start)
 }
 
 effect fn parseImportMemberList(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let start = Parsing.insertionSpan(&initial)
-  let left = run Parsing.expect(Parsing.begin(move initial), TokenKind.LeftBrace)
+  let left = run move initial
+    |> Parsing.begin
+    |> Parsing.expect(TokenKind.LeftBrace)
   let ElementsResult {state: afterLeft, elements: initialElements} = move left
   let mut state = move afterLeft
   let mut elements = move initialElements
@@ -145,8 +160,11 @@ effect fn parseImportMemberList(initial: State) -> NodeResult ! OutOfMemoryError
       parsedMember = true
     } else {
       let errorStart = Parsing.insertionSpan(&state)
-      let unexpected = run Parsing.unexpected(Parsing.begin(move state))
-      let result = run Parsing.finish(move unexpected, NodeKind.Error, errorStart)
+      let unexpected = run move state
+        |> Parsing.begin
+        |> Parsing.unexpected
+      let result = run move unexpected
+        |> Parsing.finish(NodeKind.Error, errorStart)
       let NodeResult {state: afterError, node} = move result
       state = move afterError
       run Vector.append<Element>(&mut elements, Element.Node {id: node})
@@ -182,8 +200,10 @@ effect fn parseImportMemberList(initial: State) -> NodeResult ! OutOfMemoryError
     let withMember = run Parsing.attach(move emptyElements, move missingMember)
     list = move withMember
   }
-  let right = run Parsing.expect(move list, TokenKind.RightBrace)
-  return run Parsing.finish(move right, NodeKind.ImportMemberList, start)
+  let right = run move list
+    |> Parsing.expect(TokenKind.RightBrace)
+  return run move right
+    |> Parsing.finish(NodeKind.ImportMemberList, start)
 }
 
 /// Parses one import declaration and appends its nodes to the shared flat node array.
@@ -215,10 +235,12 @@ pub effect fn parseImportDeclaration(initial: State) -> NodeResult
 
   if Parsing.currentKind(&declaration.state) == TokenKind.PubKeyword {
     isPublic = true
-    let consumed = run Parsing.consume(move declaration)
+    let consumed = run move declaration
+      |> Parsing.consume
     declaration = move consumed
   }
-  let keyword = run Parsing.expect(move declaration, TokenKind.ImportKeyword)
+  let keyword = run move declaration
+    |> Parsing.expect(TokenKind.ImportKeyword)
   let ElementsResult {state: afterKeyword, elements: keywordElements} = move keyword
   let path = run parseImportPath(move afterKeyword)
   let withPath = run attach(move keywordElements, move path)
@@ -240,9 +262,11 @@ pub effect fn parseImportDeclaration(initial: State) -> NodeResult
   }
 
   if isPublic && !hasMembers {
-    let missing = run Parsing.missing(move declaration, TokenKind.LeftBrace)
+    let missing = run move declaration
+      |> Parsing.missing(TokenKind.LeftBrace)
     declaration = move missing
   }
 
-  return run Parsing.finish(move declaration, NodeKind.ImportDeclaration, start)
+  return run move declaration
+    |> Parsing.finish(NodeKind.ImportDeclaration, start)
 }

--- a/compiler/src/parser/ParseState.silk
+++ b/compiler/src/parser/ParseState.silk
@@ -36,6 +36,12 @@ import silk.string {String}
 import silk.usize as Usize
 import silk.vector {Vector}
 
+/// Maximum number of active recursive grammar operations.
+///
+/// The parser reports `NestingLimit` before it enters an operation beyond this budget.
+/// Sibling operations reuse the budget. This is not a limit on the number of nodes in a file.
+pub const NESTING_LIMIT: usize = 32
+
 /// All mutable data for one parse, passed by ownership between grammar operations.
 ///
 /// # Details
@@ -511,12 +517,20 @@ pub effect fn nestingError(initial: State) -> NodeResult ! OutOfMemoryError ? &m
   let location = insertionSpan(&p.state)
   run Vector.append<Diagnostic>(
     &mut p.state.diagnostics,
-    Diagnostic.NestingLimit {limit: 256, span: location},
+    Diagnostic.NestingLimit {limit: NESTING_LIMIT, span: location},
   )
   let mut closing = Vector.make<TokenKind>()
   while currentKind(&p.state) != TokenKind.EndOfFile {
     let kind = currentKind(&p.state)
     let length = Vector.length<TokenKind>(&closing)
+    // A named function cannot belong to an expression or type, even if damaged source left
+    // delimiters open. Anonymous fn(...) and effect {...} remain part of the skipped branch.
+    if (kind == TokenKind.FnKeyword && peek(&p.state, 1) == TokenKind.Identifier) || (kind == TokenKind.EffectKeyword && peek(
+      &p.state,
+      1,
+    ) == TokenKind.FnKeyword && peek(&p.state, 2) == TokenKind.Identifier) || kind == TokenKind.PubKeyword {
+      break
+    }
     if length == 0 && (kind == TokenKind.RightParenthesis || kind == TokenKind.RightBracket || kind == TokenKind.RightBrace || kind == TokenKind.Comma || kind == TokenKind.FatArrow || kind == TokenKind.LetKeyword || kind == TokenKind.ReturnKeyword || kind == TokenKind.PubKeyword) {
       break
     }
@@ -534,9 +548,6 @@ pub effect fn nestingError(initial: State) -> NodeResult ! OutOfMemoryError ? &m
     }
     let next = run consume(move p)
     p = move next
-    if Vector.length<TokenKind>(&closing) == 0 {
-      break
-    }
   }
   return run complete(move p, NodeKind.Error)
 }

--- a/compiler/src/parser/ParseState.silk
+++ b/compiler/src/parser/ParseState.silk
@@ -104,7 +104,9 @@ fn significantIndex(state: &State) -> usize {
   let mut index = state.index
   while index < Vector.length<Token>(&state.tokens) {
     let token = Vector.get<Token>(&state.tokens, index)
-    if !isTrivia(kind(token)) {
+    if !(token
+      |> kind
+      |> isTrivia) {
       return index
     }
     index = Usize.add(index, Usize.ONE)
@@ -115,7 +117,9 @@ fn significantIndex(state: &State) -> usize {
 fn elementSpan(state: &State, element: Element) -> Span {
   return match move element {
     Element.Node {id} => Vector.asSlice<Node>(&state.nodes)[id.index].span
-    Element.Token {id} => span(Vector.get<Token>(&state.tokens, id.index))
+    Element.Token {id} => &state.tokens
+      |> Vector.get<Token>(id.index)
+      |> span
     Element.MissingToken {expected: ignoredExpected, span} => span
   }
 }
@@ -168,7 +172,9 @@ pub fn currentKind(state: &State) -> TokenKind {
   if Vector.length<Token>(&state.tokens) <= index {
     return TokenKind.EndOfFile
   }
-  return kind(Vector.get<Token>(&state.tokens, index))
+  return &state.tokens
+    |> Vector.get<Token>(index)
+    |> kind
 }
 
 /// Returns the zero-width source span for a missing token at the current position.
@@ -182,14 +188,18 @@ pub fn currentKind(state: &State) -> TokenKind {
 pub fn insertionSpan(state: &State) -> Span {
   let index = significantIndex(state)
   if index < Vector.length<Token>(&state.tokens) {
-    let tokenSpan = span(Vector.get<Token>(&state.tokens, index))
+    let tokenSpan = &state.tokens
+      |> Vector.get<Token>(index)
+      |> span
     return Span.make(tokenSpan.start, tokenSpan.start)
   }
   let length = Vector.length<Token>(&state.tokens)
   if length == Usize.ZERO {
     return Span.make(Usize.ZERO, Usize.ZERO)
   }
-  let finalSpan = span(Vector.get<Token>(&state.tokens, Usize.subtract(length, Usize.ONE)))
+  let finalSpan = &state.tokens
+    |> Vector.get<Token>(Usize.subtract(length, Usize.ONE))
+    |> span
   return Span.make(finalSpan.end, finalSpan.end)
 }
 
@@ -387,7 +397,9 @@ pub fn peek(state: &State, offset: usize) -> TokenKind {
   let mut index = significantIndex(state)
   let mut remaining = offset
   while index < Vector.length<Token>(&state.tokens) {
-    let candidate = kind(Vector.get<Token>(&state.tokens, index))
+    let candidate = &state.tokens
+      |> Vector.get<Token>(index)
+      |> kind
     if !isTrivia(candidate) {
       if remaining == 0 {
         return candidate
@@ -408,7 +420,9 @@ pub fn word(state: &State, expected: string) -> bool {
     return false
   }
   let tokenIndex = significantIndex(state)
-  let location = span(Vector.get<Token>(&state.tokens, tokenIndex))
+  let location = &state.tokens
+    |> Vector.get<Token>(tokenIndex)
+    |> span
   let bytes = Bytes.asSlice(&state.source)
   let text = String.utf8Bytes(expected)
   if location.end > bytes.length || Usize.subtract(location.end, location.start) != text.length {
@@ -432,7 +446,10 @@ pub fn lineBreakBefore(state: &State) -> bool {
   let mut index = end
   if state.index < Vector.length<Token>(&state.tokens) {
     let tokenIndex = state.index
-    index = span(Vector.get<Token>(&state.tokens, tokenIndex)).start
+    let location = &state.tokens
+      |> Vector.get<Token>(tokenIndex)
+      |> span
+    index = location.start
   }
   let bytes = Bytes.asSlice(&state.source)
   while index < end && index < bytes.length {

--- a/compiler/src/parser/Parser.silk
+++ b/compiler/src/parser/Parser.silk
@@ -76,6 +76,8 @@ pub effect fn parse(source: Bytes, tokens: Vector<Token>) -> SyntaxTree
     ElementsResult {state: move state, elements: move elements},
     TokenKind.EndOfFile,
   )
-  let sourceFile = run Parsing.finishSourceFile(move endOfFile)
-  return Parsing.intoSyntaxTree(move sourceFile)
+  let sourceFile = run move endOfFile
+    |> Parsing.finishSourceFile
+  return move sourceFile
+    |> Parsing.intoSyntaxTree
 }

--- a/compiler/src/parser/Pattern.silk
+++ b/compiler/src/parser/Pattern.silk
@@ -14,48 +14,60 @@ import silk.usize as Usize
 /// Parses the parent type and member name of an applied variant or operation selector.
 pub effect fn selector(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run P.wrap(run Types.named(move initial))
-  let afterDot = run P.expect(move p, TokenKind.Dot)
+  let afterDot = run move p
+    |> P.expect(TokenKind.Dot)
   p = move afterDot
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  return run P.complete(move p, NodeKind.AppliedMemberSelector)
+  return run move p
+    |> P.complete(NodeKind.AppliedMemberSelector)
 }
 
 effect fn field(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   if P.currentKind(&initial) == TokenKind.DotDot {
     return run P.complete(run P.consume(P.begin(move initial)), NodeKind.RestPattern)
   }
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
   if P.currentKind(&p.state) == TokenKind.Colon {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     if Look.record(&p.state) || Look.appliedMember(&p.state) {
       let attached = run P.attach(move p.elements, run parse(move p.state))
       p = move attached
     } else {
-      let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+      let afterIdentifier = run move p
+        |> P.expect(TokenKind.Identifier)
       p = move afterIdentifier
     }
   }
-  return run P.complete(move p, NodeKind.PatternField)
+  return run move p
+    |> P.complete(NodeKind.PatternField)
 }
 
 effect fn fields(initial: ElementsResult, kind: NodeKind) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(move initial, TokenKind.LeftBrace)
+  let mut p = run move initial
+    |> P.expect(TokenKind.LeftBrace)
   while P.currentKind(&p.state) == TokenKind.Identifier || P.currentKind(&p.state) == TokenKind.DotDot {
     let attached = run P.attach(move p.elements, run field(move p.state))
     p = move attached
     if P.currentKind(&p.state) == TokenKind.RightBrace {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, kind)
+  return run move p
+    |> P.complete(kind)
 }
 
 /// Parses one complete pattern, stopping before its guard, initializer, or arm separator.
@@ -64,7 +76,8 @@ effect fn fields(initial: ElementsResult, kind: NodeKind) -> NodeResult
 /// by its enclosing rule, allowing the remainder of the arm or binding to stay navigable.
 pub effect fn parse(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -80,28 +93,38 @@ effect fn parseInner(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
     return run P.complete(run P.consume(P.begin(move initial)), NodeKind.UniversalPattern)
   }
   if kind == TokenKind.DecimalInteger || (kind == TokenKind.Minus && P.peek(&initial, 1) == TokenKind.DecimalInteger) {
-    let mut p = run P.optional(P.begin(move initial), TokenKind.Minus)
-    let afterDecimalInteger = run P.expect(move p, TokenKind.DecimalInteger)
+    let mut p = run move initial
+      |> P.begin
+      |> P.optional(TokenKind.Minus)
+    let afterDecimalInteger = run move p
+      |> P.expect(TokenKind.DecimalInteger)
     p = move afterDecimalInteger
-    return run P.complete(move p, NodeKind.IntegerPattern)
+    return run move p
+      |> P.complete(NodeKind.IntegerPattern)
   }
   if Look.appliedMember(&initial) {
     let p = run P.wrap(run selector(move initial))
     if P.currentKind(&p.state) == TokenKind.LeftBrace {
       return run fields(move p, NodeKind.UnionVariantPattern)
     }
-    return run P.complete(move p, NodeKind.UnionVariantPattern)
+    return run move p
+      |> P.complete(NodeKind.UnionVariantPattern)
   }
   if kind == TokenKind.Identifier && P.peek(&initial, 1) == TokenKind.Dot && P.peek(&initial, 2) == TokenKind.Identifier && P.peek(
     &initial,
     3,
   ) != TokenKind.LeftBrace && P.peek(&initial, 3) != TokenKind.Less && P.peek(&initial, 3) != TokenKind.Identifier {
-    let mut p = run P.consume(P.begin(move initial))
-    let consumed = run P.consume(move p)
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
-    return run P.complete(move p, NodeKind.EnumMemberPattern)
+    return run move p
+      |> P.complete(NodeKind.EnumMemberPattern)
   }
   if kind == TokenKind.Identifier || kind == TokenKind.LeftBracket || ((kind == TokenKind.MutKeyword || kind == TokenKind.OnceKeyword) && P.peek(
     &initial,
@@ -109,19 +132,24 @@ effect fn parseInner(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
   ) == TokenKind.Identifier) {
     let mut p = run P.wrap(run Types.primary(move initial))
     if P.currentKind(&p.state) == TokenKind.Identifier {
-      let consumed3 = run P.consume(move p)
+      let consumed3 = run move p
+        |> P.consume
       p = move consumed3
-      return run P.complete(move p, NodeKind.BindingPattern)
+      return run move p
+        |> P.complete(NodeKind.BindingPattern)
     }
     return run fields(move p, NodeKind.NominalPattern)
   }
   let mut p = P.begin(move initial)
   if kind == TokenKind.FatArrow || kind == TokenKind.Equals || kind == TokenKind.RightBrace || kind == TokenKind.EndOfFile || kind == TokenKind.IfKeyword {
-    let afterIdentifier = run P.missing(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.missing(TokenKind.Identifier)
     p = move afterIdentifier
   } else {
-    let advanced = run P.unexpected(move p)
+    let advanced = run move p
+      |> P.unexpected
     p = move advanced
   }
-  return run P.complete(move p, NodeKind.ErrorPattern)
+  return run move p
+    |> P.complete(NodeKind.ErrorPattern)
 }

--- a/compiler/src/parser/Pattern.silk
+++ b/compiler/src/parser/Pattern.silk
@@ -63,7 +63,7 @@ effect fn fields(initial: ElementsResult, kind: NodeKind) -> NodeResult
 /// Invalid starts become error patterns. A missing pattern does not consume the delimiter owned
 /// by its enclosing rule, allowing the remainder of the arm or binding to stay navigable.
 pub effect fn parse(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  if initial.depth >= 256 {
+  if initial.depth >= P.NESTING_LIMIT {
     return run P.nestingError(move initial)
   }
   let depth = initial.depth

--- a/compiler/src/parser/Property.silk
+++ b/compiler/src/parser/Property.silk
@@ -7,27 +7,37 @@ import parser.Expression as Expressions
 import silk.allocator {Allocator, OutOfMemoryError}
 
 effect fn property(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let withExpressionsParse = run P.attach(
     move p.elements,
     run Expressions.parse(move p.state, false),
   )
   p = move withExpressionsParse
-  return run P.complete(move p, NodeKind.FunctionProperty)
+  return run move p
+    |> P.complete(NodeKind.FunctionProperty)
 }
 
 /// Parses one `with Namespace.operation(name: value, ...)` clause without interpreting it.
 pub effect fn clause(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.contextual(P.begin(move initial), "with")
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.contextual("with")
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  let afterDot = run P.expect(move p, TokenKind.Dot)
+  let afterDot = run move p
+    |> P.expect(TokenKind.Dot)
   p = move afterDot
-  let afterIdentifier2 = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier2 = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier2
-  let afterLeftParenthesis = run P.expect(move p, TokenKind.LeftParenthesis)
+  let afterLeftParenthesis = run move p
+    |> P.expect(TokenKind.LeftParenthesis)
   p = move afterLeftParenthesis
   while P.currentKind(&p.state) == TokenKind.Identifier {
     let attached = run P.attach(move p.elements, run property(move p.state))
@@ -35,12 +45,15 @@ pub effect fn clause(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
     if P.currentKind(&p.state) != TokenKind.Comma {
       break
     }
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  return run P.complete(move p, NodeKind.FunctionPropertyClause)
+  return run move p
+    |> P.complete(NodeKind.FunctionPropertyClause)
 }
 
 /// Appends all consecutive property clauses to an unfinished declaration or foreign type.

--- a/compiler/src/parser/Statement.silk
+++ b/compiler/src/parser/Statement.silk
@@ -19,7 +19,9 @@ import silk.vector {Vector}
 import silk.usize as Usize
 
 effect fn binding(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let mut nodeKind = NodeKind.BindingStatement
   let kind = P.currentKind(&p.state)
   let ordinary = kind == TokenKind.MutKeyword || kind == TokenKind.StaticKeyword || kind == TokenKind.Equals || (kind == TokenKind.Identifier && !P.word(
@@ -28,13 +30,16 @@ effect fn binding(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
   ) && (P.peek(&p.state, 1) == TokenKind.Colon || P.peek(&p.state, 1) == TokenKind.Equals))
   if ordinary {
     if kind == TokenKind.MutKeyword || kind == TokenKind.StaticKeyword {
-      let consumed = run P.consume(move p)
+      let consumed = run move p
+        |> P.consume
       p = move consumed
     }
-    let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier
     if P.currentKind(&p.state) == TokenKind.Colon {
-      let consumed2 = run P.consume(move p)
+      let consumed2 = run move p
+        |> P.consume
       p = move consumed2
       let withTypesParse = run P.attach(move p.elements, run Types.parse(move p.state))
       p = move withTypesParse
@@ -44,21 +49,24 @@ effect fn binding(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
     p = move withPatternsParse
     nodeKind = NodeKind.PatternBindingStatement
   }
-  let afterEquals = run P.expect(move p, TokenKind.Equals)
+  let afterEquals = run move p
+    |> P.expect(TokenKind.Equals)
   p = move afterEquals
   let withExpressionsParse = run P.attach(
     move p.elements,
     run Expressions.parse(move p.state, true),
   )
   p = move withExpressionsParse
-  return run P.complete(move p, nodeKind)
+  return run move p
+    |> P.complete(nodeKind)
 }
 
 effect fn conditional(initial: State, isStatic: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -73,18 +81,22 @@ effect fn conditionalInner(initial: State, isStatic: bool) -> NodeResult
 ? &mut Allocator {
   let mut p = P.begin(move initial)
   if isStatic {
-    let afterStaticKeyword = run P.expect(move p, TokenKind.StaticKeyword)
+    let afterStaticKeyword = run move p
+      |> P.expect(TokenKind.StaticKeyword)
     p = move afterStaticKeyword
   }
-  let afterIfKeyword = run P.expect(move p, TokenKind.IfKeyword)
+  let afterIfKeyword = run move p
+    |> P.expect(TokenKind.IfKeyword)
   p = move afterIfKeyword
   let pattern = !isStatic && P.currentKind(&p.state) == TokenKind.LetKeyword
   if pattern {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let withPatternsParse = run P.attach(move p.elements, run Patterns.parse(move p.state))
     p = move withPatternsParse
-    let afterEquals = run P.expect(move p, TokenKind.Equals)
+    let afterEquals = run move p
+      |> P.expect(TokenKind.Equals)
     p = move afterEquals
   }
   let withExpressionsParse = run P.attach(
@@ -95,7 +107,8 @@ effect fn conditionalInner(initial: State, isStatic: bool) -> NodeResult
   let attached = run P.attach(move p.elements, run block(move p.state, false, false))
   p = move attached
   if P.currentKind(&p.state) == TokenKind.ElseKeyword {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
     if !isStatic && P.currentKind(&p.state) == TokenKind.IfKeyword {
       let attached2 = run P.attach(move p.elements, run conditional(move p.state, false))
@@ -106,26 +119,35 @@ effect fn conditionalInner(initial: State, isStatic: bool) -> NodeResult
     }
   }
   if isStatic {
-    return run P.complete(move p, NodeKind.StaticConditionalStatement)
+    return run move p
+      |> P.complete(NodeKind.StaticConditionalStatement)
   }
   if pattern {
-    return run P.complete(move p, NodeKind.PatternConditionalStatement)
+    return run move p
+      |> P.complete(NodeKind.PatternConditionalStatement)
   }
-  return run P.complete(move p, NodeKind.ConditionalStatement)
+  return run move p
+    |> P.complete(NodeKind.ConditionalStatement)
 }
 
 effect fn staticFor(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
-  let afterForKeyword = run P.expect(move p, TokenKind.ForKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
+  let afterForKeyword = run move p
+    |> P.expect(TokenKind.ForKeyword)
   p = move afterForKeyword
   if P.word(&p.state, "in") {
-    let afterIdentifier = run P.missing(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.missing(TokenKind.Identifier)
     p = move afterIdentifier
   } else {
-    let afterIdentifier2 = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier2 = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier2
   }
-  let advanced = run P.contextual(move p, "in")
+  let advanced = run move p
+    |> P.contextual("in")
   p = move advanced
   let withExpressionsParse = run P.attach(
     move p.elements,
@@ -134,11 +156,14 @@ effect fn staticFor(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
   p = move withExpressionsParse
   let attached = run P.attach(move p.elements, run block(move p.state, false, false))
   p = move attached
-  return run P.complete(move p, NodeKind.StaticForStatement)
+  return run move p
+    |> P.complete(NodeKind.StaticForStatement)
 }
 
 effect fn whileStatement(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let withExpressionsParse = run P.attach(
     move p.elements,
     run Expressions.parse(move p.state, false),
@@ -146,7 +171,8 @@ effect fn whileStatement(initial: State) -> NodeResult ! OutOfMemoryError ? &mut
   p = move withExpressionsParse
   let attached = run P.attach(move p.elements, run block(move p.state, false, false))
   p = move attached
-  return run P.complete(move p, NodeKind.WhileStatement)
+  return run move p
+    |> P.complete(NodeKind.WhileStatement)
 }
 
 effect fn transfer(initial: State, kind: NodeKind) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
@@ -156,7 +182,9 @@ effect fn transfer(initial: State, kind: NodeKind) -> NodeResult ! OutOfMemoryEr
 effect fn valueStatement(initial: State, kind: NodeKind) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   if kind == NodeKind.ReturnStatement && P.currentKind(&p.state) == TokenKind.RightBrace {
     let attached = run P.attach(
       move p.elements,
@@ -165,7 +193,8 @@ effect fn valueStatement(initial: State, kind: NodeKind) -> NodeResult
     p = move attached
   } else {
     if kind == NodeKind.FailStatement {
-      let afterMoveKeyword = run P.optional(move p, TokenKind.MoveKeyword)
+      let afterMoveKeyword = run move p
+        |> P.optional(TokenKind.MoveKeyword)
       p = move afterMoveKeyword
     }
     let withExpressionsParse = run P.attach(
@@ -174,7 +203,8 @@ effect fn valueStatement(initial: State, kind: NodeKind) -> NodeResult
     )
     p = move withExpressionsParse
   }
-  return run P.complete(move p, kind)
+  return run move p
+    |> P.complete(kind)
 }
 
 /// Parses one ordinary statement; an expression followed by `=` becomes an assignment.
@@ -214,24 +244,30 @@ pub effect fn parse(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
     return run valueStatement(move initial, NodeKind.DropStatement)
   }
   if kind == TokenKind.UnsafeKeyword && P.peek(&initial, 1) == TokenKind.LeftBrace {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let attached = run P.attach(move p.elements, run block(move p.state, false, false))
     p = move attached
-    return run P.complete(move p, NodeKind.UnsafeStatement)
+    return run move p
+      |> P.complete(NodeKind.UnsafeStatement)
   }
   if G.expressionStart(kind) {
     let mut p = run P.wrap(run Expressions.parse(move initial, true))
     if P.currentKind(&p.state) == TokenKind.Equals {
-      let consumed = run P.consume(move p)
+      let consumed = run move p
+        |> P.consume
       p = move consumed
       let withExpressionsParse = run P.attach(
         move p.elements,
         run Expressions.parse(move p.state, true),
       )
       p = move withExpressionsParse
-      return run P.complete(move p, NodeKind.AssignmentStatement)
+      return run move p
+        |> P.complete(NodeKind.AssignmentStatement)
     }
-    return run P.complete(move p, NodeKind.ExpressionStatement)
+    return run move p
+      |> P.complete(NodeKind.ExpressionStatement)
   }
   let error = run P.complete(run P.unexpected(P.begin(move initial)), NodeKind.Error)
   return run P.complete(run P.wrap(move error), NodeKind.ErrorStatement)
@@ -271,7 +307,8 @@ pub effect fn block(initial: State, terminal: bool, matchArm: bool) -> NodeResul
 ! OutOfMemoryError
 ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -285,7 +322,9 @@ effect fn blockInner(initial: State, terminal: bool, matchArm: bool) -> NodeResu
 ! OutOfMemoryError
 ? &mut Allocator {
   let opened = P.currentKind(&initial) == TokenKind.LeftBrace
-  let mut p = run P.expect(P.begin(move initial), TokenKind.LeftBrace)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.LeftBrace)
   let mut terminated = false
   if opened {
     while !G.blockEnd(&p.state) && !(matchArm && Look.arm(&p.state)) {
@@ -298,18 +337,23 @@ effect fn blockInner(initial: State, terminal: bool, matchArm: bool) -> NodeResu
       let attached = run P.attach(move p.elements, move statement)
       p = move attached
       if p.state.index == before {
-        let advanced = run P.unexpected(move p)
+        let advanced = run move p
+          |> P.unexpected
         p = move advanced
       }
     }
   }
   if terminal && !terminated {
-    let unit = run P.complete(P.begin(move p.state), NodeKind.UnitExpression)
+    let unit = run move p.state
+      |> P.begin
+      |> P.complete(NodeKind.UnitExpression)
     let statement = run P.complete(run P.wrap(move unit), NodeKind.ReturnStatement)
     let attached2 = run P.attach(move p.elements, move statement)
     p = move attached2
   }
-  let afterRightBrace = run P.expect(move p, TokenKind.RightBrace)
+  let afterRightBrace = run move p
+    |> P.expect(TokenKind.RightBrace)
   p = move afterRightBrace
-  return run P.complete(move p, NodeKind.Block)
+  return run move p
+    |> P.complete(NodeKind.Block)
 }

--- a/compiler/src/parser/Statement.silk
+++ b/compiler/src/parser/Statement.silk
@@ -57,7 +57,7 @@ effect fn binding(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
 effect fn conditional(initial: State, isStatic: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  if initial.depth >= 256 {
+  if initial.depth >= P.NESTING_LIMIT {
     return run P.nestingError(move initial)
   }
   let depth = initial.depth
@@ -270,7 +270,7 @@ fn terminates(state: &State, id: NodeId) -> bool {
 pub effect fn block(initial: State, terminal: bool, matchArm: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  if initial.depth >= 256 {
+  if initial.depth >= P.NESTING_LIMIT {
     return run P.nestingError(move initial)
   }
   let depth = initial.depth

--- a/compiler/src/parser/Type.silk
+++ b/compiler/src/parser/Type.silk
@@ -419,7 +419,7 @@ effect fn modeQualified(initial: State) -> NodeResult ! OutOfMemoryError ? &mut 
 ///
 /// References and pointers bind to one primary. Parentheses explicitly admit a union subject.
 pub effect fn primary(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  if initial.depth >= 256 {
+  if initial.depth >= P.NESTING_LIMIT {
     return run P.nestingError(move initial)
   }
   let depth = initial.depth

--- a/compiler/src/parser/Type.silk
+++ b/compiler/src/parser/Type.silk
@@ -14,27 +14,35 @@ import silk.usize as Usize
 
 /// Parses a one- or two-segment nominal type path, without its generic arguments.
 pub effect fn path(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  return run P.complete(run pathElements(P.begin(move initial)), NodeKind.TypePath)
+  let path = run move initial
+    |> P.begin
+    |> pathElements
+  return run move path
+    |> P.complete(NodeKind.TypePath)
 }
 
 effect fn pathElements(initial: ElementsResult) -> ElementsResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(move initial, TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.expect(TokenKind.Identifier)
   if P.currentKind(&p.state) == TokenKind.Dot {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier
   }
   return move p
 }
 
 effect fn lifetime(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  return run P.complete(
-    run P.expect(P.begin(move initial), TokenKind.Lifetime),
-    NodeKind.LifetimeType,
-  )
+  let lifetime = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Lifetime)
+  return run move lifetime
+    |> P.complete(NodeKind.LifetimeType)
 }
 
 /// Parses a named type and its optional type arguments.
@@ -43,10 +51,12 @@ pub effect fn named(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
   if P.currentKind(&result.state) != TokenKind.Less {
     return move result
   }
-  let mut p = run P.wrap(move result)
+  let mut p = run move result
+    |> P.wrap
   let attached = run P.attach(move p.elements, run arguments(move p.state, false))
   p = move attached
-  return run P.complete(move p, NodeKind.AppliedType)
+  return run move p
+    |> P.complete(NodeKind.AppliedType)
 }
 
 fn nullablePointer(state: &State) -> bool {
@@ -63,13 +73,18 @@ fn nullablePointer(state: &State) -> bool {
 pub effect fn arguments(initial: State, call: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Less)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Less)
   if !call && (P.currentKind(&p.state) == TokenKind.Semicolon || (P.currentKind(&p.state) == TokenKind.Lifetime && P.peek(
     &p.state,
     1,
   ) == TokenKind.Semicolon)) {
-    let mut environment = run P.expect(P.begin(move p.state), TokenKind.Lifetime)
-    let afterSemicolon = run P.expect(move environment, TokenKind.Semicolon)
+    let mut environment = run move p.state
+      |> P.begin
+      |> P.expect(TokenKind.Lifetime)
+    let afterSemicolon = run move environment
+      |> P.expect(TokenKind.Semicolon)
     environment = move afterSemicolon
     let attached = run P.attach(
       move p.elements,
@@ -78,7 +93,8 @@ pub effect fn arguments(initial: State, call: bool) -> NodeResult
     p = move attached
   }
   if P.currentKind(&p.state) == TokenKind.Greater {
-    let afterIdentifier = run P.missing(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.missing(TokenKind.Identifier)
     p = move afterIdentifier
   }
   while P.currentKind(&p.state) != TokenKind.Greater && P.currentKind(&p.state) != TokenKind.EndOfFile {
@@ -99,7 +115,8 @@ pub effect fn arguments(initial: State, call: bool) -> NodeResult
       argument = move attached3
     }
     if call && P.word(&argument.state, "at") {
-      let consumed = run P.consume(move argument)
+      let consumed = run move argument
+        |> P.consume
       argument = move consumed
       let attached4 = run P.attach(move argument.elements, run path(move argument.state))
       argument = move attached4
@@ -119,7 +136,8 @@ pub effect fn arguments(initial: State, call: bool) -> NodeResult
     if P.currentKind(&p.state) != TokenKind.Comma {
       break
     }
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   }
   if !call && P.currentKind(&p.state) == TokenKind.Bang {
@@ -130,27 +148,35 @@ pub effect fn arguments(initial: State, call: bool) -> NodeResult
     let attached7 = run P.attach(move p.elements, run requirementRow(move p.state))
     p = move attached7
   }
-  let afterGreater = run P.expect(move p, TokenKind.Greater)
+  let afterGreater = run move p
+    |> P.expect(TokenKind.Greater)
   p = move afterGreater
   if call {
-    return run P.complete(move p, NodeKind.CallTypeArgumentList)
+    return run move p
+      |> P.complete(NodeKind.CallTypeArgumentList)
   }
-  return run P.complete(move p, NodeKind.TypeArgumentList)
+  return run move p
+    |> P.complete(NodeKind.TypeArgumentList)
 }
 
 effect fn typeParameter(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let isLifetime = P.currentKind(&initial) == TokenKind.Lifetime
   let isRow = P.currentKind(&initial) == TokenKind.Question
-  let mut p = run P.optional(P.begin(move initial), TokenKind.Question)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.Question)
   if isLifetime {
-    let afterLifetime = run P.expect(move p, TokenKind.Lifetime)
+    let afterLifetime = run move p
+      |> P.expect(TokenKind.Lifetime)
     p = move afterLifetime
   } else {
-    let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier
   }
   if !isRow && P.currentKind(&p.state) == TokenKind.Colon {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     while true {
       if P.currentKind(&p.state) == TokenKind.Lifetime {
@@ -163,23 +189,29 @@ effect fn typeParameter(initial: State) -> NodeResult ! OutOfMemoryError ? &mut 
       if P.currentKind(&p.state) != TokenKind.Plus {
         break
       }
-      let consumed2 = run P.consume(move p)
+      let consumed2 = run move p
+        |> P.consume
       p = move consumed2
     }
   }
   if isLifetime {
-    return run P.complete(move p, NodeKind.LifetimeParameter)
+    return run move p
+      |> P.complete(NodeKind.LifetimeParameter)
   }
-  return run P.complete(move p, NodeKind.TypeParameter)
+  return run move p
+    |> P.complete(NodeKind.TypeParameter)
 }
 
 /// Parses declaration binders or a higher-ranked callable lifetime binder list.
 pub effect fn parameters(initial: State, binders: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Less)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Less)
   if P.currentKind(&p.state) == TokenKind.Greater {
-    let afterIdentifier = run P.missing(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.missing(TokenKind.Identifier)
     p = move afterIdentifier
   }
   while P.currentKind(&p.state) == TokenKind.Identifier || P.currentKind(&p.state) == TokenKind.Lifetime || P.currentKind(
@@ -190,54 +222,71 @@ pub effect fn parameters(initial: State, binders: bool) -> NodeResult
     if P.currentKind(&p.state) != TokenKind.Comma {
       break
     }
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  let afterGreater = run P.expect(move p, TokenKind.Greater)
+  let afterGreater = run move p
+    |> P.expect(TokenKind.Greater)
   p = move afterGreater
   if binders {
-    return run P.complete(move p, NodeKind.LifetimeBinderList)
+    return run move p
+      |> P.complete(NodeKind.LifetimeBinderList)
   }
-  return run P.complete(move p, NodeKind.TypeParameterList)
+  return run move p
+    |> P.complete(NodeKind.TypeParameterList)
 }
 
 /// Parses the explicit lifetime environment after `fn` or `effect`.
 pub effect fn environment(initial: State, effectEnvironment: bool) -> NodeResult
 ! OutOfMemoryError
 ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Less)
-  let afterLifetime = run P.expect(move p, TokenKind.Lifetime)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Less)
+  let afterLifetime = run move p
+    |> P.expect(TokenKind.Lifetime)
   p = move afterLifetime
-  let afterGreater = run P.expect(move p, TokenKind.Greater)
+  let afterGreater = run move p
+    |> P.expect(TokenKind.Greater)
   p = move afterGreater
   if effectEnvironment {
-    return run P.complete(move p, NodeKind.EffectEnvironment)
+    return run move p
+      |> P.complete(NodeKind.EffectEnvironment)
   }
-  return run P.complete(move p, NodeKind.CallableEnvironment)
+  return run move p
+    |> P.complete(NodeKind.CallableEnvironment)
 }
 
 effect fn callable(initial: ElementsResult) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let foreign = P.currentKind(&initial.state) == TokenKind.ExternKeyword
   let mut p = move initial
   if foreign {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
-    let afterTextLiteral = run P.expect(move p, TokenKind.TextLiteral)
+    let afterTextLiteral = run move p
+      |> P.expect(TokenKind.TextLiteral)
     p = move afterTextLiteral
   }
-  let afterUnsafeKeyword = run P.optional(move p, TokenKind.UnsafeKeyword)
+  let afterUnsafeKeyword = run move p
+    |> P.optional(TokenKind.UnsafeKeyword)
   p = move afterUnsafeKeyword
-  let afterMutKeyword = run P.optional(move p, TokenKind.MutKeyword)
+  let afterMutKeyword = run move p
+    |> P.optional(TokenKind.MutKeyword)
   p = move afterMutKeyword
-  let afterOnceKeyword = run P.optional(move p, TokenKind.OnceKeyword)
+  let afterOnceKeyword = run move p
+    |> P.optional(TokenKind.OnceKeyword)
   p = move afterOnceKeyword
-  let afterFnKeyword = run P.expect(move p, TokenKind.FnKeyword)
+  let afterFnKeyword = run move p
+    |> P.expect(TokenKind.FnKeyword)
   p = move afterFnKeyword
   if P.currentKind(&p.state) == TokenKind.Less {
     let attached = run P.attach(move p.elements, run environment(move p.state, false))
     p = move attached
   }
-  let afterLeftParenthesis = run P.expect(move p, TokenKind.LeftParenthesis)
+  let afterLeftParenthesis = run move p
+    |> P.expect(TokenKind.LeftParenthesis)
   p = move afterLeftParenthesis
   while G.typeStart(P.currentKind(&p.state)) {
     let before = p.state.index
@@ -246,50 +295,67 @@ effect fn callable(initial: ElementsResult) -> NodeResult ! OutOfMemoryError ? &
     if p.state.index == before || P.currentKind(&p.state) != TokenKind.Comma {
       break
     }
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  let afterArrow = run P.expect(move p, TokenKind.Arrow)
+  let afterArrow = run move p
+    |> P.expect(TokenKind.Arrow)
   p = move afterArrow
   let attached3 = run P.attach(move p.elements, run parse(move p.state))
   p = move attached3
   if foreign {
     let advanced = run Properties.list(move p)
     p = move advanced
-    return run P.complete(move p, NodeKind.ForeignFunctionType)
+    return run move p
+      |> P.complete(NodeKind.ForeignFunctionType)
   }
-  return run P.complete(move p, NodeKind.CallableType)
+  return run move p
+    |> P.complete(NodeKind.CallableType)
 }
 
 effect fn pointer(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.optional(P.begin(move initial), TokenKind.Question)
+  let mut p = run move initial
+    |> P.begin
+    |> P.optional(TokenKind.Question)
   let many = P.currentKind(&p.state) == TokenKind.LeftBracket
   if many {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  let afterStar = run P.expect(move p, TokenKind.Star)
+  let afterStar = run move p
+    |> P.expect(TokenKind.Star)
   p = move afterStar
   if many {
-    let afterRightBracket = run P.expect(move p, TokenKind.RightBracket)
+    let afterRightBracket = run move p
+      |> P.expect(TokenKind.RightBracket)
     p = move afterRightBracket
   }
   if P.currentKind(&p.state) == TokenKind.MutKeyword {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
   } else {
-    let afterConstKeyword = run P.expect(move p, TokenKind.ConstKeyword)
+    let afterConstKeyword = run move p
+      |> P.expect(TokenKind.ConstKeyword)
     p = move afterConstKeyword
   }
   while (P.word(&p.state, "align") || P.word(&p.state, "addrspace")) && P.peek(&p.state, 1) == TokenKind.LeftParenthesis {
-    let mut q = run P.consume(P.begin(move p.state))
-    let afterLeftParenthesis = run P.expect(move q, TokenKind.LeftParenthesis)
+    let mut q = run move p.state
+      |> P.begin
+      |> P.consume
+    let afterLeftParenthesis = run move q
+      |> P.expect(TokenKind.LeftParenthesis)
     q = move afterLeftParenthesis
-    let afterDecimalInteger = run P.expect(move q, TokenKind.DecimalInteger)
+    let afterDecimalInteger = run move q
+      |> P.expect(TokenKind.DecimalInteger)
     q = move afterDecimalInteger
-    let afterRightParenthesis = run P.expect(move q, TokenKind.RightParenthesis)
+    let afterRightParenthesis = run move q
+      |> P.expect(TokenKind.RightParenthesis)
     q = move afterRightParenthesis
     let withPComplete = run P.attach(
       move p.elements,
@@ -299,61 +365,83 @@ effect fn pointer(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Alloca
   }
   let attached = run P.attach(move p.elements, run primary(move p.state))
   p = move attached
-  return run P.complete(move p, NodeKind.PointerType)
+  return run move p
+    |> P.complete(NodeKind.PointerType)
 }
 
 effect fn reference(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
-  let afterLifetime = run P.optional(move p, TokenKind.Lifetime)
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
+  let afterLifetime = run move p
+    |> P.optional(TokenKind.Lifetime)
   p = move afterLifetime
-  let afterMutKeyword = run P.optional(move p, TokenKind.MutKeyword)
+  let afterMutKeyword = run move p
+    |> P.optional(TokenKind.MutKeyword)
   p = move afterMutKeyword
   if P.currentKind(&p.state) == TokenKind.LeftBracket {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached = run P.attach(move p.elements, run parse(move p.state))
     p = move attached
-    let afterRightBracket = run P.expect(move p, TokenKind.RightBracket)
+    let afterRightBracket = run move p
+      |> P.expect(TokenKind.RightBracket)
     p = move afterRightBracket
-    return run P.complete(move p, NodeKind.SliceType)
+    return run move p
+      |> P.complete(NodeKind.SliceType)
   }
   let attached2 = run P.attach(move p.elements, run primary(move p.state))
   p = move attached2
   if P.currentKind(&p.state) == TokenKind.At {
-    let consumed2 = run P.consume(move p)
+    let consumed2 = run move p
+      |> P.consume
     p = move consumed2
-    let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+    let afterIdentifier = run move p
+      |> P.expect(TokenKind.Identifier)
     p = move afterIdentifier
   }
-  return run P.complete(move p, NodeKind.ReferenceType)
+  return run move p
+    |> P.complete(NodeKind.ReferenceType)
 }
 
 effect fn bracketed(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let attached = run P.attach(move p.elements, run parse(move p.state))
   p = move attached
-  let afterSemicolon = run P.expect(move p, TokenKind.Semicolon)
+  let afterSemicolon = run move p
+    |> P.expect(TokenKind.Semicolon)
   p = move afterSemicolon
-  let afterDecimalInteger = run P.expect(move p, TokenKind.DecimalInteger)
+  let afterDecimalInteger = run move p
+    |> P.expect(TokenKind.DecimalInteger)
   p = move afterDecimalInteger
-  let afterRightBracket = run P.expect(move p, TokenKind.RightBracket)
+  let afterRightBracket = run move p
+    |> P.expect(TokenKind.RightBracket)
   p = move afterRightBracket
-  return run P.complete(move p, NodeKind.FixedArrayType)
+  return run move p
+    |> P.complete(NodeKind.FixedArrayType)
 }
 
 effect fn parenthesized(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let unit = P.currentKind(&p.state) == TokenKind.RightParenthesis
   if !unit {
     let attached = run P.attach(move p.elements, run parse(move p.state))
     p = move attached
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
   if unit {
-    return run P.complete(move p, NodeKind.UnitType)
+    return run move p
+      |> P.complete(NodeKind.UnitType)
   }
-  return run P.complete(move p, NodeKind.ParenthesizedType)
+  return run move p
+    |> P.complete(NodeKind.ParenthesizedType)
 }
 
 effect fn rowOperandMember(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
@@ -367,7 +455,8 @@ effect fn rowOperandMember(initial: State) -> NodeResult ! OutOfMemoryError ? &m
   let mut p = run P.consume(run P.wrap(move result))
   let attached = run P.attach(move p.elements, run path(move p.state))
   p = move attached
-  return run P.complete(move p, NodeKind.Requirement)
+  return run move p
+    |> P.complete(NodeKind.Requirement)
 }
 
 effect fn rowOperand(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
@@ -375,44 +464,57 @@ effect fn rowOperand(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
   if P.currentKind(&first.state) != TokenKind.Pipe {
     return move first
   }
-  let mut p = run P.wrap(move first)
+  let mut p = run move first
+    |> P.wrap
   while P.currentKind(&p.state) == TokenKind.Pipe {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached = run P.attach(move p.elements, run rowOperandMember(move p.state))
     p = move attached
   }
-  return run P.complete(move p, NodeKind.UnionType)
+  return run move p
+    |> P.complete(NodeKind.UnionType)
 }
 
 effect fn without(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
-  let afterLess = run P.expect(move p, TokenKind.Less)
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
+  let afterLess = run move p
+    |> P.expect(TokenKind.Less)
   p = move afterLess
   let attached = run P.attach(move p.elements, run rowOperand(move p.state))
   p = move attached
-  let afterComma = run P.expect(move p, TokenKind.Comma)
+  let afterComma = run move p
+    |> P.expect(TokenKind.Comma)
   p = move afterComma
   let attached2 = run P.attach(move p.elements, run rowOperand(move p.state))
   p = move attached2
-  let afterGreater = run P.expect(move p, TokenKind.Greater)
+  let afterGreater = run move p
+    |> P.expect(TokenKind.Greater)
   p = move afterGreater
-  return run P.complete(move p, NodeKind.RowWithout)
+  return run move p
+    |> P.complete(NodeKind.RowWithout)
 }
 
 // An applied type owns its mode token; a bare path owns that token directly. Delay completing
 // the path until the following token selects the shape, so neither case leaves an orphan node.
 effect fn modeQualified(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.consume(P.begin(move initial))
+  let mut p = run move initial
+    |> P.begin
+    |> P.consume
   let subject = run pathElements(P.begin(move p.state))
   if P.currentKind(&subject.state) != TokenKind.Less {
     let combined = run P.extend(move p.elements, move subject)
-    return run P.complete(move combined, NodeKind.TypePath)
+    return run move combined
+      |> P.complete(NodeKind.TypePath)
   }
   let attached = run P.attach(move p.elements, run P.complete(move subject, NodeKind.TypePath))
   p = move attached
   let withArguments = run P.attach(move p.elements, run arguments(move p.state, false))
-  return run P.complete(move withArguments, NodeKind.AppliedType)
+  return run move withArguments
+    |> P.complete(NodeKind.AppliedType)
 }
 
 /// Parses a type without a following union separator.
@@ -420,7 +522,8 @@ effect fn modeQualified(initial: State) -> NodeResult ! OutOfMemoryError ? &mut 
 /// References and pointers bind to one primary. Parentheses explicitly admit a union subject.
 pub effect fn primary(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   if initial.depth >= P.NESTING_LIMIT {
-    return run P.nestingError(move initial)
+    return run move initial
+      |> P.nestingError
   }
   let depth = initial.depth
   let mut state = move initial
@@ -433,7 +536,9 @@ pub effect fn primary(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Al
 effect fn primaryInner(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let kind = P.currentKind(&initial)
   if kind == TokenKind.ForKeyword {
-    let mut p = run P.consume(P.begin(move initial))
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
     let attached = run P.attach(move p.elements, run parameters(move p.state, true))
     p = move attached
     return run callable(move p)
@@ -442,14 +547,19 @@ effect fn primaryInner(initial: State) -> NodeResult ! OutOfMemoryError ? &mut A
     return run without(move initial)
   }
   if P.word(&initial, "typeof") && P.peek(&initial, 1) == TokenKind.LeftParenthesis {
-    let mut p = run P.consume(P.begin(move initial))
-    let consumed = run P.consume(move p)
+    let mut p = run move initial
+      |> P.begin
+      |> P.consume
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached2 = run P.attach(move p.elements, run named(move p.state))
     p = move attached2
-    let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+    let afterRightParenthesis = run move p
+      |> P.expect(TokenKind.RightParenthesis)
     p = move afterRightParenthesis
-    return run P.complete(move p, NodeKind.ExactRepresentationType)
+    return run move p
+      |> P.complete(NodeKind.ExactRepresentationType)
   }
   if (kind == TokenKind.MutKeyword || kind == TokenKind.OnceKeyword) && P.peek(&initial, 1) == TokenKind.Identifier {
     return run modeQualified(move initial)
@@ -481,21 +591,28 @@ pub effect fn parse(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allo
   if P.currentKind(&first.state) != TokenKind.Pipe {
     return move first
   }
-  let mut p = run P.wrap(move first)
+  let mut p = run move first
+    |> P.wrap
   while P.currentKind(&p.state) == TokenKind.Pipe {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached = run P.attach(move p.elements, run primary(move p.state))
     p = move attached
   }
-  return run P.complete(move p, NodeKind.UnionType)
+  return run move p
+    |> P.complete(NodeKind.UnionType)
 }
 
 /// Parses an arrow and result type, including a contextual opaque result binder.
 pub effect fn result(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Arrow)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Arrow)
   if P.word(&p.state, "some") && P.peek(&p.state, 1) == TokenKind.Less {
-    let mut opaque = run P.consume(P.begin(move p.state))
+    let mut opaque = run move p.state
+      |> P.begin
+      |> P.consume
     let attached = run P.attach(move opaque.elements, run parameters(move opaque.state, false))
     opaque = move attached
     let attached2 = run P.attach(move opaque.elements, run parse(move opaque.state))
@@ -509,35 +626,46 @@ pub effect fn result(initial: State) -> NodeResult ! OutOfMemoryError ? &mut All
     let attached4 = run P.attach(move p.elements, run parse(move p.state))
     p = move attached4
   }
-  return run P.complete(move p, NodeKind.ReturnType)
+  return run move p
+    |> P.complete(NodeKind.ReturnType)
 }
 
 /// Parses `!` followed by the failure union; semantic row validation happens later.
 pub effect fn failureRow(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Bang)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Bang)
   let attached = run P.attach(move p.elements, run parse(move p.state))
   p = move attached
-  return run P.complete(move p, NodeKind.FailureRow)
+  return run move p
+    |> P.complete(NodeKind.FailureRow)
 }
 
 effect fn requirement(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Ampersand)
-  let afterMutKeyword = run P.optional(move p, TokenKind.MutKeyword)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Ampersand)
+  let afterMutKeyword = run move p
+    |> P.optional(TokenKind.MutKeyword)
   p = move afterMutKeyword
   let attached = run P.attach(move p.elements, run primary(move p.state))
   p = move attached
   if P.word(&p.state, "at") {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
     let attached2 = run P.attach(move p.elements, run path(move p.state))
     p = move attached2
   }
-  return run P.complete(move p, NodeKind.Requirement)
+  return run move p
+    |> P.complete(NodeKind.Requirement)
 }
 
 /// Parses a requirement row containing borrowed services, row names, or `Without` expressions.
 pub effect fn requirementRow(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Question)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Question)
   while true {
     if P.currentKind(&p.state) == TokenKind.Ampersand {
       let attached = run P.attach(move p.elements, run requirement(move p.state))
@@ -552,72 +680,90 @@ pub effect fn requirementRow(initial: State) -> NodeResult ! OutOfMemoryError ? 
     if P.currentKind(&p.state) != TokenKind.Pipe {
       break
     }
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  return run P.complete(move p, NodeKind.RequirementRow)
+  return run move p
+    |> P.complete(NodeKind.RequirementRow)
 }
 
 effect fn constraint(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = run P.wrap(run parse(move initial))
   let membership = P.word(&p.state, "in")
   if membership {
-    let advanced = run P.contextual(move p, "in")
+    let advanced = run move p
+      |> P.contextual("in")
     p = move advanced
   } else {
-    let advanced2 = run P.contextual(move p, "provides")
+    let advanced2 = run move p
+      |> P.contextual("provides")
     p = move advanced2
   }
   let attached = run P.attach(move p.elements, run parse(move p.state))
   p = move attached
   if membership {
-    return run P.complete(move p, NodeKind.MembershipConstraint)
+    return run move p
+      |> P.complete(NodeKind.MembershipConstraint)
   }
-  let advanced3 = run P.contextual(move p, "from")
+  let advanced3 = run move p
+    |> P.contextual("from")
   p = move advanced3
   let attached2 = run P.attach(move p.elements, run parse(move p.state))
   p = move attached2
-  return run P.complete(move p, NodeKind.ProviderConstraint)
+  return run move p
+    |> P.complete(NodeKind.ProviderConstraint)
 }
 
 /// Parses a contextual `where` clause with comma-separated membership/provider constraints.
 pub effect fn whereClause(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.Identifier)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.Identifier)
   while true {
     let attached = run P.attach(move p.elements, run constraint(move p.state))
     p = move attached
     if P.currentKind(&p.state) != TokenKind.Comma {
       break
     }
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  return run P.complete(move p, NodeKind.WhereClause)
+  return run move p
+    |> P.complete(NodeKind.WhereClause)
 }
 
 effect fn parameter(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
   let mut p = P.begin(move initial)
   if P.currentKind(&p.state) == TokenKind.StaticKeyword || P.currentKind(&p.state) == TokenKind.MutKeyword {
-    let consumed = run P.consume(move p)
+    let consumed = run move p
+      |> P.consume
     p = move consumed
   }
-  let afterIdentifier = run P.expect(move p, TokenKind.Identifier)
+  let afterIdentifier = run move p
+    |> P.expect(TokenKind.Identifier)
   p = move afterIdentifier
-  let afterColon = run P.expect(move p, TokenKind.Colon)
+  let afterColon = run move p
+    |> P.expect(TokenKind.Colon)
   p = move afterColon
   let attached = run P.attach(move p.elements, run parse(move p.state))
   p = move attached
-  return run P.complete(move p, NodeKind.ParameterDeclaration)
+  return run move p
+    |> P.complete(NodeKind.ParameterDeclaration)
 }
 
 /// Parses named callable parameters and the optional trailing C-variadic marker.
 pub effect fn parameterList(initial: State) -> NodeResult ! OutOfMemoryError ? &mut Allocator {
-  let mut p = run P.expect(P.begin(move initial), TokenKind.LeftParenthesis)
+  let mut p = run move initial
+    |> P.begin
+    |> P.expect(TokenKind.LeftParenthesis)
   while P.currentKind(&p.state) == TokenKind.Identifier || P.currentKind(&p.state) == TokenKind.StaticKeyword || P.currentKind(
     &p.state,
   ) == TokenKind.MutKeyword || P.currentKind(&p.state) == TokenKind.Ellipsis {
     if P.currentKind(&p.state) == TokenKind.Ellipsis {
-      let consumed = run P.consume(move p)
+      let consumed = run move p
+        |> P.consume
       p = move consumed
       break
     }
@@ -629,12 +775,15 @@ pub effect fn parameterList(initial: State) -> NodeResult ! OutOfMemoryError ? &
     if P.currentKind(&p.state) == TokenKind.RightParenthesis {
       break
     }
-    let afterComma = run P.expect(move p, TokenKind.Comma)
+    let afterComma = run move p
+      |> P.expect(TokenKind.Comma)
     p = move afterComma
   }
-  let afterRightParenthesis = run P.expect(move p, TokenKind.RightParenthesis)
+  let afterRightParenthesis = run move p
+    |> P.expect(TokenKind.RightParenthesis)
   p = move afterRightParenthesis
-  return run P.complete(move p, NodeKind.ParameterList)
+  return run move p
+    |> P.complete(NodeKind.ParameterList)
 }
 
 /// Appends the shared generic/parameter/result/row/constraint suffix of a callable declaration.


### PR DESCRIPTION
## Summary

- Add 41 targeted behavioral cases adapted from the bootstrap parser tests, covering accepted syntax, damaged headers and arguments, preserved valid regions, precedence, and excessive nesting.
- Compare functional acceptance and explicit intact syntax witnesses without requiring identical diagnostic wording or error-tree shapes. Document the cases where native recovery is stronger than the bootstrap.
- Validate native diagnostic spans and token identities; retain the existing valid-source structural regression corpus.
- Move expression-depth accounting around the complete expression parse so nested call arguments cannot bypass the guard.
- Share a 32-operation recursion budget across grammar entry points. The previous 256 budget allowed the bootstrap-generated debug executable to exhaust its native stack before diagnosing excessive nesting.
- Recover over-deep branches iteratively and preserve the following named function even when closing delimiters are missing.

## Validation

- Self-hosted native build and Silk check: passed.
- Parser harness: **154 checks passed** (113 repository source files + 41 behavioral cases).
- Focused missing-token cases verify the token kind and exact insertion span.
- Workspace typecheck: passed (18 tasks).
- Workspace lint and formatting of changed JavaScript, Markdown, and Silk files: passed.
- Full workspace test run: compiler suite had **2,442 passing tests and two 60-second timeouts** in unchanged `Driver.test.ts` tests: “reports array layouts and keeps array failures in their owning phase” and “rejects invalid generic specialization before layout and MIR”. The complete workspace test command therefore failed.
- `pnpm check` was rerun before opening this PR and stops at the pre-existing, untracked `.zuse/settings.toml` formatting issue. That file is not included.

## Scope

No benchmark files, profiling scripts, local workspace settings, or unrelated ignore changes are included. The broader documentation/function-decomposition improvements identified in the subsequent review remain follow-up work; this PR contains the completed parser-hardening work only.
