### PR TITLE
Add Silk code snapshot workbench

### DIFF
--- a/.hallmark/log.json
+++ b/.hallmark/log.json
@@ -1,0 +1,9 @@
+[
+  {
+    "date": "2026-09-10",
+    "macrostructure": "Workbench",
+    "theme": "Silk landing",
+    "enrichment": "product canvas",
+    "brief": "Route-based Silk code image generator"
+  }
+]

--- a/.hallmark/preflight.json
+++ b/.hallmark/preflight.json
@@ -1,0 +1,8 @@
+{
+  "date": "2026-09-10",
+  "fontStack": "JetBrains Mono via next/font on the Silk introduction",
+  "framework": "Next.js 16, React 19, Tailwind CSS 4, Fumadocs",
+  "motion": "motion-cut; no animation library",
+  "palette": "warm near-black, off-white ink, amber, violet, green",
+  "spacing": "4px base"
+}

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -29,6 +29,7 @@ export default function Home() {
       <header className="bar">
         <span className="title">silk</span>
         <span className="spacer" />
+        <Link href="/share">share</Link>
         <Link href="/docs/language">docs</Link>
       </header>
       {/* Repo-authored content, not user-supplied. */}

--- a/apps/docs/app/share/ShareWorkbench.tsx
+++ b/apps/docs/app/share/ShareWorkbench.tsx
@@ -1,0 +1,463 @@
+'use client'
+
+import type {
+  SilkAnalysisDetail,
+  SilkChangeDetail,
+  SilkSnippetElement,
+} from '@silklang/editor-support/Element'
+import * as Effect from 'effect/Effect'
+import * as Fiber from 'effect/Fiber'
+import { AlignLeft, Check, Clipboard, Download, LoaderCircle, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
+import type { DetailedHTMLProps, HTMLAttributes } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import styles from './share.module.css'
+import * as Snapshot from './snapshot'
+import * as SourceCode from './SourceCode'
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'silk-snippet': DetailedHTMLProps<HTMLAttributes<SilkSnippetElement>, SilkSnippetElement>
+    }
+  }
+}
+
+interface Options {
+  readonly backdrop: boolean
+  readonly diagnostics: boolean
+  readonly diagnosticTooltip: boolean
+  readonly filename: string
+  readonly height: number | undefined
+  readonly inlayHints: boolean
+  readonly padding: number
+  readonly width: number
+}
+
+interface Props {
+  readonly initialOptions: Options
+  readonly initialSource: string
+  readonly monoClassName: string
+}
+
+type Action =
+  | { readonly kind: 'idle'; readonly message: string }
+  | { readonly kind: 'loading'; readonly message: string }
+  | { readonly kind: 'success'; readonly message: string }
+  | { readonly kind: 'error'; readonly message: string }
+
+const isSilkChange = (event: Event): event is CustomEvent<SilkChangeDetail> =>
+  event instanceof CustomEvent &&
+  typeof event.detail === 'object' &&
+  event.detail !== null &&
+  'source' in event.detail
+
+const isSilkAnalysis = (event: Event): event is CustomEvent<SilkAnalysisDetail> =>
+  event instanceof CustomEvent &&
+  typeof event.detail === 'object' &&
+  event.detail !== null &&
+  'diagnostics' in event.detail
+
+const nextPaint = (): Promise<void> =>
+  Effect.runPromise(
+    Effect.callback<void>((resume) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resume(Effect.void)))
+    }),
+  )
+
+const diagnosticLine = (source: string, offset: number): number =>
+  source.slice(0, offset).split('\n').length
+
+const toggleAttribute = (element: HTMLElement, name: string, enabled: boolean): void => {
+  if (enabled) element.setAttribute(name, '')
+  else element.removeAttribute(name)
+}
+
+export function ShareWorkbench({ initialOptions, initialSource, monoClassName }: Props) {
+  const snippetRef = useRef<SilkSnippetElement>(null)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const resetRef = useRef<Fiber.Fiber<void>>(undefined)
+  const [source, setSource] = useState(initialSource)
+  const [options, setOptions] = useState(initialOptions)
+  const [diagnostics, setDiagnostics] = useState<
+    ReadonlyArray<{ readonly from: number; readonly message: string }>
+  >([])
+  const [action, setAction] = useState<Action>({
+    kind: 'idle',
+    message: 'Ready to export.',
+  })
+
+  const report = (next: Action): void => {
+    if (resetRef.current !== undefined) Effect.runFork(Fiber.interrupt(resetRef.current))
+    setAction(next)
+    if (next.kind === 'success') {
+      resetRef.current = Effect.runFork(
+        Effect.sleep(2500).pipe(
+          Effect.andThen(
+            Effect.sync(() => setAction({ kind: 'idle', message: 'Ready to export.' })),
+          ),
+        ),
+      )
+    }
+  }
+
+  useEffect(
+    () => () => {
+      if (resetRef.current !== undefined) Effect.runFork(Fiber.interrupt(resetRef.current))
+    },
+    [],
+  )
+
+  useEffect(() => {
+    const element = snippetRef.current
+    if (element === null) return
+    element.setAttribute('editable', '')
+    element.setAttribute('hover', '')
+    toggleAttribute(element, 'diagnostics', options.diagnostics)
+    toggleAttribute(element, 'inlay-hints', options.inlayHints)
+
+    const onChange = (event: Event) => {
+      if (isSilkChange(event)) setSource(event.detail.source)
+    }
+    const onAnalysis = (event: Event) => {
+      if (isSilkAnalysis(event)) setDiagnostics(event.detail.diagnostics)
+    }
+    element.addEventListener('silk-change', onChange)
+    element.addEventListener('silk-analysis', onAnalysis)
+    void import('@silklang/editor-support/register')
+
+    return () => {
+      element.removeEventListener('silk-change', onChange)
+      element.removeEventListener('silk-analysis', onAnalysis)
+    }
+  }, [])
+
+  useEffect(() => {
+    const element = snippetRef.current
+    if (element === null) return
+    toggleAttribute(element, 'diagnostics', options.diagnostics)
+    toggleAttribute(element, 'inlay-hints', options.inlayHints)
+    if (!options.diagnostics) setDiagnostics([])
+  }, [options.diagnostics, options.inlayHints])
+
+  useEffect(() => {
+    const update = Effect.sleep(250).pipe(
+      Effect.andThen(
+        Effect.sync(() => {
+          const url = new URL(window.location.href)
+          url.searchParams.set('code', SourceCode.encode(source))
+          url.searchParams.set('hints', options.inlayHints ? '1' : '0')
+          url.searchParams.set('diagnostics', options.diagnostics ? '1' : '0')
+          url.searchParams.set('tooltip', options.diagnosticTooltip ? '1' : '0')
+          url.searchParams.set('filename', options.filename)
+          url.searchParams.set('width', String(options.width))
+          url.searchParams.set('padding', String(options.padding))
+          url.searchParams.set('backdrop', options.backdrop ? '1' : '0')
+          if (options.height === undefined) url.searchParams.delete('height')
+          else url.searchParams.set('height', String(options.height))
+          window.history.replaceState(null, '', url)
+        }),
+      ),
+    )
+    const fiber = Effect.runFork(update)
+    return () => {
+      Effect.runFork(Fiber.interrupt(fiber))
+    }
+  }, [options, source])
+
+  const updateOption = (
+    name: 'backdrop' | 'diagnostics' | 'diagnosticTooltip' | 'inlayHints',
+    enabled: boolean,
+  ): void => {
+    setOptions((current) => ({ ...current, [name]: enabled }))
+  }
+
+  const updateNumber = (
+    name: 'padding' | 'width',
+    value: number,
+    minimum: number,
+    maximum: number,
+  ): void => {
+    if (!Number.isFinite(value)) return
+    setOptions((current) => ({
+      ...current,
+      [name]: Math.min(maximum, Math.max(minimum, Math.round(value))),
+    }))
+  }
+
+  const format = (): void => {
+    const snippet = snippetRef.current
+    const formatted = snippet?.format() ?? false
+    if (formatted && snippet !== null) setSource(snippet.source)
+    report({
+      kind: 'success',
+      message: formatted ? 'Source formatted.' : 'Source is already formatted.',
+    })
+  }
+
+  const prepareSnapshot = async (): Promise<Snapshot.Snapshot> => {
+    const snippet = snippetRef.current
+    const surface = surfaceRef.current
+    if (snippet === null || surface === null) throw new Error('The editor is still loading.')
+    setDiagnostics(snippet.analyze())
+    await nextPaint()
+    return Effect.runPromise(Snapshot.capture(surface))
+  }
+
+  const copyPng = async (): Promise<void> => {
+    report({ kind: 'loading', message: 'Rendering PNG…' })
+    try {
+      const image = await Effect.runPromise(Snapshot.png(await prepareSnapshot()))
+      if (typeof ClipboardItem === 'undefined' || navigator.clipboard.write === undefined) {
+        Snapshot.download(image, 'silk-snippet.png')
+        report({ kind: 'success', message: 'Clipboard unavailable; PNG downloaded.' })
+        return
+      }
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': image })])
+      report({ kind: 'success', message: 'PNG copied.' })
+    } catch (cause) {
+      report({
+        kind: 'error',
+        message: cause instanceof Error ? cause.message : 'The PNG could not be copied.',
+      })
+    }
+  }
+
+  const downloadSvg = async (): Promise<void> => {
+    report({ kind: 'loading', message: 'Rendering SVG…' })
+    try {
+      const snapshot = await prepareSnapshot()
+      Snapshot.download(
+        new Blob([snapshot.svg], { type: 'image/svg+xml;charset=utf-8' }),
+        'silk-snippet.svg',
+      )
+      report({ kind: 'success', message: 'SVG downloaded.' })
+    } catch (cause) {
+      report({
+        kind: 'error',
+        message: cause instanceof Error ? cause.message : 'The SVG could not be downloaded.',
+      })
+    }
+  }
+
+  const firstDiagnostic = options.diagnostics ? diagnostics[0] : undefined
+  const tooltipTop =
+    firstDiagnostic === undefined
+      ? undefined
+      : `${Math.min(diagnosticLine(source, firstDiagnostic.from) * 24 + 28, 260)}px`
+  const busy = action.kind === 'loading'
+
+  return (
+    <div className={`${styles.share} ${monoClassName}`}>
+      <header className={styles.navigation}>
+        <Link className={styles.wordmark} href="/">
+          silk
+        </Link>
+        <Link className={styles.docsLink} href="/docs/language">
+          docs →
+        </Link>
+      </header>
+
+      <main className={styles.main}>
+        <aside className={styles.controls} aria-labelledby="share-title">
+          <div className={styles.introduction}>
+            <h1 id="share-title">Silk snapshot</h1>
+            <p>Edit the source, choose what the compiler shows, then export the image.</p>
+          </div>
+
+          <fieldset className={styles.options}>
+            <legend>Presentation</legend>
+            <label className={styles.option}>
+              <span>
+                <strong>Inlay hints</strong>
+                <small>Include inferred types.</small>
+              </span>
+              <input
+                checked={options.inlayHints}
+                onChange={(event) => updateOption('inlayHints', event.target.checked)}
+                type="checkbox"
+              />
+            </label>
+            <label className={styles.option}>
+              <span>
+                <strong>Diagnostics</strong>
+                <small>Draw compiler squiggles.</small>
+              </span>
+              <input
+                checked={options.diagnostics}
+                onChange={(event) => updateOption('diagnostics', event.target.checked)}
+                type="checkbox"
+              />
+            </label>
+            <label className={styles.option} data-disabled={!options.diagnostics}>
+              <span>
+                <strong>Diagnostic tooltip</strong>
+                <small>Pin the first compiler message.</small>
+              </span>
+              <input
+                checked={options.diagnosticTooltip}
+                disabled={!options.diagnostics}
+                onChange={(event) => updateOption('diagnosticTooltip', event.target.checked)}
+                type="checkbox"
+              />
+            </label>
+          </fieldset>
+
+          <fieldset className={styles.frameOptions}>
+            <legend>Frame</legend>
+            <label className={styles.field}>
+              <span>Filename</span>
+              <input
+                maxLength={120}
+                onChange={(event) =>
+                  setOptions((current) => ({ ...current, filename: event.target.value }))
+                }
+                spellCheck={false}
+                type="text"
+                value={options.filename}
+              />
+            </label>
+            <div className={styles.dimensions}>
+              <label className={styles.field}>
+                <span>Width</span>
+                <input
+                  inputMode="numeric"
+                  max={1600}
+                  min={320}
+                  onChange={(event) => updateNumber('width', event.target.valueAsNumber, 320, 1600)}
+                  type="number"
+                  value={options.width}
+                />
+              </label>
+              <label className={styles.field}>
+                <span>Height</span>
+                <input
+                  inputMode="numeric"
+                  max={1600}
+                  min={200}
+                  onChange={(event) => {
+                    const value = event.target.valueAsNumber
+                    setOptions((current) => ({
+                      ...current,
+                      height: Number.isFinite(value)
+                        ? Math.min(1600, Math.max(200, Math.round(value)))
+                        : undefined,
+                    }))
+                  }}
+                  placeholder="Auto"
+                  type="number"
+                  value={options.height ?? ''}
+                />
+              </label>
+            </div>
+            <label className={styles.field}>
+              <span>Outer padding</span>
+              <input
+                inputMode="numeric"
+                max={160}
+                min={0}
+                onChange={(event) => updateNumber('padding', event.target.valueAsNumber, 0, 160)}
+                type="number"
+                value={options.padding}
+              />
+            </label>
+            <label className={styles.option}>
+              <span>
+                <strong>Backdrop</strong>
+                <small>Fill the area around the code.</small>
+              </span>
+              <input
+                checked={options.backdrop}
+                onChange={(event) => updateOption('backdrop', event.target.checked)}
+                type="checkbox"
+              />
+            </label>
+          </fieldset>
+
+          <p className={styles.draftNote}>
+            The URL follows this draft, but it is not version-pinned. Export the image you intend to
+            share.
+          </p>
+        </aside>
+
+        <section className={styles.workbench} aria-label="Image workbench">
+          <div className={styles.actionBar}>
+            <button className={styles.secondaryButton} onClick={format} type="button">
+              <AlignLeft aria-hidden="true" />
+              Format
+            </button>
+            <div className={styles.exportActions}>
+              <button
+                className={styles.primaryButton}
+                data-state={action.kind}
+                disabled={busy}
+                onClick={() => void copyPng()}
+                type="button"
+              >
+                {busy ? <LoaderCircle aria-hidden="true" /> : <Clipboard aria-hidden="true" />}
+                {busy ? 'Rendering…' : 'Copy PNG'}
+              </button>
+              <button
+                className={styles.secondaryButton}
+                disabled={busy}
+                onClick={() => void downloadSvg()}
+                type="button"
+              >
+                <Download aria-hidden="true" />
+                SVG
+              </button>
+            </div>
+          </div>
+
+          <div className={styles.previewViewport}>
+            <div
+              ref={surfaceRef}
+              className={styles.exportSurface}
+              data-backdrop={options.backdrop}
+              style={{ height: options.height, padding: options.padding, width: options.width }}
+            >
+              <figure className={styles.codeFigure} data-snapshot-figure>
+                <figcaption className={styles.codeLabel} data-snapshot-label>
+                  <span>{options.filename || 'untitled.silk'}</span>
+                </figcaption>
+                <div
+                  className={styles.codeArea}
+                  data-snapshot-code
+                  style={{
+                    paddingBottom:
+                      options.diagnosticTooltip && firstDiagnostic !== undefined ? 64 : undefined,
+                  }}
+                >
+                  <silk-snippet ref={snippetRef} className={styles.snippet}>
+                    {initialSource}
+                  </silk-snippet>
+                  {options.diagnosticTooltip && firstDiagnostic !== undefined ? (
+                    <div
+                      className={styles.diagnosticTooltip}
+                      data-snapshot-diagnostic
+                      style={{ top: tooltipTop }}
+                    >
+                      <TriangleAlert aria-hidden="true" />
+                      <span>{firstDiagnostic.message}</span>
+                    </div>
+                  ) : null}
+                </div>
+              </figure>
+            </div>
+          </div>
+
+          <div className={styles.status} data-state={action.kind} role="status" aria-live="polite">
+            {action.kind === 'success' ? <Check aria-hidden="true" /> : null}
+            {action.kind === 'error' ? <TriangleAlert aria-hidden="true" /> : null}
+            {action.message}
+          </div>
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
+        <span>Silk source, rendered by the current compiler.</span>
+        <span>PNG clipboard · SVG download</span>
+      </footer>
+    </div>
+  )
+}

--- a/apps/docs/app/share/SourceCode.ts
+++ b/apps/docs/app/share/SourceCode.ts
@@ -1,0 +1,24 @@
+const chunkSize = 0x8000
+
+/** Encodes UTF-8 Silk source as unpadded, URL-safe Base64. */
+export const encode = (source: string): string => {
+  const bytes = new TextEncoder().encode(source)
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.slice(offset, offset + chunkSize))
+  }
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
+}
+
+/** Decodes URL-safe Base64, rejecting malformed input and source above the supplied limit. */
+export const decode = (encoded: string, maximumLength: number): string | undefined => {
+  try {
+    const base64 = encoded.replaceAll('-', '+').replaceAll('_', '/')
+    const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, '='))
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0))
+    const source = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    return source.length <= maximumLength ? source : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/docs/app/share/page.tsx
+++ b/apps/docs/app/share/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from 'next'
+import { JetBrains_Mono } from 'next/font/google'
+import { ShareWorkbench } from './ShareWorkbench'
+import * as SourceCode from './SourceCode'
+
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  style: ['normal'],
+  variable: '--share-mono',
+})
+
+const defaultSource = `import silk.allocator { Allocator, SystemAllocator }
+
+pub fn main() -> i32 {
+  let mut allocator = Allocator.systemAllocatorProvider()
+  return missing()
+}
+`
+
+export const metadata: Metadata = {
+  title: 'Silk Snapshot',
+  description: 'Turn Silk source into a syntax-highlighted PNG or SVG.',
+}
+
+type SearchParams = Promise<Record<string, string | ReadonlyArray<string> | undefined>>
+
+const first = (value: string | ReadonlyArray<string> | undefined): string | undefined =>
+  typeof value === 'string' ? value : value?.[0]
+
+const enabled = (value: string | undefined): boolean => value !== '0'
+
+const integer = (
+  value: string | undefined,
+  minimum: number,
+  maximum: number,
+  fallback: number,
+): number => {
+  const parsed = value === undefined ? Number.NaN : Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? Math.min(maximum, Math.max(minimum, parsed)) : fallback
+}
+
+const optionalInteger = (
+  value: string | undefined,
+  minimum: number,
+  maximum: number,
+): number | undefined => {
+  if (value === undefined || value === '') return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? Math.min(maximum, Math.max(minimum, parsed)) : undefined
+}
+
+const filename = (value: string | undefined): string => {
+  const normalized = value
+    ?.replace(/[\r\n]/g, '')
+    .trim()
+    .slice(0, 120)
+  return normalized === undefined || normalized === '' ? 'untitled.silk' : normalized
+}
+
+export default async function SharePage({ searchParams }: { readonly searchParams: SearchParams }) {
+  const parameters = await searchParams
+  const encoded = first(parameters.code)
+  const source =
+    encoded === undefined ? defaultSource : (SourceCode.decode(encoded, 50_000) ?? defaultSource)
+  return (
+    <ShareWorkbench
+      initialOptions={{
+        backdrop: enabled(first(parameters.backdrop)),
+        diagnostics: enabled(first(parameters.diagnostics)),
+        diagnosticTooltip: enabled(first(parameters.tooltip)),
+        filename: filename(first(parameters.filename)),
+        height: optionalInteger(first(parameters.height), 200, 1600),
+        inlayHints: enabled(first(parameters.hints)),
+        padding: integer(first(parameters.padding), 0, 160, 64),
+        width: integer(first(parameters.width), 320, 1600, 960),
+      }}
+      initialSource={source}
+      monoClassName={mono.variable}
+    />
+  )
+}

--- a/apps/docs/app/share/share.module.css
+++ b/apps/docs/app/share/share.module.css
@@ -1,0 +1,563 @@
+/* Hallmark · pre-emit critique: P5 H4 E4 S5 R5 V4 · genre: modern-minimal · macrostructure: Workbench · theme: studied-DNA (source: silklang.org) · enrichment: product canvas · nav: N9 · footer: Ft2 · contrast: pass (40–41) · slop: pass (42–45) · honest: pass (46) · chrome: pass (47) · tokens: pass (48) · responsive: pass (49) · icons: pass (30) · mobile: pass (34, 49, 50–57) */
+
+:global(html),
+:global(body) {
+  overflow-x: clip;
+}
+
+.share {
+  --color-paper: oklch(15.5% 0.007 70);
+  --color-paper-raised: oklch(18.5% 0.008 70);
+  --color-paper-high: oklch(21% 0.01 70);
+  --color-stage: oklch(17% 0 0);
+  --color-code: oklch(11.5% 0 0);
+  --color-rule: oklch(27% 0.012 70);
+  --color-rule-strong: oklch(34% 0.016 70);
+  --color-ink: oklch(93.5% 0.014 78);
+  --color-ink-soft: oklch(84% 0.014 74);
+  --color-muted: oklch(67% 0.012 70);
+  --color-dim: oklch(55% 0.012 70);
+  --color-accent: oklch(75% 0.075 75);
+  --color-accent-ink: oklch(20% 0.018 70);
+  --color-focus: oklch(78% 0.09 300);
+  --color-violet: oklch(76% 0.07 300);
+  --color-green: oklch(78% 0.08 155);
+  --color-error: oklch(68% 0.16 45);
+  --color-error-paper: oklch(24% 0.035 45);
+  --color-shadow: oklch(8% 0.008 70 / 0.4);
+  --color-transparent: transparent;
+  --font-display: var(--share-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-body: var(--share-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2.5rem;
+  --space-2xl: 4rem;
+  --text-xs: 0.6875rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-md: 1.25rem;
+  --text-lg: 1.5625rem;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.7, 0, 0.84, 0);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --dur-micro: 120ms;
+  --dur-short: 220ms;
+  --rule-thin: 1px;
+  --radius-control: 0.25rem;
+  --radius-canvas: 0.125rem;
+
+  min-height: 100svh;
+  overflow-x: clip;
+  background-color: var(--color-paper);
+  color: var(--color-ink-soft);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-variant-ligatures: none;
+  line-height: 1.55;
+}
+
+.navigation {
+  display: flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: space-between;
+  padding-inline: clamp(var(--space-md), 4vw, var(--space-xl));
+  border-block-end: var(--rule-thin) solid var(--color-rule);
+  background-color: var(--color-paper-raised);
+  color: var(--color-muted);
+}
+
+.wordmark,
+.docsLink {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  color: var(--color-muted);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.wordmark {
+  color: var(--color-accent);
+}
+
+.main {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-xl);
+  padding: clamp(var(--space-lg), 4vw, var(--space-2xl))
+    clamp(var(--space-md), 4vw, var(--space-xl));
+}
+
+.controls,
+.workbench {
+  min-width: 0;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+}
+
+.introduction {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.introduction h1 {
+  min-width: 0;
+  margin: 0;
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: clamp(var(--text-lg), 5vw, 2rem);
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.introduction p,
+.draftNote {
+  max-width: 45ch;
+  margin: 0;
+  color: var(--color-muted);
+  font-size: var(--text-sm);
+}
+
+.options,
+.frameOptions {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-block-start: var(--rule-thin) solid var(--color-rule-strong);
+}
+
+.options legend,
+.frameOptions legend {
+  padding-block: var(--space-sm);
+  color: var(--color-accent);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.frameOptions {
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-sm);
+}
+
+.field {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-xs);
+  color: var(--color-muted);
+  font-size: var(--text-xs);
+}
+
+.field input {
+  width: 100%;
+  min-width: 0;
+  min-height: 2.75rem;
+  box-sizing: border-box;
+  padding-inline: var(--space-sm);
+  border: var(--rule-thin) solid var(--color-rule-strong);
+  border-radius: var(--radius-control);
+  outline: 2px solid var(--color-transparent);
+  outline-offset: 1px;
+  background-color: var(--color-paper-raised);
+  color: var(--color-ink);
+  font: inherit;
+}
+
+.field input::placeholder {
+  color: var(--color-dim);
+}
+
+.field input:hover {
+  border-color: var(--color-muted);
+}
+
+.field input:focus-visible {
+  border-color: var(--color-rule-strong);
+  outline-color: var(--color-focus);
+}
+
+.field input:active {
+  background-color: var(--color-paper-high);
+}
+
+.field input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.dimensions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.option {
+  display: flex;
+  min-height: 4rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  border-block-end: var(--rule-thin) solid var(--color-rule);
+  color: var(--color-ink-soft);
+  cursor: pointer;
+}
+
+.option > span {
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.option strong {
+  color: var(--color-ink-soft);
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.option small {
+  color: var(--color-muted);
+  font-size: var(--text-xs);
+}
+
+.option[data-disabled='true'] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.option input {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: 0 0 auto;
+  accent-color: var(--color-accent);
+}
+
+.option input:focus-visible,
+.wordmark:focus-visible,
+.docsLink:focus-visible,
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 3px;
+}
+
+.draftNote {
+  padding-inline-start: var(--space-sm);
+  border-inline-start: var(--rule-thin) solid var(--color-accent);
+}
+
+.workbench {
+  display: grid;
+  align-content: start;
+  gap: var(--space-sm);
+}
+
+.actionBar,
+.exportActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.actionBar {
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  padding-inline: var(--space-md);
+  border: var(--rule-thin) solid var(--color-rule-strong);
+  border-radius: var(--radius-control);
+  background-color: var(--color-paper-raised);
+  color: var(--color-ink-soft);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color var(--dur-short) var(--ease-out),
+    color var(--dur-short) var(--ease-out),
+    transform var(--dur-micro) var(--ease-out);
+}
+
+.primaryButton {
+  border-color: var(--color-accent);
+  background-color: var(--color-accent);
+  color: var(--color-accent-ink);
+}
+
+.primaryButton svg,
+.secondaryButton svg,
+.status svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.primaryButton:active,
+.secondaryButton:active {
+  transform: translateY(1px);
+}
+
+.wordmark:active,
+.docsLink:active {
+  color: var(--color-accent);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.primaryButton[data-state='loading'] svg {
+  animation: spin 900ms linear infinite;
+}
+
+.primaryButton[data-state='success'] {
+  border-color: var(--color-green);
+}
+
+.primaryButton[data-state='error'] {
+  border-color: var(--color-error);
+}
+
+.previewViewport {
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.exportSurface {
+  min-width: 0;
+  box-sizing: border-box;
+  overflow: clip;
+  padding: clamp(var(--space-lg), 6vw, var(--space-2xl));
+  border-radius: var(--radius-canvas);
+  background-color: var(--color-stage);
+  color: var(--color-ink-soft);
+}
+
+.exportSurface[data-backdrop='false'] {
+  background-color: var(--color-transparent);
+}
+
+.codeFigure {
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  border: var(--rule-thin) solid var(--color-rule-strong);
+  background-color: var(--color-code);
+  color: var(--color-ink-soft);
+  box-shadow: 0 var(--space-lg) var(--space-2xl) var(--color-shadow);
+}
+
+.codeLabel {
+  display: flex;
+  min-height: 2.25rem;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-sm);
+  padding-inline: var(--space-sm);
+  border-block-end: var(--rule-thin) solid var(--color-rule-strong);
+  color: var(--color-accent);
+  font-size: var(--text-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.codeLabel span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codeArea {
+  position: relative;
+  min-width: 0;
+  background-color: var(--color-code);
+  color: var(--color-ink-soft);
+}
+
+.snippet {
+  display: block;
+  border: 0;
+  border-radius: 0;
+  background-color: var(--color-code);
+  color: var(--color-ink-soft);
+  font-family: var(--font-body);
+  --silk-snippet-font: var(--font-body);
+  --silk-snippet-font-size: 0.8125rem;
+  --silk-snippet-line-height: 1.85;
+  --silk-snippet-padding: var(--space-md);
+  --silk-snippet-bg: var(--color-code);
+  --silk-snippet-border: var(--color-rule-strong);
+  --silk-snippet-ink: var(--color-ink);
+  --silk-snippet-ink-muted: var(--color-ink-soft);
+  --silk-snippet-selection: var(--color-paper-high);
+  --silk-snippet-error: var(--color-error);
+  --silk-snippet-tooltip-bg: var(--color-paper-high);
+  --silk-snippet-code-bg: var(--color-paper-high);
+  --silk-snippet-accent: var(--color-violet);
+  --silk-snippet-hint: var(--color-dim);
+  --silk-snippet-token-keyword: var(--color-accent);
+  --silk-snippet-token-type: var(--color-violet);
+  --silk-snippet-token-identifier: var(--color-ink);
+  --silk-snippet-token-number: var(--color-violet);
+  --silk-snippet-token-string: var(--color-green);
+  --silk-snippet-token-comment: var(--color-muted);
+  --silk-snippet-token-operator: var(--color-ink-soft);
+  --silk-snippet-token-punctuation: var(--color-muted);
+}
+
+.snippet:not(:defined) {
+  padding: var(--space-md);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.diagnosticTooltip {
+  position: absolute;
+  z-index: 1;
+  inset-inline: clamp(var(--space-md), 8%, var(--space-2xl)) var(--space-md);
+  display: flex;
+  max-width: 42rem;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  padding: var(--space-sm);
+  border: var(--rule-thin) solid var(--color-error);
+  border-radius: var(--radius-control);
+  background-color: var(--color-error-paper);
+  color: var(--color-ink);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+  box-shadow: 0 var(--space-sm) var(--space-xl) var(--color-shadow);
+  pointer-events: none;
+}
+
+.diagnosticTooltip svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  color: var(--color-error);
+}
+
+.status {
+  display: flex;
+  min-height: 1.5rem;
+  align-items: center;
+  gap: var(--space-xs);
+  color: var(--color-muted);
+  font-size: var(--text-xs);
+}
+
+.status[data-state='success'] {
+  color: var(--color-green);
+}
+
+.status[data-state='error'] {
+  color: var(--color-error);
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-inline: clamp(var(--space-md), 4vw, var(--space-xl));
+  padding-block: var(--space-lg);
+  border-block-start: var(--rule-thin) solid var(--color-rule);
+  color: var(--color-dim);
+  font-size: var(--text-xs);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .wordmark:hover,
+  .docsLink:hover {
+    color: var(--color-ink);
+  }
+
+  .secondaryButton:hover {
+    background-color: var(--color-paper-high);
+    color: var(--color-ink);
+    transform: translateY(-1px);
+  }
+
+  .primaryButton:hover:not(:disabled) {
+    transform: translateY(-1px);
+  }
+}
+
+@media (min-width: 40rem) {
+  .footer {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 60rem) {
+  .main {
+    grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .controls {
+    position: sticky;
+    top: var(--space-lg);
+  }
+}
+
+@media (pointer: coarse) {
+  .primaryButton,
+  .secondaryButton,
+  .wordmark,
+  .docsLink {
+    min-height: 3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primaryButton,
+  .secondaryButton {
+    transition: none;
+  }
+
+  .primaryButton:hover,
+  .secondaryButton:hover,
+  .primaryButton:active,
+  .secondaryButton:active {
+    transform: none;
+  }
+
+  .primaryButton[data-state='loading'] svg {
+    animation: none;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/apps/docs/app/share/snapshot.ts
+++ b/apps/docs/app/share/snapshot.ts
@@ -1,0 +1,272 @@
+import * as Data from 'effect/Data'
+import * as Effect from 'effect/Effect'
+
+export class SnapshotError extends Data.TaggedError('SnapshotError')<{
+  readonly message: string
+}> {}
+
+const xml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+
+const number = (value: number): string => String(Math.round(value * 100) / 100)
+
+const relative = (bounds: DOMRect, root: DOMRect) => ({
+  height: bounds.height,
+  width: bounds.width,
+  x: bounds.left - root.left,
+  y: bounds.top - root.top,
+})
+
+const rect = (
+  bounds: ReturnType<typeof relative>,
+  options: {
+    readonly fill: string
+    readonly radius?: number
+    readonly stroke?: string
+    readonly strokeWidth?: number
+  },
+): string =>
+  `<rect x="${number(bounds.x)}" y="${number(bounds.y)}" width="${number(bounds.width)}" height="${number(bounds.height)}" fill="${xml(options.fill)}"${options.stroke === undefined ? '' : ` stroke="${xml(options.stroke)}" stroke-width="${number(options.strokeWidth ?? 1)}"`}${options.radius === undefined ? '' : ` rx="${number(options.radius)}"`}/>`
+
+const text = (value: string, element: Element, bounds: DOMRect, root: DOMRect): string => {
+  const style = getComputedStyle(element)
+  const box = relative(bounds, root)
+  const baseline = box.y + box.height * 0.8
+  return `<text x="${number(box.x)}" y="${number(baseline)}" fill="${xml(style.color)}" fill-opacity="${xml(style.opacity)}" font-family="${xml(style.fontFamily)}" font-size="${xml(style.fontSize)}" font-style="${xml(style.fontStyle)}" font-weight="${xml(style.fontWeight)}" letter-spacing="${xml(style.letterSpacing)}" xml:space="preserve">${xml(value)}</text>`
+}
+
+const elementText = (element: Element, root: DOMRect): string => {
+  const value = element.textContent ?? ''
+  return value === '' ? '' : text(value, element, element.getBoundingClientRect(), root)
+}
+
+const textNodes = (element: Element): ReadonlyArray<Text> => {
+  const nodes: Array<Text> = []
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  while (walker.nextNode() !== null) {
+    if (walker.currentNode instanceof Text && walker.currentNode.data !== '')
+      nodes.push(walker.currentNode)
+  }
+  return nodes
+}
+
+const renderedText = (node: Text, root: DOMRect): string => {
+  const parent = node.parentElement
+  if (parent === null) return ''
+  const range = document.createRange()
+  range.selectNodeContents(node)
+  const bounds = range.getBoundingClientRect()
+  return bounds.width === 0 || bounds.height === 0 ? '' : text(node.data, parent, bounds, root)
+}
+
+const squiggle = (element: Element, root: DOMRect): string => {
+  const bounds = relative(element.getBoundingClientRect(), root)
+  const y = bounds.y + bounds.height + 1
+  const end = bounds.x + bounds.width
+  const points: Array<string> = []
+  for (let x = bounds.x; x <= end; x += 2) {
+    points.push(`${number(x)},${number(y + (Math.round((x - bounds.x) / 2) % 2 === 0 ? 0 : 2))}`)
+  }
+  const color = getComputedStyle(element).textDecorationColor
+  return `<polyline points="${points.join(' ')}" fill="none" stroke="${xml(color)}" stroke-width="1"/>`
+}
+
+const wrap = (value: string, maximum: number): ReadonlyArray<string> => {
+  const lines: Array<string> = []
+  let line = ''
+  for (const word of value.split(/\s+/)) {
+    const candidate = line === '' ? word : `${line} ${word}`
+    if (candidate.length <= maximum || line === '') line = candidate
+    else {
+      lines.push(line)
+      line = word
+    }
+  }
+  if (line !== '') lines.push(line)
+  return lines
+}
+
+export interface Snapshot {
+  readonly height: number
+  readonly svg: string
+  readonly width: number
+}
+
+const captureVisible = (surface: HTMLElement): Snapshot => {
+  const root = surface.getBoundingClientRect()
+  const width = Math.ceil(root.width)
+  const height = Math.ceil(root.height)
+  if (width === 0 || height === 0) throw new Error('The image preview is not visible yet.')
+
+  const figure = surface.querySelector<HTMLElement>('[data-snapshot-figure]')
+  const label = surface.querySelector<HTMLElement>('[data-snapshot-label]')
+  const codeArea = surface.querySelector<HTMLElement>('[data-snapshot-code]')
+  const snippet = surface.querySelector<HTMLElement>('silk-snippet')
+  const content = snippet?.shadowRoot?.querySelector<HTMLElement>('.cm-content')
+  if (
+    figure === null ||
+    label === null ||
+    codeArea === null ||
+    content === null ||
+    content === undefined
+  )
+    throw new Error('The Silk editor is still loading.')
+
+  const surfaceStyle = getComputedStyle(surface)
+  const figureStyle = getComputedStyle(figure)
+  const labelStyle = getComputedStyle(label)
+  const codeStyle = getComputedStyle(codeArea)
+  const figureBounds = relative(figure.getBoundingClientRect(), root)
+  const labelBounds = relative(label.getBoundingClientRect(), root)
+  const codeBounds = relative(codeArea.getBoundingClientRect(), root)
+  const primitives: Array<string> = [
+    rect({ x: 0, y: 0, width, height }, { fill: surfaceStyle.backgroundColor }),
+    rect(figureBounds, {
+      fill: figureStyle.backgroundColor,
+      stroke: figureStyle.borderTopColor,
+      strokeWidth: Number.parseFloat(figureStyle.borderTopWidth) || 1,
+    }),
+    rect(labelBounds, { fill: labelStyle.backgroundColor }),
+    `<line x1="${number(labelBounds.x)}" x2="${number(labelBounds.x + labelBounds.width)}" y1="${number(labelBounds.y + labelBounds.height)}" y2="${number(labelBounds.y + labelBounds.height)}" stroke="${xml(labelStyle.borderBottomColor)}" stroke-width="${number(Number.parseFloat(labelStyle.borderBottomWidth) || 1)}"/>`,
+    rect(codeBounds, { fill: codeStyle.backgroundColor }),
+  ]
+
+  for (const child of label.children) primitives.push(elementText(child, root))
+
+  const clipId = 'silk-code-clip'
+  const codeText = textNodes(content)
+    .map((node) => renderedText(node, root))
+    .join('')
+  const diagnostics = Array.from(
+    snippet?.shadowRoot?.querySelectorAll<HTMLElement>('.cm-lintRange-error') ?? [],
+  )
+    .map((element) => squiggle(element, root))
+    .join('')
+  primitives.push(
+    `<defs><clipPath id="${clipId}"><rect x="${number(codeBounds.x)}" y="${number(codeBounds.y)}" width="${number(codeBounds.width)}" height="${number(codeBounds.height)}"/></clipPath></defs>`,
+    `<g clip-path="url(#${clipId})">${codeText}${diagnostics}</g>`,
+  )
+
+  const diagnostic = surface.querySelector<HTMLElement>('[data-snapshot-diagnostic]')
+  if (diagnostic !== null) {
+    const style = getComputedStyle(diagnostic)
+    const bounds = relative(diagnostic.getBoundingClientRect(), root)
+    primitives.push(
+      rect(bounds, {
+        fill: style.backgroundColor,
+        radius: Number.parseFloat(style.borderRadius) || 0,
+        stroke: style.borderTopColor,
+        strokeWidth: Number.parseFloat(style.borderTopWidth) || 1,
+      }),
+    )
+    const message = diagnostic.querySelector('span')?.textContent ?? ''
+    const fontSize = Number.parseFloat(style.fontSize) || 12
+    const lineHeight = Number.parseFloat(style.lineHeight) || fontSize * 1.45
+    const maximum = Math.max(18, Math.floor((bounds.width - 48) / (fontSize * 0.62)))
+    const lines = wrap(message, maximum)
+    const color = xml(style.color)
+    const family = xml(style.fontFamily)
+    const x = bounds.x + 36
+    const firstY =
+      bounds.y + Math.max(lineHeight, (bounds.height - lines.length * lineHeight) / 2 + fontSize)
+    primitives.push(
+      `<path d="M ${number(bounds.x + 14)} ${number(bounds.y + 22)} L ${number(bounds.x + 20)} ${number(bounds.y + 10)} L ${number(bounds.x + 26)} ${number(bounds.y + 22)} Z" fill="none" stroke="${xml(getComputedStyle(diagnostic.querySelector('svg') ?? diagnostic).color)}" stroke-width="1.5"/>`,
+      ...lines.map(
+        (line, index) =>
+          `<text x="${number(x)}" y="${number(firstY + index * lineHeight)}" fill="${color}" font-family="${family}" font-size="${number(fontSize)}" font-weight="${xml(style.fontWeight)}">${xml(line)}</text>`,
+      ),
+    )
+  }
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="Silk source code snapshot">${primitives.join('')}</svg>`
+  return { height, svg, width }
+}
+
+const nextPaint = Effect.callback<void>((resume) => {
+  requestAnimationFrame(() => requestAnimationFrame(() => resume(Effect.void)))
+})
+
+/**
+ * Draws the editor as origin-clean SVG primitives at a stable share width, independent of the
+ * device currently editing it.
+ */
+export const capture = Effect.fn('Snapshot.capture')(function* (
+  surface: HTMLElement,
+): Effect.fn.Return<Snapshot> {
+  return yield* Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const originalStyle = surface.getAttribute('style')
+      surface.style.position = 'fixed'
+      surface.style.insetBlockStart = '0'
+      surface.style.insetInlineStart = '-10000px'
+      surface.style.maxWidth = 'none'
+      surface.style.visibility = 'hidden'
+      return originalStyle
+    }),
+    () => nextPaint.pipe(Effect.andThen(Effect.sync(() => captureVisible(surface)))),
+    (originalStyle) =>
+      Effect.sync(() => {
+        if (originalStyle === null) surface.removeAttribute('style')
+        else surface.setAttribute('style', originalStyle)
+      }),
+  )
+})
+
+/** Rasterizes a pure-SVG snapshot at 2× for crisp clipboard output. */
+export const png = Effect.fn('Snapshot.png')(function* (
+  snapshot: Snapshot,
+): Effect.fn.Return<Blob, SnapshotError> {
+  const source = new Blob([snapshot.svg], { type: 'image/svg+xml;charset=utf-8' })
+  return yield* Effect.acquireUseRelease(
+    Effect.sync(() => URL.createObjectURL(source)),
+    (url) =>
+      Effect.gen(function* () {
+        const image = yield* Effect.callback<HTMLImageElement, SnapshotError>((resume) => {
+          const image = new Image()
+          image.onload = () => resume(Effect.succeed(image))
+          image.onerror = () =>
+            resume(
+              Effect.fail(
+                new SnapshotError({ message: 'The browser could not rasterize this SVG.' }),
+              ),
+            )
+          image.src = url
+        })
+        const scale = 2
+        const canvas = document.createElement('canvas')
+        canvas.width = snapshot.width * scale
+        canvas.height = snapshot.height * scale
+        const context = canvas.getContext('2d')
+        if (context === null)
+          return yield* new SnapshotError({
+            message: 'Canvas rendering is unavailable in this browser.',
+          })
+        context.scale(scale, scale)
+        context.drawImage(image, 0, 0, snapshot.width, snapshot.height)
+        return yield* Effect.callback<Blob, SnapshotError>((resume) => {
+          canvas.toBlob((blob) => {
+            if (blob === null)
+              resume(
+                Effect.fail(new SnapshotError({ message: 'The browser could not create a PNG.' })),
+              )
+            else resume(Effect.succeed(blob))
+          }, 'image/png')
+        })
+      }),
+    (url) => Effect.sync(() => URL.revokeObjectURL(url)),
+  )
+})
+
+export const download = (blob: Blob, filename: string): void => {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.download = filename
+  link.href = url
+  link.click()
+  URL.revokeObjectURL(url)
+}

--- a/packages/editor-support/src/Editor.ts
+++ b/packages/editor-support/src/Editor.ts
@@ -49,10 +49,19 @@ export interface Session {
   readonly source: string
 }
 
+/** One editor-ready diagnostic, projected into UTF-16 offsets for the visible document. */
+export interface Diagnostic {
+  readonly from: number
+  readonly to: number
+  readonly message: string
+}
+
 /** The imperative surface a host (custom element or React wrapper) drives the editor through. */
 export interface Handle {
   value(): string
   setValue(doc: string): void
+  /** Diagnostics from the current, source-matched analysis session. */
+  diagnostics(): ReadonlyArray<Diagnostic>
   /** Installs the session every enabled semantic feature reads; `undefined` clears semantics. */
   setSession(session: Session | undefined): void
   /** Draws the shared span highlight over one byte range; `null` clears it. */
@@ -262,11 +271,16 @@ const theme = EditorView.theme({
 export const mount = (options: Options): Handle => {
   const features = options.features ?? {}
   let current: Session | undefined
+  let currentDiagnostics: ReadonlyArray<Diagnostic> = []
 
   const applyDiagnostics = (view: EditorView): void => {
-    if (features.diagnostics !== true) return
+    if (features.diagnostics !== true) {
+      currentDiagnostics = []
+      return
+    }
     const session_ = current
     if (session_ === undefined || view.state.doc.toString() !== session_.source) {
+      currentDiagnostics = []
       view.dispatch(setDiagnostics(view.state, []))
       return
     }
@@ -275,17 +289,22 @@ export const mount = (options: Options): Handle => {
       session_.snapshot,
       () => undefined,
     )
+    currentDiagnostics = diagnostics.map((diagnostic) => ({
+      from: lspOffset(view.state, diagnostic.range.start),
+      to: lspOffset(view.state, diagnostic.range.end),
+      message:
+        typeof diagnostic.code === 'string'
+          ? `${diagnostic.code}: ${diagnostic.message}`
+          : diagnostic.message,
+    }))
     view.dispatch(
       setDiagnostics(
         view.state,
-        diagnostics.map((diagnostic) => ({
-          from: lspOffset(view.state, diagnostic.range.start),
-          to: lspOffset(view.state, diagnostic.range.end),
+        currentDiagnostics.map((diagnostic) => ({
+          from: diagnostic.from,
+          to: diagnostic.to,
           severity: 'error' as const,
-          message:
-            typeof diagnostic.code === 'string'
-              ? `${diagnostic.code}: ${diagnostic.message}`
-              : diagnostic.message,
+          message: diagnostic.message,
         })),
       ),
     )
@@ -417,6 +436,7 @@ export const mount = (options: Options): Handle => {
         annotations: External.of(true),
       })
     },
+    diagnostics: () => currentDiagnostics,
     setSession: (session_) => {
       current = session_
       applyDiagnostics(view)

--- a/packages/editor-support/src/Element.ts
+++ b/packages/editor-support/src/Element.ts
@@ -30,6 +30,17 @@ const nextModule = (): string => {
   return `snippet/${ordinal}`
 }
 
+/** Detail published whenever editable Silk source changes. */
+export interface SilkChangeDetail {
+  readonly source: string
+}
+
+/** Detail published whenever semantic analysis catches up with the visible source. */
+export interface SilkAnalysisDetail {
+  readonly diagnostics: ReadonlyArray<Editor.Diagnostic>
+  readonly source: string
+}
+
 /**
  * Shadow-scoped chrome and the default palette for both color schemes. Every value is a
  * `--silk-snippet-*` custom property, so a host page can retheme snippets with one rule on the
@@ -125,6 +136,17 @@ export class SilkSnippetElement extends HTMLElement {
     return this.#handle?.value() ?? this.#source ?? ''
   }
 
+  set source(source: string) {
+    this.#source = source
+    this.#handle?.setValue(source)
+    if (this.#handle !== undefined && this.#semantic()) this.#compile()
+  }
+
+  /** Diagnostics from the latest analysis of the current source. */
+  get diagnostics(): ReadonlyArray<Editor.Diagnostic> {
+    return this.#handle?.diagnostics() ?? []
+  }
+
   #features(): Editor.Features {
     return {
       diagnostics: this.hasAttribute('diagnostics'),
@@ -157,6 +179,34 @@ export class SilkSnippetElement extends HTMLElement {
       }).pipe(Effect.provide(SourceResolver.empty)),
     )
     handle.setSession(Editor.session(this.#module, bytes, snapshot))
+    this.dispatchEvent(
+      new CustomEvent<SilkAnalysisDetail>('silk-analysis', {
+        bubbles: true,
+        composed: true,
+        detail: { diagnostics: handle.diagnostics(), source: handle.value() },
+      }),
+    )
+  }
+
+  /** Immediately refreshes semantic presentation and returns its diagnostics. */
+  analyze(): ReadonlyArray<Editor.Diagnostic> {
+    if (this.#handle === undefined || !this.#semantic()) return []
+    this.#compile()
+    return this.diagnostics
+  }
+
+  /** Formats the current source through the language server. */
+  format(): boolean {
+    const handle = this.#handle
+    if (handle === undefined) return false
+    this.#compile()
+    const formatted = handle.format()
+    if (!formatted) return false
+    this.#source = handle.value()
+    if (this.#recompileFiber !== undefined) Effect.runFork(Fiber.interrupt(this.#recompileFiber))
+    this.#recompileFiber = undefined
+    this.#compile()
+    return true
   }
 
   #scheduleRecompile(): void {
@@ -207,6 +257,13 @@ export class SilkSnippetElement extends HTMLElement {
       features: this.#features(),
       onChange: (doc) => {
         this.#source = doc
+        this.dispatchEvent(
+          new CustomEvent<SilkChangeDetail>('silk-change', {
+            bubbles: true,
+            composed: true,
+            detail: { source: doc },
+          }),
+        )
         this.#scheduleRecompile()
       },
     })


### PR DESCRIPTION
## Summary

- add a /share workbench for editing and exporting Silk source as PNG or SVG
- expose inlay hints, diagnostics, pinned diagnostic messages, and compiler formatting
- persist draft and presentation settings in the route with URL-safe Base64 source encoding
- support configurable filename, width, automatic or fixed height, padding, and transparent backdrop
- extend the editor custom element with source replacement, analysis diagnostics, and formatting hooks

## Validation

- pnpm typecheck
- pnpm format:check
- pnpm lint
- pnpm --filter @silklang/docs build
- pnpm release:candidate
- browser QA for PNG/SVG export, route restoration, toggles, responsive overflow, automatic height, and transparent backgrounds

No page-specific tests were added, per request.