### PR TITLE
Specify bounded PEM, DER, and X.509 decoding

### DIFF
--- a/openspec/changes/specify-bounded-certificate-decoding/.openspec.yaml
+++ b/openspec/changes/specify-bounded-certificate-decoding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/specify-bounded-certificate-decoding/design.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/design.md
@@ -137,6 +137,8 @@ All rejection below is `Malformed` unless explicitly `Unsupported` or `ResourceL
 | Later invalid block in bundle                                                     | Entire call fails; no prefix result |
 
 Markers have exactly five hyphens at each end and exactly one space between BEGIN/END and label.
+A well-formed unsupported label follows the RFC 7468 §3 `label` grammar; malformed labels
+return Malformed.PemSyntax rather than Unsupported.PemLabel.
 After ignoring allowed body whitespace, base64 length is a multiple of four; only its last
 quartet may use one or two `=` as dictated by the decoded length. Each block decodes exactly one
 DER certificate, with no decoded suffix. No automatic DER/PEM detection or recovery scanning.
@@ -289,6 +291,11 @@ claimed. See [fixtures.md](fixtures.md) and [implementation.md](implementation.m
 - Owned copies increase storage → finite aggregate budgets, exact reservation where available, simple immutable lifetime contract.
 - Structural success can be mistaken for Web PKI validity → distinct decoder errors and consumer responsibilities; never expose a validation flag.
 - Open ASN.1 types lack schemas → preserve encodings and limit checks honestly; algorithm/extension consumers enforce their own schemas.
+
+The pinned [Zig Certificate implementation](https://raw.githubusercontent.com/ziglang/zig/e78ea8f2cb3677c0a104319b8aa5e37ea64d9cfa/lib/std/crypto/Certificate.zig)
+provides a structural precedent for retaining signed-message spans. Its omission of unknown
+extensions is deliberately not adopted. The owned bundle design avoids borrowed views being
+invalidated by later acquisition or mutation; acquisition remains a separate consumer.
 
 ## Migration Plan
 

--- a/openspec/changes/specify-bounded-certificate-decoding/design.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/design.md
@@ -1,0 +1,297 @@
+## Context
+
+Status: proposed contract only; no certificate parser ships in JUL-167. Admission at
+`c6eae2f976a8f1a7681ffbfdcbbc8c776b9f0c96` inspected the delta from
+`f5ada543a1738e4f0c69b311bdeb9a72e32e9dd3`. Graph discovery plus direct manifest,
+Silk source, reference and active/archived OpenSpec review found no owning decoder.
+Silk source is not fully indexed. Neighboring HMAC/HKDF, URI and compression actors now exist.
+`Uri.parseOwned`, `Bytes.copy`, `Slice.view` and ordinary owned storage supply the API precedent.
+
+## Goals / Non-Goals
+
+Define a portable structural decoder that preserves information for independent validators.
+Successful decoding means only that the selected envelope/schema is well formed and within limits.
+It says nothing about trust, signatures, dates relative to now, identities or algorithm security.
+No public generic ASN.1 tree, OS service, clock, network or cryptographic dependency is required.
+
+## Decisions
+
+### Public actors and ownership
+
+The following are exact proposed declarations, with implementation bodies omitted, not runnable
+examples or claims of installed modules. Imports use `silk.allocator`, `silk.result`,
+`silk.option`, `silk.certificate` and `silk.certificate_bundle`. `Allocator`,
+`OutOfMemoryError`, `Result` and `Option` retain their existing definitions.
+
+```silk
+// silk.certificate, inside impl Certificate
+pub effect fn decodeDer(input: &[u8], limits: DecodeLimits) -> Result<Certificate, DecodeError>
+! OutOfMemoryError ? &mut Allocator
+pub effect fn decodePem(input: &[u8], limits: DecodeLimits) -> Result<Certificate, DecodeError>
+! OutOfMemoryError ? &mut Allocator
+pub fn der(self: &Self) -> &[u8]
+pub fn tbsDer(self: &Self) -> &[u8]
+pub fn version(self: &Self) -> CertificateVersion
+pub fn serial(self: &Self) -> &[u8]
+pub fn issuerDer(self: &Self) -> &[u8]
+pub fn subjectDer(self: &Self) -> &[u8]
+pub fn notBefore(self: &Self) -> CertificateTime
+pub fn notAfter(self: &Self) -> CertificateTime
+pub fn validityDer(self: &Self) -> &[u8]
+pub fn spkiDer(self: &Self) -> &[u8]
+pub fn publicKey<'a>(self: &'a Self) -> BitStringView<'a>
+pub fn publicKeyAlgorithm<'a>(self: &'a Self) -> AlgorithmView<'a>
+pub fn tbsSignatureAlgorithm<'a>(self: &'a Self) -> AlgorithmView<'a>
+pub fn signatureAlgorithm<'a>(self: &'a Self) -> AlgorithmView<'a>
+pub fn signature<'a>(self: &'a Self) -> BitStringView<'a>
+pub fn issuerUniqueId<'a>(self: &'a Self) -> Option<BitStringView<'a>>
+pub fn subjectUniqueId<'a>(self: &'a Self) -> Option<BitStringView<'a>>
+pub fn extensionCount(self: &Self) -> usize
+pub fn extension<'a>(self: &'a Self, index: usize) -> Option<ExtensionView<'a>>
+
+// silk.certificate_bundle, inside impl CertificateBundle
+pub effect fn decodePem(input: &[u8], limits: DecodeLimits) -> Result<CertificateBundle, DecodeError>
+! OutOfMemoryError ? &mut Allocator
+pub fn length(self: &Self) -> usize
+pub fn get<'a>(self: &'a Self, index: usize) -> Option<&'a Certificate>
+```
+
+`Certificate` and `CertificateBundle` are opaque, move-only owners with private storage and no
+public mutators or unchecked constructors. They store owned DER and checked offsets, never
+self-references. The effect borrows input until execution completes or is dropped; outputs and
+errors retain no input loan. The caller may then mutate/drop input. Returned views borrow the
+owner, allocate nothing, and cannot outlive it. `get`/`extension` return `None` out of range.
+A bundle retains input order and duplicate certificates; it does not imply chain order or trust.
+No partial certificate, callback, iterator yield or prefix bundle escapes on failure.
+Ordinary owned cleanup releases scratch and prior certificates on structured exits, including
+allocation failure; no cleanup guarantee is invented for process termination or unrecoverable traps.
+
+```silk
+pub enum CertificateVersion { V1, V2, V3 }
+pub struct CertificateTime {
+  pub year: u16
+  pub month: u8
+  pub day: u8
+  pub hour: u8
+  pub minute: u8
+  pub second: u8
+}
+pub struct BitStringView<'a> {
+  pub bytes: &'a [u8]
+  pub unusedBits: u8
+}
+pub struct AlgorithmView<'a> {
+  pub der: &'a [u8]
+  pub oid: &'a [u8]
+  pub parametersDer: Option<&'a [u8]>
+}
+pub struct ExtensionView<'a> {
+  pub der: &'a [u8]
+  pub oid: &'a [u8]
+  pub critical: bool
+  pub value: &'a [u8]
+}
+```
+
+All `der` views include tag and length; `tbsDer` is the original complete TBSCertificate TLV,
+never reconstructed. `serial` is the original minimal signed INTEGER content, including any
+necessary sign octet. OIDs are canonical DER content octets (no tag/length), not narrowed machine
+integers or lossy text. Parameters preserve absence versus explicit NULL and the complete TLV.
+BIT STRING views exclude the initial unused-bit-count octet but retain its value separately.
+All three AlgorithmIdentifiers remain distinct. Every extension is retained in original order,
+including unknown and critical ones; values are exact OCTET STRING content. Names remain full
+RDNSequence DER, preserving RDN boundaries, attribute OIDs, value types and encoded values.
+No string normalization, common-name extraction, SAN selection or key algorithm parsing occurs.
+
+### Input profile
+
+All rejection below is `Malformed` unless explicitly `Unsupported` or `ResourceLimit`.
+
+| Input                                                                             | Outcome                             |
+| --------------------------------------------------------------------------------- | ----------------------------------- |
+| One exact DER Certificate TLV                                                     | Accept                              |
+| Empty DER, concatenated DER, trailing byte/whitespace                             | Reject                              |
+| v1 (version absent), v2 (INTEGER 1), v3 (INTEGER 2)                               | Accept                              |
+| Explicit default v1 INTEGER 0                                                     | Reject noncanonical DEFAULT         |
+| Negative version                                                                  | Reject                              |
+| Canonical nonnegative version above 2                                             | Unsupported.Version                 |
+| v1 unique IDs; v1/v2 extensions                                                   | Reject schema violation             |
+| v2/v3 unique IDs; v3 extensions absent                                            | Accept                              |
+| Exact case-sensitive CERTIFICATE markers                                          | Accept                              |
+| X509 CERTIFICATE, TRUSTED CERTIFICATE, PUBLIC KEY or any other well-formed label  | Unsupported.PemLabel; never skip    |
+| Mismatched, missing, malformed or nested markers                                  | Reject                              |
+| LF, CRLF, bare CR, including mixed newline styles                                 | Accept                              |
+| SP/HT around markers on their otherwise empty lines                               | Accept                              |
+| SP/HT/CR/LF between blocks or before/after the document                           | Accept                              |
+| SP/HT/CR/LF anywhere within base64                                                | Ignore; any line width accepted     |
+| VT, FF, BOM, NUL, non-ASCII or other nonalphabet content                          | Reject                              |
+| Preamble, explanatory text, PEM headers, comments, unrelated blocks               | Reject                              |
+| Missing newline after BEGIN or before END                                         | Reject                              |
+| END at EOF without final newline                                                  | Accept                              |
+| Empty base64 block, empty/whitespace-only PEM document                            | Reject                              |
+| Standard base64 alphabet, exact final padding, zero pad bits                      | Accept                              |
+| Missing required padding, excess/interior padding, URL alphabet, nonzero pad bits | Reject                              |
+| Full final quartet needing no padding                                             | Accept                              |
+| Two or more valid blocks in Certificate.decodePem                                 | Reject TrailingData at second BEGIN |
+| One or more blocks in CertificateBundle.decodePem                                 | Accept within count/byte bounds     |
+| Later invalid block in bundle                                                     | Entire call fails; no prefix result |
+
+Markers have exactly five hyphens at each end and exactly one space between BEGIN/END and label.
+After ignoring allowed body whitespace, base64 length is a multiple of four; only its last
+quartet may use one or two `=` as dictated by the decoded length. Each block decodes exactly one
+DER certificate, with no decoded suffix. No automatic DER/PEM detection or recovery scanning.
+
+This is a deliberate strict subset of [RFC 7468 §§2–3,5](https://www.rfc-editor.org/rfc/rfc7468.html):
+it rejects surrounding explanatory text and non-base64 characters rather than ignoring them,
+rejects VT/FF, requires matching labels, and requires DER although textual certificates can
+carry BER. It supports all three newline conventions. It does not claim universal RFC 7468
+parser acceptance. A trust-source provider needing decorated bundles must explicitly adapt its
+input policy; the decoder never silently salvages a subset.
+
+### DER and selected schema
+
+Authority: [X.690 (02/2021)](https://www.itu.int/rec/T-REC-X.690-202102-I/en),
+including [Erratum 1 (09/2021)](https://www.itu.int/rec/T-REC-X.690-202109-I!Err1/en),
+§§8,10,11, and [RFC 5280 §4.1 and Appendix A.1](https://www.rfc-editor.org/rfc/rfc5280.html#section-4.1).
+The decoder recognizes the Certificate/TBSCertificate schema and Name/RDN/AttributeTypeAndValue,
+Validity, SubjectPublicKeyInfo, AlgorithmIdentifier and Extension envelopes. It does not interpret
+extension OCTET STRING payloads, SPKI BIT STRING payloads or signature BIT STRING payloads as ASN.1.
+
+| Rule        | Accepted / rejected boundary                                                                                                                                                                        |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tags        | Correct class, number and primitive/constructed bit for every known field; shortest identifier; no EOC; high-tag form must use nonzero first base-128 group and encode a number >=31                |
+| Length      | Definite only; shortest form (short below 128); no leading zero length octet, indefinite form or reserved FF length octet                                                                           |
+| Containment | Every child fits its parent; mandatory fields, exact sequence order, no duplicate singleton fields, no unconsumed child/suffix                                                                      |
+| INTEGER     | Nonempty minimal two's-complement; no redundant 00/FF; serial sign/size retained without positivity/20-octet Web PKI policy                                                                         |
+| BOOLEAN     | Exactly one content octet, 00 or FF; explicit extension critical FALSE is rejected because DEFAULT FALSE must be absent                                                                             |
+| BIT STRING  | Primitive; count 0..7; zero unused tail bits; empty payload requires count zero; do not force count zero for keys/signatures at decoding layer                                                      |
+| OID         | Nonempty; each subidentifier terminates; no leading 80 base-128 group; first combined subidentifier decoded conceptually into arcs 0/1/2; no u32/u64 arc restriction                                |
+| NULL        | Primitive with zero content octets                                                                                                                                                                  |
+| SET OF      | RDN members ordered lexicographically by complete DER TLV octets (unsigned); equal encodings allowed; no sorting or rewriting                                                                       |
+| DEFAULT     | Known schema defaults omitted (version v1, critical FALSE); no guessed defaults in open types                                                                                                       |
+| Time        | UTCTime YYMMDDhhmmssZ for 1950..2049; GeneralizedTime YYYYMMDDhhmmssZ for 0001..9999; Gregorian valid date, seconds 00..59, no offset/fraction/omitted seconds; reject year zero and alternate tags |
+| Names       | SEQUENCE OF nonempty SET OF attribute SEQUENCE {OID, exactly one value TLV}; empty overall issuer/subject retained for later policy                                                                 |
+| Extensions  | Optional explicit [3] containing nonempty SEQUENCE OF Extension; duplicate OIDs retained, not collapsed/rejected by this decoder                                                                    |
+| Unique IDs  | Optional primitive implicit [1]/[2] BIT STRING contents in schema order, preserved                                                                                                                  |
+| Algorithms  | SEQUENCE {OID, optional one parameter TLV}; absent/NULL distinct; no OID allowlist or inner/outer algorithm equality check                                                                          |
+
+Open parameter and attribute values receive bounded TLV framing checks. Constructed values are
+walked for canonical child framing; recognizable universal INTEGER, BOOLEAN, BIT STRING, OID,
+NULL and string encodings receive their universal canonical checks. Universal UTF8String must
+encode Unicode scalars without overlong forms; PrintableString uses its ASN.1 alphabet, IA5String
+is ASCII, BMPString is even-length UCS-2 without surrogates, UniversalString contains valid scalar
+values in four-byte big-endian units. Other primitive open values are opaque. Recognized universal tags enforce their primitive/constructed bit even in open values: SEQUENCE
+and SET are constructed; INTEGER, BOOLEAN, BIT STRING, OID, NULL and DER primitive strings are
+primitive. For unknown tags, validate identifier/length and framing
+without inventing a schema, DEFAULT rule, implicit content type or SET-vs-SET-OF order. In
+particular an unknown universal SET open value has no schema to choose ordering rules; its children
+are framed only. This is not a claim to certify canonical encoding of arbitrary open ASN.1 types.
+Extension payloads remain opaque even for familiar extension OIDs: an unknown critical extension
+with payload FF is retained, not parsed as malformed DER.
+
+The time profile excludes fractional GeneralizedTime permitted by DER, following RFC 5280
+certificate time syntax. Canonical GeneralizedTime before 2050 is accepted by this decoder;
+issuance year/tag policy belongs to the validator.
+
+Duplicate extensions, zero/negative/long serials, empty names, reversed validity, algorithm
+mismatch, unknown algorithms and unknown critical extensions all survive decoding if structurally
+valid and within budgets. RFC 5280 validation/algorithm policy must decide their acceptability.
+This preserves evidence instead of silently weakening or preselecting a future validator's rules.
+
+### Finite resources and errors
+
+```silk
+pub struct DecodeLimits {
+  pub inputBytes: usize
+  pub certificateBytes: usize
+  pub totalDerBytes: usize
+  pub certificates: usize
+  pub fieldBytes: usize
+  pub extensions: usize
+  pub depth: usize
+  pub nodes: usize
+}
+// inside impl DecodeLimits
+pub fn defaults() -> DecodeLimits
+pub enum DecodeClass { Malformed, Unsupported, ResourceLimit }
+pub enum DecodeReason {
+  EmptyInput, PemSyntax, Base64, TrailingData, Truncated, Tag, Length,
+  Integer, Boolean, BitString, Oid, SetOrder, DefaultValue, Time, Schema,
+  StringEncoding, Version, PemLabel, InputBytes, CertificateBytes,
+  TotalDerBytes, Certificates, FieldBytes, Extensions, Depth, Nodes, SizeOverflow,
+}
+pub enum DecodeOffsetSpace { Input, Der }
+pub struct DecodeError {
+  pub kind: DecodeClass
+  pub reason: DecodeReason
+  pub certificateIndex: usize
+  pub offsetSpace: DecodeOffsetSpace
+  pub offset: usize
+}
+```
+
+`DecodeLimits` is a Copy value. All limits are inclusive and independent, zero means zero (never
+unlimited). No sentinel, implicit budget growth or unchecked platform conversion exists.
+
+| Limit            |  Default | Accounting                                                                                                                                                                                                         |
+| ---------------- | -------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| inputBytes       | 16777216 | Entire supplied input including PEM decoration/whitespace                                                                                                                                                          |
+| certificateBytes |  1048576 | Complete DER TLV for each certificate                                                                                                                                                                              |
+| totalDerBytes    |  8388608 | Sum of DER lengths across the call, including duplicates                                                                                                                                                           |
+| certificates     |     1024 | Certificates in call, including single-certificate APIs                                                                                                                                                            |
+| fieldBytes       |   262144 | Content length of every primitive field and every open value (including constructed parameters/attribute values); includes BIT STRING unused-count octet; other constructed schema containers use certificateBytes |
+| extensions       |      256 | Per-certificate extension count, duplicates included                                                                                                                                                               |
+| depth            |       32 | Traversed TLVs, Certificate root depth 1; opaque octets/bits do not add depth                                                                                                                                      |
+| nodes            |    65536 | Total visited TLVs per certificate, including open-value descendants; opaque bytes do not add nodes                                                                                                                |
+
+Use subtraction-before-addition bounds checks for offsets and checked arithmetic for allocation,
+base64 sizing, counts and totals. A nonrepresentable decoded length/tag number or accounting total
+returns ResourceLimit.SizeOverflow, never wraps or truncates. Arbitrarily large OID subidentifiers
+are compared/retained as bytes rather than accumulated in a machine integer. End-of-buffer inside
+an otherwise admissible field is Malformed.Truncated, including missing length/content/base64
+quartet/END. No cursor advances past a checked parent boundary.
+
+Error precedence is deterministic: check entire inputBytes first; then parse left to right,
+checking certificate count before each new block. At each TLV: identifier/length syntax and
+representability, field/certificate size budgets, parent containment, depth/node budget, then
+schema/content. Aggregate DER budget is checked from the known certificate size before decoding
+its contents. Thus a declared oversized but truncated field reports its size limit first.
+A single PEM decoder reports TrailingData on a second BEGIN instead of inspecting its contents.
+Version/PemLabel are the only Unsupported reasons; budget reasons map only to ResourceLimit;
+all remaining reasons map to Malformed. Missing data points at the relevant end offset; bad
+encoding points at the first offending octet, semantic TLV violations at that TLV's tag.
+PEM lexical errors use Input offsets; decoded DER errors use Der offsets relative to that block.
+DER entry-point errors use Input offsets. The zero-based certificateIndex is the attempted block
+index (zero for single calls or document-level errors). Allocation refusal uses only the existing
+`OutOfMemoryError` effect channel, not DecodeError, and can precede defects not yet visited.
+
+Implementation uses a bounded explicit traversal stack and monotonic scanning, no recursive native
+stack growth, backtracking or quadratic duplicate detection. Comparing adjacent RDN encodings is
+linear in their total bytes; extension duplicates need no scan because all are retained. Fixed
+passes plus bounded per-node bookkeeping give O(inputBytes + totalDerBytes + total nodes) work
+and O(totalDerBytes + total nodes + depth) owned/scratch storage. Allocation lengths are checked;
+allocator metadata is not falsely promised to fit a byte-exact portable budget.
+
+### Consumer coordination
+
+- [JUL-166](https://linear.app/juliaortiz/issue/JUL-166): pass original signed TLV, both signature AlgorithmIdentifiers, complete SPKI and signature bits. Its selected ECDSA/RSA policy does not restrict decoding; its verifier checks key/signature encoding, parameters and algorithm agreement.
+- [JUL-168](https://linear.app/juliaortiz/issue/JUL-168): consume preserved names, serial, dates, version and ordered raw extensions; reject duplicate/unknown critical extensions and apply policy in that layer. Decoding success carries no trusted flag.
+- [JUL-169](https://linear.app/juliaortiz/issue/JUL-169): obtain SAN OCTET STRING content by OID from retained extensions. Its bounded GeneralNames decoding/matching contract owns SAN semantics, malformed entries and duplicate SAN policy; this slice exposes no lossy DNS/IP list.
+- [JUL-170](https://linear.app/juliaortiz/issue/JUL-170): provide bytes explicitly, receive an atomic owned bundle, and choose acquisition, caching, deduplication and trust metadata separately. No input is silently skipped.
+
+These boundaries are usable before consumer implementations exist. The design is portable across
+native and LLVM-to-Wasm with an explicit allocator; no retired evaluator/direct-Wasm support is
+claimed. See [fixtures.md](fixtures.md) and [implementation.md](implementation.md).
+
+## Risks / Trade-offs
+
+- Strict PEM rejects decorated root files → explicit provider policy and named deviations, no salvage fallback.
+- Owned copies increase storage → finite aggregate budgets, exact reservation where available, simple immutable lifetime contract.
+- Structural success can be mistaken for Web PKI validity → distinct decoder errors and consumer responsibilities; never expose a validation flag.
+- Open ASN.1 types lack schemas → preserve encodings and limit checks honestly; algorithm/extension consumers enforce their own schemas.
+
+## Migration Plan
+
+No current certificate API exists to migrate. Publish this design and follow-up; implement ordinary
+source actors in that follow-up, regenerate manifest/docs, and run the required verification before
+claiming availability. Rollback of this design removes planning artifacts only.

--- a/openspec/changes/specify-bounded-certificate-decoding/fixtures.json
+++ b/openspec/changes/specify-bounded-certificate-decoding/fixtures.json
@@ -1,0 +1,1098 @@
+{
+  "formatVersion": 1,
+  "status": "Design fixtures; no decoder implementation or executable tests delivered",
+  "provenance": {
+    "source": "https://www.rfc-editor.org/rfc/rfc7468.txt",
+    "location": "Section 5.1 Figure 1",
+    "rfcPublished": "2015-04",
+    "retrieved": "2026-09-10",
+    "normalization": "Exact CERTIFICATE block; LF lines; one terminal LF. DER is standard base64 decoding of its body.",
+    "license": "RFC 7468 copyright (c) 2015 IETF Trust and identified authors; BCP 78 / IETF Trust Legal Provisions. Preserve the applicable Simplified BSD notice if treated as extracted Code Components.",
+    "licenseUrl": "https://trustee.ietf.org/trust-legal-provisions.html"
+  },
+  "recipeSemantics": "Select baseline; replace half-open [start,end) with decoded base64; offsets refer to original baseline, apply from highest start downward. Omitted limits use DecodeLimits.defaults(). SHA-256 and byteLength describe the complete reconstructed input.",
+  "baselines": {
+    "der": {
+      "base64": "MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4XuQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1UdDwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqGSM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEAl4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=",
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "byteLength": 560
+    },
+    "pem": {
+      "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+      "sha256": "5a835eeab533da03447de6c6e1fa6cf362f99894acbdd76df05b2ef5f3c5f803",
+      "byteLength": 814
+    }
+  },
+  "baselineAccounting": {
+    "nodes": 73,
+    "depth": 6,
+    "fieldBytes": 72,
+    "extensions": 3
+  },
+  "fixtures": [
+    {
+      "id": "rfc7468-figure1",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": [
+          "Version V3; serial content 00 is retained",
+          "TBS DER is bytes [4,474)",
+          "Extensions in order: 2.5.29.19 critical; 2.5.29.15 critical; 2.5.29.14 noncritical",
+          "All original DER bytes are retained; signature validity is not assessed"
+        ]
+      }
+    },
+    {
+      "id": "negative-serial",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 15,
+          "end": 16,
+          "base64": "/w=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "d064475dbebfe905a7c4463004be957c8dcae025d64cc3e5efc9c029631f8f95",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["serial content ff retained"]
+      }
+    },
+    {
+      "id": "explicit-default-version",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 12,
+          "end": 13,
+          "base64": "AA=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "ebfa710cf4085cd84c82c36115bed768e79dbadf70a8b0fc020865e7760505f9",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "DefaultValue"
+      }
+    },
+    {
+      "id": "v2-extensions-forbidden",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 12,
+          "end": 13,
+          "base64": "AQ=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "caeca7c162586ef71dd77ee5bfd6ab44088f46782a840880468cbc66ba62d1d0",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Schema"
+      }
+    },
+    {
+      "id": "unsupported-version",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 12,
+          "end": 13,
+          "base64": "Aw=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "61a1684a2f69744a85c191283fee038516706730437ebe4ff68971d00d212156",
+      "limits": {},
+      "expected": {
+        "kind": "Unsupported",
+        "reason": "Version"
+      }
+    },
+    {
+      "id": "negative-version",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 12,
+          "end": 13,
+          "base64": "/w=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "6169a32d7f790a2b258164ba4115e725816763c1616b2ee71ccc8794a54b7241",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Schema"
+      }
+    },
+    {
+      "id": "algorithm-mismatch",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 485,
+          "end": 486,
+          "base64": "Aw=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "ec5260cead9725e8db04685719c0d0cd38c5309b85fee7b4223855af095954cd",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["inner algorithm 1.2.840.10045.4.3.2; outer algorithm 1.2.840.10045.4.3.3"]
+      }
+    },
+    {
+      "id": "unknown-critical-extension",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 415,
+          "end": 416,
+          "base64": "fw=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "21e9370f1d2d4eb2f89e953f7657ddd63247d36874b6391e1d6eb51ffc4e92f9",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["Retain critical 2.5.29.127 with original 30030101ff payload"]
+      }
+    },
+    {
+      "id": "duplicate-extension",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 432,
+          "end": 433,
+          "base64": "Ew=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "96a12a860c7587a822ceb66f5960589d5f88c7dbcba8564fd83df763da442e33",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": [
+          "Retain both critical 2.5.29.19 entries in order, with distinct raw values; retain third extension"
+        ]
+      }
+    },
+    {
+      "id": "noncanonical-boolean",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 418,
+          "end": 419,
+          "base64": "AQ=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "05b88d807d2a42efd91fd2b6a320ef379af102ad688f3a32b9299a0a25062ad0",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Boolean"
+      }
+    },
+    {
+      "id": "explicit-false-default",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 418,
+          "end": 419,
+          "base64": "AA=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "3a33e7d3e121f8201f6ad23a676325693b51a78814c554fd0df386427a71ed39",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "DefaultValue"
+      }
+    },
+    {
+      "id": "opaque-extension-payload",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 421,
+          "end": 422,
+          "base64": "/w=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "a9dcb76211716003b24c6fbd25eaea5dbf4da8eefb3adf8ba71bb47acdff32b5",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["Retain ff030101ff extnValue; do not parse as ASN.1"]
+      }
+    },
+    {
+      "id": "unused-bits-over-seven",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 488,
+          "end": 489,
+          "base64": "CA=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "cffe8c898850b4e912afc80c9a817cb9ea9364fe8d0cea301e766024a56287a1",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "BitString"
+      }
+    },
+    {
+      "id": "unused-bits-one",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 488,
+          "end": 489,
+          "base64": "AQ=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "5bfb48cf3924e44c2b64e3d77e49b2631f15e0a7f990c14cfb97f9e5fb39036a",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["signature unusedBits=1; bytes remain [489,560), final octet9a"]
+      }
+    },
+    {
+      "id": "nonzero-unused-tail",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 488,
+          "end": 560,
+          "base64": "ATBFAiAxrsA9Sj8hvoUX/PDHsjEHKjhWQ9E21ZXhflLABkOHpwIhAJeMDrg8CkGvrqXPBn7VxNgv/+JigDQQuiLdNYFGkyKb"
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "9f0f355fd21226658ca7470524662e8383d5872b6f98286bd3e28922883734b5",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "BitString"
+      }
+    },
+    {
+      "id": "invalid-month",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 161,
+          "end": 163,
+          "base64": "MTM="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "0e5f3bb11bfce817be4dc9d8921c1c95d222b877453b049bf2f703deea027f65",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Time"
+      }
+    },
+    {
+      "id": "invalid-calendar-day",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 163,
+          "end": 165,
+          "base64": "MzI="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "abbfbf79443768361b6b2f8594717ae9574d1476cf29e8129bed111c2377f320",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Time"
+      }
+    },
+    {
+      "id": "indefinite-length",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 1,
+          "end": 2,
+          "base64": "gA=="
+        }
+      ],
+      "byteLength": 560,
+      "sha256": "19c49b1f04414c6c6d324e0dff30224067362e8945f3bb6d4182e7d29a9ab633",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Length"
+      }
+    },
+    {
+      "id": "nonminimal-long-length",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 1,
+          "end": 2,
+          "base64": "gwA="
+        }
+      ],
+      "byteLength": 561,
+      "sha256": "e7cf2ab56c57394f8b51000090b012b66197e686dcc89f40b32164b68c5acb28",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Length"
+      }
+    },
+    {
+      "id": "truncated-content",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 559,
+          "end": 560,
+          "base64": ""
+        }
+      ],
+      "byteLength": 559,
+      "sha256": "795d8a8b12c3d0345a41a940a16b79edee7f86f8cdc2cab1f57b5281fc0a16ea",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Truncated"
+      }
+    },
+    {
+      "id": "trailing-byte",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 560,
+          "end": 560,
+          "base64": "AA=="
+        }
+      ],
+      "byteLength": 561,
+      "sha256": "c5bb3cf09728d40a46fa8a3833f71715583a297cd50bcfae8438464860c9b8c0",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "TrailingData"
+      }
+    },
+    {
+      "id": "empty-der",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 0,
+          "end": 560,
+          "base64": ""
+        }
+      ],
+      "byteLength": 0,
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "EmptyInput"
+      }
+    },
+    {
+      "id": "valid-v1-absent-version",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 2,
+          "end": 474,
+          "base64": "AeIwggGIAgEAMAoGCCqGSM49BAMCMH0xCzAJBgNVBAYTAkJFMQ8wDQYDVQQKEwZHbnVUTFMxJTAjBgNVBAsTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkxDzANBgNVBAgTBkxldXZlbjElMCMGA1UEAxMcR251VExTIGNlcnRpZmljYXRlIGF1dGhvcml0eTAeFw0xMTA1MjMyMDM4MjFaFw0xMjEyMjIwNzQxNTFaMH0xCzAJBgNVBAYTAkJFMQ8wDQYDVQQKEwZHbnVUTFMxJTAjBgNVBAsTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkxDzANBgNVBAgTBkxldXZlbjElMCMGA1UEAxMcR251VExTIGNlcnRpZmljYXRlIGF1dGhvcml0eTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFLYjSOK42fXhjaxIAsJfcjJuqIglS/FSmP6g1/OeC+P82LK/bf3gFadbhe5DhFMSLLArztZFxYwaAkHmRf+3ac="
+        }
+      ],
+      "byteLength": 486,
+      "sha256": "8f2925e9354423402d02a55ab03575bde97d6fe0609f47d87318656e27ab0013",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["V1; no unique IDs or extensions"]
+      }
+    },
+    {
+      "id": "valid-v2",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 2,
+          "end": 474,
+          "base64": "AecwggGNoAMCAQECAQAwCgYIKoZIzj0EAwIwfTELMAkGA1UEBhMCQkUxDzANBgNVBAoTBkdudVRMUzElMCMGA1UECxMcR251VExTIGNlcnRpZmljYXRlIGF1dGhvcml0eTEPMA0GA1UECBMGTGV1dmVuMSUwIwYDVQQDExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MB4XDTExMDUyMzIwMzgyMVoXDTEyMTIyMjA3NDE1MVowfTELMAkGA1UEBhMCQkUxDzANBgNVBAoTBkdudVRMUzElMCMGA1UECxMcR251VExTIGNlcnRpZmljYXRlIGF1dGhvcml0eTEPMA0GA1UECBMGTGV1dmVuMSUwIwYDVQQDExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUtiNI4rjZ9eGNrEgCwl9yMm6oiCVL8VKY/qDX854L4/zYsr9t/eAVp1uF7kOEUxIssCvO1kXFjBoCQeZF/7dpw=="
+        }
+      ],
+      "byteLength": 491,
+      "sha256": "6f025b707d51cf30df22063e1464e51c59b69257d6f8166bcd00b1c3a50ec097",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["V2; extensions absent"]
+      }
+    },
+    {
+      "id": "limit-inputBytes-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "inputBytes": 560
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-inputBytes-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "inputBytes": 559
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "InputBytes"
+      }
+    },
+    {
+      "id": "limit-certificateBytes-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "certificateBytes": 560
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-certificateBytes-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "certificateBytes": 559
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "CertificateBytes"
+      }
+    },
+    {
+      "id": "limit-totalDerBytes-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "totalDerBytes": 560
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-totalDerBytes-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "totalDerBytes": 559
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "TotalDerBytes"
+      }
+    },
+    {
+      "id": "limit-certificates-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "certificates": 1
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-certificates-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "certificates": 0
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "Certificates"
+      }
+    },
+    {
+      "id": "limit-extensions-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "extensions": 3
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-extensions-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "extensions": 2
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "Extensions"
+      }
+    },
+    {
+      "id": "limit-depth-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "depth": 6
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-depth-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "depth": 5
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "Depth"
+      }
+    },
+    {
+      "id": "limit-nodes-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "nodes": 73
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-nodes-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "nodes": 72
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "Nodes"
+      }
+    },
+    {
+      "id": "limit-fieldBytes-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "fieldBytes": 72
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "limit-fieldBytes-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [],
+      "byteLength": 560,
+      "sha256": "ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2",
+      "limits": {
+        "fieldBytes": 71
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "FieldBytes"
+      }
+    },
+    {
+      "id": "pem-lf",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [],
+      "byteLength": 814,
+      "sha256": "5a835eeab533da03447de6c6e1fa6cf362f99894acbdd76df05b2ef5f3c5f803",
+      "limits": {},
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-crlf",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 27,
+          "end": 813,
+          "base64": "DQpNSUlDTERDQ0FkS2dBd0lCQWdJQkFEQUtCZ2dxaGtqT1BRUURBakI5TVFzd0NRWURWUVFHRXdKQ1JURVBNQTBHDQpBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeWRHbG1hV05oZEdVZ1lYVjBhRzl5DQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwDQpaU0JoZFhSb2IzSnBkSGt3SGhjTk1URXdOVEl6TWpBek9ESXhXaGNOTVRJeE1qSXlNRGMwTVRVeFdqQjlNUXN3DQpDUVlEVlFRR0V3SkNSVEVQTUEwR0ExVUVDaE1HUjI1MVZFeFRNU1V3SXdZRFZRUUxFeHhIYm5WVVRGTWdZMlZ5DQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1DQpkVlJNVXlCalpYSjBhV1pwWTJGMFpTQmhkWFJvYjNKcGRIa3dXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CDQpCd05DQUFSUzJJMGppdU5uMTRZMnNTQUxDWDNJeWJxaUlKVXZ4VXBqK29OZnpuZ3ZqL05peXYyMzk0QlduVzRYDQp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkDQpEd0VCL3dRRkF3TUhCZ0F3SFFZRFZSME9CQllFRlBDMGdmNllFcisxS0xsa1FBUEx6QjltVGlnRE1Bb0dDQ3FHDQpTTTQ5QkFNQ0EwZ0FNRVVDSURHdXdEMUtQeUcraFJmODhNZXlNUWNxT0ZaRDBUYlZsZUYrVXNBR1E0ZW5BaUVBDQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0="
+        }
+      ],
+      "byteLength": 828,
+      "sha256": "41389c7574e2ce81c21e8daca93b76e831bcf4899ac0e17b71576d52cb937118",
+      "limits": {},
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-cr",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 27,
+          "end": 814,
+          "base64": "DU1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcNQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQ1hWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwDVpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cNQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQ1kR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1DWRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUINQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WA11UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkDUR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcNU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQ1sNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQ0tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQ=="
+        }
+      ],
+      "byteLength": 814,
+      "sha256": "8d1293ff7d47dd47000582882026f0a571459c150e53430d0334641936db232e",
+      "limits": {},
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-no-final-newline",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 813,
+          "end": 814,
+          "base64": ""
+        }
+      ],
+      "byteLength": 813,
+      "sha256": "9b9bd56aa20d42aef8176029216909e0316f38069244da9283d4bbd2207717dc",
+      "limits": {},
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-horizontal-whitespace",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 0,
+          "end": 814,
+          "base64": "IAktLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS0gCQpNSUlDTERDQ0FkS2dBd0lCQWdJQkFEQUtCZ2dxaGtqT1BRUURBakI5TVFzd0NRWURWUVFHRXdKQ1JURVBNQTBHIAkKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eSAJCmFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1ZFZSTVV5QmpaWEowYVdacFkyRjAgCQpaU0JoZFhSb2IzSnBkSGt3SGhjTk1URXdOVEl6TWpBek9ESXhXaGNOTVRJeE1qSXlNRGMwTVRVeFdqQjlNUXN3IAkKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeSAJCmRHbG1hV05oZEdVZ1lYVjBhRzl5YVhSNU1ROHdEUVlEVlFRSUV3Wk1aWFYyWlc0eEpUQWpCZ05WQkFNVEhFZHUgCQpkVlJNVXlCalpYSjBhV1pwWTJGMFpTQmhkWFJvYjNKcGRIa3dXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CIAkKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WCAJCnVRNFJURWl5d0s4N1dSY1dNR2dKQjVrWC90Mm5vME13UVRBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUE4R0ExVWQgCQpEd0VCL3dRRkF3TUhCZ0F3SFFZRFZSME9CQllFRlBDMGdmNllFcisxS0xsa1FBUEx6QjltVGlnRE1Bb0dDQ3FHIAkKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQSAJCmw0d091RHdLUWErdXBjOEdmdFhFMkMvLzRtS0FOQkM2SXQwMWdVYVRJcG89IAkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSAJCgk="
+        }
+      ],
+      "byteLength": 845,
+      "sha256": "2f4843dbdb31118af56e99c5e524688fcedaa8d69a5e646cb8da04bdfaf6bae7",
+      "limits": {},
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-two-block-single",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "8f80eb7d779129dc0ded5d90c54826787bdb84d3573525d49f921c5fd0d12998",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "TrailingData"
+      }
+    },
+    {
+      "id": "pem-two-block-bundle",
+      "api": "CertificateBundle.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "8f80eb7d779129dc0ded5d90c54826787bdb84d3573525d49f921c5fd0d12998",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["Two owned certificates in input order; duplicates retained"]
+      }
+    },
+    {
+      "id": "pem-bundle-count-limit",
+      "api": "CertificateBundle.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "8f80eb7d779129dc0ded5d90c54826787bdb84d3573525d49f921c5fd0d12998",
+      "limits": {
+        "certificates": 1
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "Certificates"
+      }
+    },
+    {
+      "id": "pem-bundle-total-exact",
+      "api": "CertificateBundle.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "8f80eb7d779129dc0ded5d90c54826787bdb84d3573525d49f921c5fd0d12998",
+      "limits": {
+        "totalDerBytes": 1120
+      },
+      "expected": {
+        "kind": "Success"
+      }
+    },
+    {
+      "id": "pem-bundle-total-one-below",
+      "api": "CertificateBundle.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "8f80eb7d779129dc0ded5d90c54826787bdb84d3573525d49f921c5fd0d12998",
+      "limits": {
+        "totalDerBytes": 1119
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "TotalDerBytes"
+      }
+    },
+    {
+      "id": "pem-bundle-invalid-second",
+      "api": "CertificateBundle.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 814,
+          "end": 814,
+          "base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+        }
+      ],
+      "byteLength": 1628,
+      "sha256": "ead73b03ba5d732d22e41eddbd5f006491073768c7dcfce92b0d5af2484c197d",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Base64",
+        "observations": ["certificateIndex=1; no prefix result escapes"]
+      }
+    },
+    {
+      "id": "pem-unsupported-label",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 11,
+          "end": 808,
+          "base64": "UFVCTElDIEtFWS0tLS0tCk1JSUNMRENDQWRLZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQjlNUXN3Q1FZRFZRUUdFd0pDUlRFUE1BMEcKQTFVRUNoTUdSMjUxVkV4VE1TVXdJd1lEVlFRTEV4eEhiblZVVEZNZ1kyVnlkR2xtYVdOaGRHVWdZWFYwYUc5eQphWFI1TVE4d0RRWURWUVFJRXdaTVpYVjJaVzR4SlRBakJnTlZCQU1USEVkdWRWUk1VeUJqWlhKMGFXWnBZMkYwClpTQmhkWFJvYjNKcGRIa3dIaGNOTVRFd05USXpNakF6T0RJeFdoY05NVEl4TWpJeU1EYzBNVFV4V2pCOU1Rc3cKQ1FZRFZRUUdFd0pDUlRFUE1BMEdBMVVFQ2hNR1IyNTFWRXhUTVNVd0l3WURWUVFMRXh4SGJuVlVURk1nWTJWeQpkR2xtYVdOaGRHVWdZWFYwYUc5eWFYUjVNUTh3RFFZRFZRUUlFd1pNWlhWMlpXNHhKVEFqQmdOVkJBTVRIRWR1CmRWUk1VeUJqWlhKMGFXWnBZMkYwWlNCaGRYUm9iM0pwZEhrd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUIKQndOQ0FBUlMySTBqaXVObjE0WTJzU0FMQ1gzSXlicWlJSlV2eFVwaitvTmZ6bmd2ai9OaXl2MjM5NEJXblc0WAp1UTRSVEVpeXdLODdXUmNXTUdnSkI1a1gvdDJubzBNd1FUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BOEdBMVVkCkR3RUIvd1FGQXdNSEJnQXdIUVlEVlIwT0JCWUVGUEMwZ2Y2WUVyKzFLTGxrUUFQTHpCOW1UaWdETUFvR0NDcUcKU000OUJBTUNBMGdBTUVVQ0lER3V3RDFLUHlHK2hSZjg4TWV5TVFjcU9GWkQwVGJWbGVGK1VzQUdRNGVuQWlFQQpsNHdPdUR3S1FhK3VwYzhHZnRYRTJDLy80bUtBTkJDNkl0MDFnVWFUSXBvPQotLS0tLUVORCBQVUJMSUMgS0VZ"
+        }
+      ],
+      "byteLength": 812,
+      "sha256": "ffad83cf236e27b509b2434130d8e26c63603b098717d2135a66bc37b4d493c5",
+      "limits": {},
+      "expected": {
+        "kind": "Unsupported",
+        "reason": "PemLabel"
+      }
+    },
+    {
+      "id": "pem-mismatched-label",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 797,
+          "end": 808,
+          "base64": "UFVCTElDIEtFWQ=="
+        }
+      ],
+      "byteLength": 813,
+      "sha256": "2af8bd6ccec578e3e2d3bd9304ffeec305fd985383c54a4dd29cdc2305a221e4",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "PemSyntax"
+      }
+    },
+    {
+      "id": "pem-preamble",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 0,
+          "end": 0,
+          "base64": "Q2VydGlmaWNhdGU6Cg=="
+        }
+      ],
+      "byteLength": 827,
+      "sha256": "61e432c0758cd726386ed736a952df04f7ae30203c570b27f0f4df06895999e8",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "PemSyntax"
+      }
+    },
+    {
+      "id": "pem-vt",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 29,
+          "end": 29,
+          "base64": "Cw=="
+        }
+      ],
+      "byteLength": 815,
+      "sha256": "ff136c0bcf89079387073af614fe4a8fc700b5ebb3c5ffb059b2011ca28f39d7",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "PemSyntax"
+      }
+    },
+    {
+      "id": "pem-nonzero-pad-bits",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 785,
+          "end": 786,
+          "base64": "cA=="
+        }
+      ],
+      "byteLength": 814,
+      "sha256": "b9bb5367eeaf12ad86afcf26efbd089ba6bc5f50cf98605b2142a3a167c1fcca",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Base64"
+      }
+    },
+    {
+      "id": "pem-missing-padding",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 786,
+          "end": 787,
+          "base64": ""
+        }
+      ],
+      "byteLength": 813,
+      "sha256": "fae06548481e71a360dc673734a3e5bc82459935f1d75a4b911016ca3bca8086",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Truncated"
+      }
+    },
+    {
+      "id": "pem-excess-padding",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 787,
+          "end": 787,
+          "base64": "PQ=="
+        }
+      ],
+      "byteLength": 815,
+      "sha256": "a1a1bddbf0afacffb16e0a1484ebff39e5ae0024d159f00df57e270e567c2d6e",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Base64"
+      }
+    },
+    {
+      "id": "pem-missing-end",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 788,
+          "end": 814,
+          "base64": ""
+        }
+      ],
+      "byteLength": 788,
+      "sha256": "9c0336a32e345f28399ac8c5df3a4b8a82cf0a1bc41711d7c1b7eec6b3a9a07c",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Truncated"
+      }
+    },
+    {
+      "id": "pem-begin-without-newline",
+      "api": "Certificate.decodePem",
+      "baseline": "pem",
+      "patches": [
+        {
+          "start": 27,
+          "end": 28,
+          "base64": ""
+        }
+      ],
+      "byteLength": 813,
+      "sha256": "fafe5b7f961d34a7c133690c601add3a2cd607b19801d9219c51b9311f12686b",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "PemSyntax"
+      }
+    }
+  ]
+}

--- a/openspec/changes/specify-bounded-certificate-decoding/fixtures.json
+++ b/openspec/changes/specify-bounded-certificate-decoding/fixtures.json
@@ -1093,6 +1093,107 @@
         "kind": "Malformed",
         "reason": "PemSyntax"
       }
+    },
+    {
+      "id": "primitive-sequence-parameter",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 3,
+          "end": 486,
+          "base64": "LjCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4XuQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1UdDwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAwGCCqGSM49BAMCEAA="
+        }
+      ],
+      "byteLength": 562,
+      "sha256": "8bd439288fda11f843ebcb538e8f42b59199c7ae3bf0c3e853a3dd7956889244",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Tag"
+      }
+    },
+    {
+      "id": "primitive-set-parameter",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 3,
+          "end": 486,
+          "base64": "LjCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4XuQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1UdDwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAwGCCqGSM49BAMCEQA="
+        }
+      ],
+      "byteLength": 562,
+      "sha256": "103fc586a5345be8cb9ef925bf02acee631f0bfdaa2e0ac418f87cbbf414effd",
+      "limits": {},
+      "expected": {
+        "kind": "Malformed",
+        "reason": "Tag"
+      }
+    },
+    {
+      "id": "constructed-open-field-exact",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 3,
+          "end": 486,
+          "base64": "fjCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4XuQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1UdDwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMFwGCCqGSM49BAMCMFAETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+        }
+      ],
+      "byteLength": 642,
+      "sha256": "fc7c32a774a75cfb369de34a7d003fe7b5f9225dc7b385304cf9136edeb5adb6",
+      "limits": {
+        "fieldBytes": 80
+      },
+      "expected": {
+        "kind": "Success",
+        "observations": [
+          "Outer signatureAlgorithm.parametersDer is SEQUENCE with content length80; its OCTET STRING child content length78 is opaque"
+        ]
+      }
+    },
+    {
+      "id": "constructed-open-field-one-below",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 3,
+          "end": 486,
+          "base64": "fjCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4XuQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1UdDwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMFwGCCqGSM49BAMCMFAETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+        }
+      ],
+      "byteLength": 642,
+      "sha256": "fc7c32a774a75cfb369de34a7d003fe7b5f9225dc7b385304cf9136edeb5adb6",
+      "limits": {
+        "fieldBytes": 79
+      },
+      "expected": {
+        "kind": "ResourceLimit",
+        "reason": "FieldBytes"
+      }
+    },
+    {
+      "id": "generalized-time-before-2050",
+      "api": "Certificate.decodeDer",
+      "baseline": "der",
+      "patches": [
+        {
+          "start": 3,
+          "end": 159,
+          "base64": "LjCCAdSgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwIBgPMjA="
+        }
+      ],
+      "byteLength": 562,
+      "sha256": "622509660704e9503edf3784e810b44e50c99c6bbe0a6189e124bd9c603a5a20",
+      "limits": {},
+      "expected": {
+        "kind": "Success",
+        "observations": ["notBefore is 2011-05-23 20:38:21; GeneralizedTime before2050 is accepted"]
+      }
     }
   ]
 }

--- a/openspec/changes/specify-bounded-certificate-decoding/fixtures.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/fixtures.md
@@ -1,0 +1,75 @@
+## Status and authority
+
+[fixtures.json](fixtures.json) is the authoritative, byte-pinned fixture manifest for the
+implementation follow-up. It contains 60 inputs with exact expected outcome class/reason and
+retention observations where relevant. These are proposed decoder expectations, not results from
+a shipped parser. No executable parser tests or runtime benchmark are added by this design.
+
+The baseline is [RFC 7468 §5.1, Figure 1](https://www.rfc-editor.org/rfc/rfc7468.html#section-5.1),
+retrieved from the RFC Editor's plain-text publication on 2026-09-10. The manifest embeds the
+complete DER and PEM bytes as base64, so reproduction requires no live network dependency.
+PEM uses the printed body, LF separators and exactly one final LF. DER is its base64-decoded body.
+
+| Baseline | Bytes | SHA-256                                                            |
+| -------- | ----: | ------------------------------------------------------------------ |
+| DER      |   560 | `ff2d1b4ee9cd625a52ca49afa1974ea33f09ed35db8e554df0ec7d4c73a772f2` |
+| PEM      |   814 | `5a835eeab533da03447de6c6e1fa6cf362f99894acbdd76df05b2ef5f3c5f803` |
+
+The source identifies the example as a functional certificate. Decoder success does not establish
+Web PKI validity: this fixture contains serial zero and historical validity dates. Mutated cases
+deliberately do not regenerate signatures. Signature verification is outside this contract.
+
+RFC 7468 is copyright © 2015 IETF Trust and the persons identified as its authors, under BCP 78 and
+the [IETF Trust Legal Provisions](https://trustee.ietf.org/trust-legal-provisions.html). Preserve
+that attribution and the applicable Simplified BSD notice when redistributing extracted Code
+Components. The baseline is an attributed standards example, not generated Silk test material;
+mutation recipes are local design material.
+
+## Reproduction and expected outcomes
+
+For each manifest entry, decode its named baseline. A patch replaces the half-open byte interval
+`[start,end)` with the decoded `base64` payload. Apply patches from highest offset downward;
+all offsets refer to the unmodified baseline. Empty patches mean identical input. Verify the
+complete resulting input against `byteLength` and `sha256`, then call the named API with the
+listed limit overrides and all other limits at their specified defaults.
+
+`Success` means structural success and full owned retention only. `Malformed`, `Unsupported` and
+`ResourceLimit` map directly to `DecodeClass`; their reason strings map to `DecodeReason`.
+Expected observations are additional requirements, not replacements for exact byte preservation.
+All rejected bundles must expose no certificate prefix. The two-block malformed-base64 case
+specifically fails at certificate index 1 after a structurally valid first certificate.
+
+| Group                    | Manifest coverage                                                                                                                        |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Valid schema             | Original v3; absent-version v1; v2 without extensions                                                                                    |
+| Retained policy evidence | Negative/zero serial, unequal signature algorithms, duplicate extensions, unknown critical extension, opaque malformed extension payload |
+| DER malformed            | Explicit defaults, v2 extensions, negative version, BOOLEAN, time/calendar, indefinite/nonminimal length, truncation and trailing data   |
+| Unsupported              | Canonical version above v3 and a well-formed PUBLIC KEY PEM label                                                                        |
+| BIT STRING               | Invalid unused-bit count, valid nonzero count, nonzero discarded tail bit                                                                |
+| PEM                      | LF/CRLF/CR, horizontal whitespace, EOF after END, forbidden preamble/VT, marker errors and base64 padding errors                         |
+| Atomic bundle            | Duplicate certificates retained, single-input trailing block, invalid second block, count and aggregate limits                           |
+| Inclusive budgets        | Every DecodeLimits field at the exact baseline requirement and one below                                                                 |
+
+The baseline accounts for 73 visited TLVs at maximum depth 6, three extensions and maximum
+primitive content length 72. Certificate and aggregate DER size are 560. The outer Certificate is
+depth 1; opaque key/signature bits and extension OCTET STRING payloads are not recursively visited.
+The 72-octet signature BIT STRING content includes its initial unused-bit count octet.
+
+Important retained baseline spans, all half-open: TBSCertificate `[4,474)`, issuer `[28,155)`,
+validity `[155,187)`, subject `[187,314)`, SPKI `[314,405)`, inner signature AlgorithmIdentifier
+`[16,28)`, outer signature AlgorithmIdentifier `[474,486)`, and signature payload `[489,560)`.
+The public-key payload is `[340,405)`; its count octet is at 339, while the signature count is at 488. These spans include TLVs unless explicitly described as payloads.
+
+## Follow-up verification requirements
+
+The implementation must reconstruct the manifest cases without network access and assert their
+typed outcomes and retained observations. Supplement them at the cheapest parser tier with schema
+tables from the design, checked-size-overflow paths, arbitrary OID groups, SET ordering and bounded
+open-value traversal. Do not infer complete malformed-input coverage from this finite manifest.
+
+Owned-lifetime and allocation behavior additionally require a replaceable allocator: after success,
+release or overwrite the input and observe unchanged owned results; inject refusal at each
+allocation boundary reached by the valid one- and two-certificate fixtures, expect only the existing
+`OutOfMemoryError` channel, and verify that no partial result or allocation survives. Allocation
+ordinals depend on the implementation and therefore are not falsely pinned as input-byte fixtures.
+Use bounded structural tests; no per-fixture native compilation, network, clock or verifier is needed.

--- a/openspec/changes/specify-bounded-certificate-decoding/fixtures.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/fixtures.md
@@ -1,7 +1,7 @@
 ## Status and authority
 
 [fixtures.json](fixtures.json) is the authoritative, byte-pinned fixture manifest for the
-implementation follow-up. It contains 60 inputs with exact expected outcome class/reason and
+implementation follow-up. It contains 65 inputs with exact expected outcome class/reason and
 retention observations where relevant. These are proposed decoder expectations, not results from
 a shipped parser. No executable parser tests or runtime benchmark are added by this design.
 
@@ -54,6 +54,9 @@ The baseline accounts for 73 visited TLVs at maximum depth 6, three extensions a
 primitive content length 72. Certificate and aggregate DER size are 560. The outer Certificate is
 depth 1; opaque key/signature bits and extension OCTET STRING payloads are not recursively visited.
 The 72-octet signature BIT STRING content includes its initial unused-bit count octet.
+A separate constructed-parameter fixture has an 80-octet SEQUENCE content with a 78-octet OCTET
+STRING child: fieldBytes 80 succeeds, while 79 fails at the constructed open field itself.
+All mutated ancestor lengths are repaired and pinned in the manifest patches.
 
 Important retained baseline spans, all half-open: TBSCertificate `[4,474)`, issuer `[28,155)`,
 validity `[155,187)`, subject `[187,314)`, SPKI `[314,405)`, inner signature AlgorithmIdentifier

--- a/openspec/changes/specify-bounded-certificate-decoding/implementation.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/implementation.md
@@ -1,0 +1,27 @@
+# Implementation follow-up
+
+Status: planned, separately estimated at **8 points**. JUL-167 delivers the contract only.
+The follow-up owns the complete portable decoder: private DER/schema traversal, strict PEM,
+owned Certificate/CertificateBundle, all limits/errors/accessors, manifest fixtures, ordinary
+allocator cleanup and generated documentation. Tasks 2.1–2.6 give the implementation order and
+observable completion evidence. The estimate includes hostile-input handling and ownership
+verification; no completed cryptographic primitives or OS providers are prerequisites.
+
+Use `packages/compiler/stdlib/silk/certificate.silk` and `certificate_bundle.silk` as public
+actor homes; private support stays under stdlib support. Register canonical source modules in
+`packages/compiler/stdlib/manifest.json`, regenerate the generated stdlib and docs, and extend
+existing compiler acceptance infrastructure. No compatibility layer or generic public ASN.1
+surface is needed. Source-callable operations remain ordinary Silk, without compiler recognition.
+
+Acceptance is the normative delta and all design tables. Fixture hashes/recipes must be reused,
+not replaced with a live certificate download. Add only tests with distinct falsification value:
+analysis for API/lifetimes, static evaluation where appropriate for pure computations, shared
+native corpus for runtime parsing/cleanup, and a selected LLVM-to-Wasm case for portability.
+Do not create a fresh process or compiler pipeline for every mutation.
+
+Explicit exclusions: signature/key verification, path construction/validation, extension semantic
+interpretation (including SAN matching), reference identities, root acquisition, transport,
+private-key formats, encoding, and generic ASN.1 tooling. JUL-166/168/169/170 retain these seams.
+
+Implementation intake: [JUL-182](https://linear.app/juliaortiz/issue/JUL-182), **8 points**,
+Triage. This separately estimated intake does not imply Julia has queued implementation.

--- a/openspec/changes/specify-bounded-certificate-decoding/proposal.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+TLS peers and trust bundles supply untrusted certificate bytes. A shared, bounded decoding contract must preserve the material later signature, path and identity consumers need without accidentally making trust decisions during parsing.
+
+## What Changes
+
+- Specify owned `Certificate` and `CertificateBundle` actors with borrowed DER/PEM inputs, atomic results and typed failures.
+- Fix a strict PEM profile, schema-aware DER rules, retained information and finite resource budgets.
+- Pin authoritative fixtures and deterministic mutations with expected results.
+- Decompose parser implementation into a separately estimated follow-up to [JUL-167](https://linear.app/juliaortiz/issue/JUL-167).
+
+This change delivers planning artifacts only. No parser, public module, generated API reference or runtime support ships here.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-certificate-decoding`: Portable owned certificate decoding with bounded work and lossless signed material.
+
+### Modified Capabilities
+
+None. Existing owned-byte/allocation requirements are reused unchanged.
+
+## Impact
+
+Future implementation belongs in ordinary Silk standard-library source, its manifest, generated documentation and existing compiler acceptance infrastructure. No compiler-recognized certificate actor, external crypto provider or public generic ASN.1 API is introduced. Consumers are JUL-166 (algorithm policy), JUL-168 (path validation), JUL-169 (identity) and JUL-170 (trust acquisition).
+
+## Non-goals
+
+Signature verification, certificate-path construction/validation, SAN interpretation and identity matching, root acquisition, network access, PEM encoding, private keys, CRLs and general-purpose ASN.1 tooling.

--- a/openspec/changes/specify-bounded-certificate-decoding/specs/bounded-certificate-decoding/spec.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/specs/bounded-certificate-decoding/spec.md
@@ -1,0 +1,153 @@
+## Purpose
+
+Provide a bounded structural certificate decoder whose independently owned outputs preserve every
+byte and field required by later cryptographic, path, identity and trust-source consumers.
+
+## ADDED Requirements
+
+### Requirement: Explicit input formats return atomic owned results
+
+The standard library SHALL expose the exact proposed Certificate.decodeDer, Certificate.decodePem
+and CertificateBundle.decodePem signatures and owner-borrowed accessors in this change's design.
+Inputs SHALL be borrowed bytes; outputs SHALL own their DER independently with no input lifetime.
+A DER call SHALL consume exactly one certificate with no suffix. A single PEM call SHALL consume
+exactly one block; a bundle SHALL consume one or more blocks and preserve order and duplicates.
+No partial result SHALL escape. Allocation refusal SHALL use OutOfMemoryError with an explicit
+mutable Allocator requirement; ordinary drop SHALL release all prior results and scratch.
+
+#### Scenario: Input owner is released
+
+- **WHEN** valid certificate input is decoded and the call completes successfully
+- **THEN** the input may be released while output accessors continue to expose identical DER
+
+#### Scenario: Later bundle member fails
+
+- **WHEN** a bundle contains a valid certificate followed by a malformed certificate
+- **THEN** the call returns only the failure and releases accumulated certificate storage
+
+#### Scenario: Allocator refuses a later reservation
+
+- **WHEN** allocation fails after earlier bundle members were decoded
+- **THEN** OutOfMemoryError escapes without any prefix result or retained scratch allocation
+
+### Requirement: A strict certificate PEM profile is explicit
+
+PEM decoding SHALL follow the design's Input profile table: exact CERTIFICATE labels, matching
+markers, standard base64 with canonical padding/pad bits, SP/HT/CR/LF whitespace and all three
+newline conventions. It SHALL reject explanatory text, headers, other nonalphabet characters,
+VT/FF, malformed markers and empty documents. Other well-formed labels SHALL be Unsupported.
+It SHALL NOT skip blocks, auto-detect formats, repair input or claim universal RFC 7468 acceptance.
+The documented RFC 7468 deviations SHALL accompany the eventual public API documentation.
+
+#### Scenario: Bare CR and unusual wrapping
+
+- **WHEN** a CERTIFICATE block uses bare CR newlines and arbitrary base64 wrapping with SP/HT
+- **THEN** it decodes identically to its canonical LF representation within input limits
+
+#### Scenario: Nonzero padding bits
+
+- **WHEN** the final quartet has nonzero unused base64 pad bits
+- **THEN** decoding returns Malformed.Base64 even if a permissive decoder would produce the same bytes
+
+#### Scenario: Decorated or mixed bundle
+
+- **WHEN** surrounding text or an unrelated PEM block appears in a bundle
+- **THEN** the entire call fails instead of returning only selected certificates
+
+### Requirement: Schema-aware DER is canonical within its declared boundary
+
+The decoder SHALL enforce the design's DER and selected schema table for tags, lengths, containment,
+INTEGER, BOOLEAN, BIT STRING, OID, NULL, RDN SET OF ordering, known DEFAULT fields, time forms,
+sequence cardinality and certificate-version restrictions. It SHALL admit v1/v2/v3 and return
+Unsupported.Version for a canonical nonnegative version above 2. It SHALL check bounded open-value
+framing without inventing unknown schemas. Extension values, key bits and signature bits SHALL
+remain opaque; the decoder SHALL NOT recursively validate them as known ASN.1 payloads.
+
+#### Scenario: Explicit default or indefinite length
+
+- **WHEN** a certificate encodes explicit default version zero or uses an indefinite DER length
+- **THEN** it fails with the corresponding Malformed.DefaultValue or Malformed.Length outcome
+
+#### Scenario: Unknown critical extension contains arbitrary bytes
+
+- **WHEN** a structurally valid extension has an unknown OID, critical TRUE and payload FF
+- **THEN** decoding succeeds and preserves the OID, critical bit and payload exactly
+
+#### Scenario: Unordered relative distinguished name
+
+- **WHEN** adjacent AttributeTypeAndValue encodings in an RDN SET OF are out of DER octet order
+- **THEN** decoding fails with Malformed.SetOrder instead of sorting them
+
+#### Scenario: Valid nonzero unused bit count
+
+- **WHEN** a signature BIT STRING has unusedBits equal to one and its final low bit is zero
+- **THEN** decoding preserves that count and payload without imposing verifier algorithm rules
+
+### Requirement: Complete certificate information survives decoding
+
+Outputs SHALL preserve complete original Certificate and signed TBSCertificate TLVs, version,
+signed serial content, issuer/subject DER, validity DER and decoded dates, optional unique IDs,
+complete SPKI and subjectPublicKey bits, signatureValue bits and unused-bit metadata, all three
+AlgorithmIdentifiers with raw OIDs and absent/present parameter TLVs, and every extension's raw
+encoding, OID, critical bit and value in source order. Unknown and duplicate extensions SHALL NOT
+be discarded, merged or treated as trusted. Algorithms SHALL NOT be allowlisted by the decoder.
+
+#### Scenario: Duplicate extension OIDs
+
+- **WHEN** two structurally valid extensions use the same OID
+- **THEN** both remain accessible in order with their original encodings and values
+
+#### Scenario: Algorithms disagree
+
+- **WHEN** inner and outer signature AlgorithmIdentifiers differ but each is structurally valid
+- **THEN** both original encodings are returned so a verifier can reject the mismatch
+
+#### Scenario: Policy-invalid serial or time interval
+
+- **WHEN** a canonical signed serial is zero or negative, or valid time encodings form a reversed interval
+- **THEN** decoding preserves them without claiming certificate validity
+
+### Requirement: Finite independent budgets and typed failures are deterministic
+
+The decoder SHALL use the exact inclusive DecodeLimits defaults and accounting in the design:
+16 MiB input, 1 MiB per certificate, 8 MiB total DER, 1024 certificates, 256 KiB primitive/open
+field content, 256 extensions per certificate, depth 32 and 65536 visited TLVs per certificate.
+Zero SHALL mean zero. Checked arithmetic SHALL prevent overflow before indexing or allocation.
+It SHALL return the declared Malformed, Unsupported or ResourceLimit reason, block index and offset
+space under the specified left-to-right precedence; allocation remains a separate effect error.
+The implementation SHALL use bounded traversal and linear scanning without recursive stack growth,
+backtracking or duplicate-search amplification.
+
+#### Scenario: Exact certificate byte boundary
+
+- **WHEN** the pinned 560-byte fixture is decoded with certificateBytes 560 and other adequate limits
+- **THEN** it succeeds, while certificateBytes 559 returns ResourceLimit.CertificateBytes
+
+#### Scenario: Oversized truncated field
+
+- **WHEN** an admissibly encoded declared length exceeds its field budget and available input
+- **THEN** the field resource limit is reported before truncation, without reading outside input
+
+#### Scenario: Limit zero
+
+- **WHEN** a nonempty certificate is supplied with certificates zero
+- **THEN** decoding returns ResourceLimit.Certificates before constructing a certificate
+
+### Requirement: Conformance evidence and delivery status are honest
+
+The follow-up SHALL exercise the pinned fixture manifest in this change, including provenance,
+hashes, exact mutation recipes and expected structural/unsupported/limit results. It SHALL use
+cheap structural/ownership checks and shared native acceptance cases; selected LLVM-to-Wasm
+coverage SHALL establish intended portable behavior without redundant per-feature executables.
+This design SHALL NOT be described as shipped parser support. Verification, path construction,
+identity matching, trust acquisition and generic public ASN.1 tooling SHALL remain separate.
+
+#### Scenario: Design-only delivery
+
+- **WHEN** JUL-167's artifacts are published
+- **THEN** the status states that the parser is planned and a separately estimated issue owns implementation
+
+#### Scenario: Validator consumes decoded data
+
+- **WHEN** a consumer receives a decoded certificate with an unknown critical extension
+- **THEN** decoding success supplies raw evidence and makes no assertion that path or identity checks passed

--- a/openspec/changes/specify-bounded-certificate-decoding/tasks.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] 1.1 Revalidate the historical baseline and absence of a competing decoder owner; record bounded graph/source/manifest/reference/OpenSpec evidence in the design and Linear admission.
 - [x] 1.2 Specify API ownership, complete field retention, encoding tables, finite budgets and failure precedence; verify every JUL-167 acceptance topic is represented in design and delta scenarios.
-- [ ] 1.3 Pin authoritative fixture bytes, mutation hashes and expected outcomes; verify manifest hashes independently and complete design review.
+- [x] 1.3 Pin authoritative fixture bytes, mutation hashes and expected outcomes; verify manifest hashes independently and complete design review.
 - [ ] 1.4 Create a separately estimated implementation intake, strictly validate OpenSpec, run repository checks and obtain independent test-economics approval; publish a confirmed draft PR with truthful verification evidence.
 
 ## 2. Decoder implementation follow-up — not delivered by JUL-167

--- a/openspec/changes/specify-bounded-certificate-decoding/tasks.md
+++ b/openspec/changes/specify-bounded-certificate-decoding/tasks.md
@@ -1,0 +1,15 @@
+## 1. JUL-167 design delivery
+
+- [x] 1.1 Revalidate the historical baseline and absence of a competing decoder owner; record bounded graph/source/manifest/reference/OpenSpec evidence in the design and Linear admission.
+- [x] 1.2 Specify API ownership, complete field retention, encoding tables, finite budgets and failure precedence; verify every JUL-167 acceptance topic is represented in design and delta scenarios.
+- [ ] 1.3 Pin authoritative fixture bytes, mutation hashes and expected outcomes; verify manifest hashes independently and complete design review.
+- [ ] 1.4 Create a separately estimated implementation intake, strictly validate OpenSpec, run repository checks and obtain independent test-economics approval; publish a confirmed draft PR with truthful verification evidence.
+
+## 2. Decoder implementation follow-up — not delivered by JUL-167
+
+- [ ] 2.1 Implement private bounded DER cursor and schema traversal in ordinary Silk; verify canonical tag/length/value/default/time/SET rules against manifest cases at the cheapest structural tier.
+- [ ] 2.2 Implement Certificate ownership and all declared views; verify signed TBS/SPKI/signature/algorithm/extension byte identity and input/output lifetime separation with shared analysis snapshots and native corpus evidence.
+- [ ] 2.3 Implement strict PEM and atomic CertificateBundle decoding; verify all input-profile table rows, canonical base64, duplicate retention and later-block rollback with distinct fixtures.
+- [ ] 2.4 Enforce every independent limit and deterministic error coordinate/precedence; verify exact/one-over boundaries and checked overflow/truncation without allocating giant fixtures.
+- [ ] 2.5 Verify allocation refusal and cleanup with a scoped fake allocator and minimal distinguishing native corpus cases; add one intended LLVM-to-Wasm portability leg without redundant feature executables.
+- [ ] 2.6 Register actors, generate API docs and update reference support status only after implementation; run typecheck, format:check, lint, test, check, release:candidate and independent test-economics review before parser handoff.


### PR DESCRIPTION
Defines the decoder contract needed by TLS, validation and trust-source consumers before parser implementation: strict PEM/schema-aware DER, owned certificate and atomic bundle outputs, complete signed/key/signature/extension retention, finite budgets and typed failures.

This is a design-only change for [JUL-167](https://linear.app/juliaortiz/issue/JUL-167). No parser support ships. OpenSpec: `specify-bounded-certificate-decoding`. [JUL-182](https://linear.app/juliaortiz/issue/JUL-182) separately estimates implementation at 8 points in Triage. Future parser tasks remain unchecked.

The proposed decoder accepts a structurally valid unknown critical extension and retains its exact bytes; a later validator decides whether to reject it. It rejects a malformed later PEM block without returning earlier certificates. The manifest pins 65 inputs derived from the attributed RFC 7468 example, exact mutation recipes, SHA-256 hashes and expected valid/malformed/unsupported/resource outcomes.

Verification on `b1b193ecdc3eb05a8ff25a045a4d420f5bdb6a4e`:

- Passed: strict OpenSpec validation, independent reconstruction of all 65 fixture lengths/hashes, diff checks, `pnpm typecheck`, `pnpm format:check`, `pnpm lint`.
- General design review: approve after correcting open-value tag forms, time policy and field-size accounting.
- Dedicated test-economics review: approve exact committed diff; no executable tests changed, incremental default-suite test execution 0 seconds. One-off fixture validation 7.67 ms; strict artifact validation 1.67 s.
- `pnpm test` failed four unchanged LSP tests (AutoImportScale/ProjectWorker timeouts, Inspection StdioTimeout, Server diagnostic assertion). `pnpm check` failed only Server.test.ts at its 120-second timeout (148 LSP tests passed). No production/test/config diff; the new OpenSpec files are not inputs to these tests. Baseline failures were not independently reproduced, so their historical status is unverified.
- Isolated `pnpm --filter @silklang/lsp exec vitest run test/Server.test.ts --maxWorkers=1` passed all 4 tests in 141.39 seconds. Full `pnpm test` retry then failed only `Workspace.test.ts:429` (profile identity/settings changes, 60000 ms timeout; 148/149 LSP tests passed). Local verification remains blocked.
- CI on this exact head: validation, LSP, CLI, compiler documentation, native smoke, compiler shards 2–4, native OS, browser and Vercel passed at last observation; compiler shard 1 remains in progress. Platform-supply job skipped by workflow.

Package contents and exports are unchanged, so `pnpm release:candidate` is not applicable. Risks are the deliberately stricter PEM acceptance profile and callers mistaking structural decoding for trust; both are explicit in the design. No signature/path/identity/root-acquisition implementation is included.

JUL-167 is restored to its prior Backlog tier with Blocked and a precise Gate; its work-admission Review baseline is preserved. Handoff requires passing full local `pnpm test` and `pnpm check` runs. The draft remains reusable; no parser or LSP changes are hidden in this design PR.
