### PR TITLE
docs(workflow): require research during implementation triage

### DIFF
--- a/.codex/silk-manager/LINEAR.md
+++ b/.codex/silk-manager/LINEAR.md
@@ -84,8 +84,12 @@ automatically.
 
 The native Triage inbox became the intake boundary on 2026-09-02. Before selecting from Backlog,
 move any preexisting issue whose `Triage disposition` is missing, `intake`, or
-`needs-more-investigation` into Triage. Preserve existing Todo as Julia's curated queue; its manual
-placement is sufficient for selection even before the durable field is added during a later review.
+`needs-more-investigation` into Triage. Preserve existing Todo as Julia's curated queue. Manual
+placement is sufficient for selection, but not for implementation admission: every implementation
+ticket must have completed triage research and independent skeptical review. If that evidence or
+the durable queue-ready marker is missing, complete triage before claiming or editing
+implementation, preserving Todo membership while it is reviewed. Explicit selection changes
+scheduling, not this research gate.
 
 ## Mutations
 

--- a/.codex/silk-manager/TRIAGE.md
+++ b/.codex/silk-manager/TRIAGE.md
@@ -25,6 +25,20 @@ Each issue receives two independent passes:
 2. **Skeptical review** — a different agent tries to refute the proposed verdict, find an existing
    owner or simpler framing, and challenge the proposed grouping and acceptance.
 
+These passes include the research required to make an implementation ticket actionable. Resolve
+public contracts, ownership and failures, finite bounds, target availability, dependencies, and
+test or interoperability evidence where relevant. Pin primary authorities and informative source
+or fixture revisions for protocol, language, runtime, and ABI work. Record decisions, deliberate
+divergences, investigator evidence, and the independent skeptical verdict on the issue before
+queue-ready admission; transient agent notes alone are insufficient. Scale this research to the
+actual uncertainty rather than requiring external comparisons for mechanical work.
+
+Do not create research, specification, or definition tickets. A split creates concrete
+implementation children in Triage; every child receives its own investigation and skeptical pass
+before admission. Shared findings may be reused with explicit attribution, but a parent's review
+does not automatically admit its children. Existing Todo placement or explicit selection changes
+scheduling, not this research gate. Preserve the manual tier while completing a missing review.
+
 Every selected issue must receive its investigation from a subagent. Every proposed Backlog,
 Duplicate, or Canceled verdict must then receive skeptical review from a different subagent. The
 coordinator adjudicates the two passes against primary evidence but does not substitute for either

--- a/.codex/silk-manager/WORKFLOW.md
+++ b/.codex/silk-manager/WORKFLOW.md
@@ -90,6 +90,23 @@ a justification by itself.
 
 ## Triage intake bar
 
+Tickets own implementation or another concrete shipped outcome. Do not create tickets whose only
+deliverable is research, specification, definition, or more tickets. Capture uncertain requested
+implementations in Triage, with provisional acceptance and explicit questions.
+
+Research is mandatory within triage for every implementation ticket, including named work,
+manually curated Todo, and children created by decomposition. Before implementation admission,
+record the completed investigation and independent skeptical review on the issue. Resolve the
+contract, scope, dependencies, acceptance evidence, and relevant reference comparisons there.
+Research depth is proportional to uncertainty: a mechanical fix may need only repository evidence;
+a new protocol or ABI requires primary authorities and pinned implementation/fixture references.
+Unresolved contract questions remain in Triage rather than becoming research-only tickets.
+
+OpenSpec remains required for language and standard-library implementation. It records and
+validates the researched contract as part of delivering the implementation, not as a separate
+design-only ticket. Historic completed research tickets retain their provenance; this rule does
+not require rewriting history.
+
 Discovery is broad intake, not final triage. Favor recall over certainty. A Triage issue needs:
 
 - a specific lead anchored to paths, symbols, output, a documentation passage, or a structural

--- a/.codex/skills/silk-demand/SKILL.md
+++ b/.codex/skills/silk-demand/SKILL.md
@@ -12,6 +12,12 @@ Julia's current statement is sufficient evidence that the request was made. A li
 not required. Preserve the requester, requested outcome, context, deadline, and wording when Julia
 provides them. Do not invent missing detail or require a person's name when a role is sufficient.
 
+Capture the requested implementation or concrete shipped outcome, not a research, specification,
+definition, or ticket-writing deliverable. Keep uncertain acceptance provisional in Triage and
+record the research questions on that implementation issue. Research and independent skeptical
+review are mandatory triage work before implementation admission; every decomposed child must
+pass that process too. OpenSpec artifacts ship with the implementation when required.
+
 ## Procedure
 
 1. Fetch the canonical Linear project by ID from `LINEAR.md` and verify its team. Never resolve or

--- a/.codex/skills/silk-work/SKILL.md
+++ b/.codex/skills/silk-work/SKILL.md
@@ -22,6 +22,14 @@ overrides automatic selection; never claim an issue still in Triage.
 
 ## Admission and claim
 
+Every selected implementation ticket must have completed triage research and independent
+skeptical review recorded on the issue, with `Triage disposition: queue-ready`. This applies to
+named tickets, Todo, and implementation children. If the marker or evidence is missing, use
+`silk-triage` before claiming or editing implementation; preserve a manually curated Todo tier
+while reviewing it. Existing recorded research can be reused and its marker normalized after
+verification. Never create a research-only ticket to satisfy this gate. Selection and the
+attention-cap override do not bypass triage.
+
 Before automatic selection, show existing In Progress issues and In Review issues that currently
 need Julia. Do not automatically start a third attention-bearing item. A named issue is an explicit
 override of this soft cap.


### PR DESCRIPTION
Implementation requests could become design-only tickets, and manually selected Todo work could
enter implementation without a recorded triage decision. Make research and independent skeptical
review mandatory parts of each implementation ticket's triage, including named work and children.

The workflow now captures uncertain implementation requests in Triage, keeps research findings and
contract decisions on that issue, and requires recorded queue-ready evidence before work admission.
Research depth follows the uncertainty; mechanical changes can use repository evidence. OpenSpec
remains part of implementation delivery, and manual Todo membership is preserved during review.

Requested alongside the HTTP milestone intake: [JUL-23](https://linear.app/juliaortiz/issue/JUL-23)
and [JUL-146](https://linear.app/juliaortiz/issue/JUL-146), plus implementation tickets JUL-190–203.
Those Linear changes are already applied; this PR makes the rule durable for subsequent work.

Validation: scoped Oxfmt check passed for all five changed Markdown files; `git diff --check`
passed. No executable code or tests changed. Full repository checks are delegated to CI per
Julia's instruction. [CI run 34673587143](https://github.com/julia-script/silk/actions/runs/34673587143)
is in progress for head `b264a2a3880cea0db6c9e8830c30d94fdb23c368`; no full-suite pass is claimed.
